### PR TITLE
Fix nickname reset on logout

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -158,6 +158,8 @@ public class MenuActivity extends AppCompatActivity {
         ed.clear().apply();                          // clears token + other cache
 
         Toast.makeText(this, R.string.logged_out, Toast.LENGTH_SHORT).show();
+        TextView nicknameLabel = findViewById(R.id.nicknameLabel);
+        nicknameLabel.setText(getString(R.string.welcome_to_soccer));
         updateUiForAuthState();      // dim buttons, “Login” label, etc.
     }
 


### PR DESCRIPTION
## Summary
- update logout UI to reset welcome message

## Testing
- `./gradlew -version`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68781368933c83309827cc7fbd7f3de0