### PR TITLE
Add scheduled task to end stale matches

### DIFF
--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -57,6 +57,10 @@
     {
       "source": "functions/expire-stale-invites",
       "codebase": "expire-stale-invites"
+    },
+    {
+      "source": "functions/expire-stale-matches",
+      "codebase": "expire-stale-matches"
     }
   ],
   "firestore": {

--- a/firebase/functions/expire-stale-matches/index.js
+++ b/firebase/functions/expire-stale-matches/index.js
@@ -1,0 +1,44 @@
+const functions = require('firebase-functions');
+const admin     = require('firebase-admin');
+admin.initializeApp();
+const db = admin.firestore();
+
+exports.expireStaleMatches = functions
+  .region('us-central1')
+  .pubsub.schedule('every 1 minutes')
+  .timeZone('Europe/Warsaw')
+  .onRun(async () => {
+    const cutoff   = Date.now() - 5 * 60 * 1000; // 5 minutes ago
+    const cutoffTs = admin.firestore.Timestamp.fromMillis(cutoff);
+
+    const snap = await db.collectionGroup('matches')
+      .where('status', '==', 'active')
+      .where('turnStartTime', '<=', cutoffTs)
+      .limit(500)
+      .get();
+
+    if (snap.empty) {
+      console.log('👌 No stale matches found this run');
+      return null;
+    }
+
+    const batch = db.batch();
+    snap.forEach(doc => {
+      const match = doc.data();
+      const turn  = match.turn;                 // 0 or 1
+      const winnerUid = turn === 0 ? match.player1 : match.player0;
+      const remainingField = turn === 0 ? 'remainingTime0' : 'remainingTime1';
+
+      batch.update(doc.ref, {
+        winner:     winnerUid,
+        status:     'completed',
+        reason:     'timeout',
+        [remainingField]: 0,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
+    });
+
+    await batch.commit();
+    console.log(`✅ Expired ${snap.size} stale match(es)`);
+    return null;
+  });

--- a/firebase/functions/expire-stale-matches/package.json
+++ b/firebase/functions/expire-stale-matches/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "expire-stale-matches",
+  "description": "Scheduled function that finalizes active matches stuck for over 5 minutes.",
+  "version": "1.0.0",
+  "main": "index.js",
+  "engines": {
+    "node": "18"
+  },
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.5.0"
+  }
+}

--- a/gcp/cloud-build/deploy_expire_stale_matches.yaml
+++ b/gcp/cloud-build/deploy_expire_stale_matches.yaml
@@ -1,0 +1,90 @@
+substitutions:
+  _ENVIRONMENT: 'dev'
+  _FOLDER_NAME: 'soccer'
+
+steps:
+  # Step 1: Get Firebase project ID
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'get-project-id'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -e
+        echo "🔎 Finding project for ${_FOLDER_NAME}-${_ENVIRONMENT}..."
+        gcloud projects list \
+          --filter="name~^${_FOLDER_NAME}-${_ENVIRONMENT}" \
+          --format="value(projectId)" \
+          | head -n 1 > /workspace/FIREBASE_PROJECT_ID.txt
+
+        if [ ! -s /workspace/FIREBASE_PROJECT_ID.txt ]; then
+          echo "❌ Project ID not found!"
+          exit 1
+        fi
+
+  # Step 2: Install Firebase CLI
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'install-firebase-cli'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -e
+        echo "⬇️ Installing Firebase CLI..."
+        curl -sL https://firebase.tools | bash
+        mkdir -p /workspace/firebase
+        cp /usr/local/bin/firebase /workspace/firebase/
+        chmod +x /workspace/firebase/firebase
+        echo "✅ Firebase CLI installed."
+
+  # Step 3: Clone source code
+  - name: 'gcr.io/cloud-builders/git'
+    id: 'pull-files'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -ex
+        echo "📦 Cloning from the development branch..."
+        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+
+        echo "📁 Copying Firestore config & expire-stale-matches function..."
+        cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json
+        cp /workspace/soccer/firebase/firestore.rules /workspace/firebase/firestore.rules
+
+        mkdir -p /workspace/firebase/functions/expire-stale-matches
+        cp /workspace/soccer/firebase/functions/expire-stale-matches/package.json /workspace/firebase/functions/expire-stale-matches/
+        cp /workspace/soccer/firebase/functions/expire-stale-matches/index.js /workspace/firebase/functions/expire-stale-matches/
+
+  # Step 4: Install dependencies
+  - name: 'node:18-slim'
+    id: 'install-deps-expire-stale-matches'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -ex
+        cd /workspace/firebase/functions/expire-stale-matches
+        npm install
+        echo "📦 Dependencies installed."
+
+  # Step 5: Deploy function
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'deploy-expire-stale-matches'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -e
+        cd /workspace/firebase
+        project_id=$(cat /workspace/FIREBASE_PROJECT_ID.txt)
+
+        ./firebase deploy \
+          --only functions:expire-stale-matches \
+          --project="$project_id" \
+          --force
+
+        echo "✅ Function 'expireStaleMatches' deployed successfully."
+
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## Summary
- add new function `expire-stale-matches` to finalize matches that are stuck
- wire the new function into Firebase config
- provide Cloud Build configuration to deploy the function

## Testing
- `python3 -m unittest` *(fails: ImportError - requires google cloud credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68781202a3808330adb05cde4c8a6886