### PR TITLE
Fix unneeded finishes after launching activities

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
@@ -131,8 +131,6 @@ public class InvitationsActivity extends AppCompatActivity {
                                         .putExtra("matchPath", matchPath)
                                         .putExtra("GameType", 3)
                                         .putExtra("localNickname", nickname));
-
-                                finish();
                             })
 
                             // ───────── failure ─────────

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/InviteFriendActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/InviteFriendActivity.java
@@ -93,7 +93,6 @@ public class InviteFriendActivity extends AppCompatActivity {
                     Intent i = new Intent(this, WaitingActivity.class)
                             .putExtra("inviteId", inviteId);
                     startActivity(i);
-                    finish();
                 })
                 .addOnFailureListener(e -> {
                     /* default fallback */

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MatchAdapter.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MatchAdapter.java
@@ -151,7 +151,6 @@ public class MatchAdapter
                         Intent i = new Intent(context, WaitingActivity.class)
                                 .putExtra("inviteId", inviteId);
                         context.startActivity(i);
-                        if (context instanceof Activity) ((Activity) context).finish();
                     })
                     .addOnFailureListener(e -> {
                         String msg = (e instanceof FirebaseFunctionsException ffe &&


### PR DESCRIPTION
## Summary
- keep InviteFriendActivity on the stack after launching WaitingActivity
- keep parent activity when inviting from MatchAdapter
- leave InvitationsActivity open when accepting an invite

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876c81a63c483308617ee4c8a9a5d13