### PR TITLE
Fix tournament accept invite to add first move

### DIFF
--- a/firebase/functions/accept-invite/index.js
+++ b/firebase/functions/accept-invite/index.js
@@ -66,6 +66,14 @@ exports.acceptInvite = functions
           turn          : 0,
           turnStartTime : null
         });
+        /* ensure first move exists */
+        tx.set(
+          matchRef.collection('moves').doc(),
+          {
+            x: 3, y: 4, p: 0,
+            createdAt: admin.firestore.FieldValue.serverTimestamp()
+          }
+        );
       } else {                                    // friendly — create new doc
         matchRef = db.collection('matches').doc();
         tx.set(matchRef, {


### PR DESCRIPTION
## Summary
- ensure scheduled tournament matches get an initial move when invite is accepted

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6877944d00dc8330a78a4cb3b2b40e4e