### PR TITLE
Add regulations seeding script

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -128,7 +128,11 @@ service cloud.firestore {
       // no writes here
     }
 
-
+    // Regulations: read-only for authenticated users
+    match /regulations/{docId} {
+      allow read: if request.auth != null;
+      allow write: if false;
+    }
 
     // 4. Everything else denied
     match /{document=**} {

--- a/firebase/functions/seed-regulations/index.js
+++ b/firebase/functions/seed-regulations/index.js
@@ -1,0 +1,23 @@
+const admin = require('firebase-admin');
+const fs = require('fs');
+const path = require('path');
+
+admin.initializeApp();
+
+const db = admin.firestore();
+
+async function main() {
+  const rulesPath = path.join(__dirname, '..', '..', 'seed', 'tournament_rules.json');
+  const body = fs.readFileSync(rulesPath, 'utf8');
+
+  await db.collection('regulations').add({
+    name: 'General Tournament Game Rules',
+    body,
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    status: 'active'
+  });
+
+  console.log('Regulations document uploaded.');
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/firebase/functions/seed-regulations/package.json
+++ b/firebase/functions/seed-regulations/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "seed-regulations",
+  "version": "1.0.0",
+  "main": "index.js",
+  "engines": {
+    "node": "18"
+  },
+  "dependencies": {
+    "firebase-admin": "^11.10.1"
+  }
+}

--- a/gcp/cloud-build/seed_regulations.yaml
+++ b/gcp/cloud-build/seed_regulations.yaml
@@ -1,0 +1,85 @@
+substitutions:
+  _ENVIRONMENT: 'dev'
+  _FOLDER_NAME: 'soccer'
+
+steps:
+  # Step 1: Get Firebase project ID
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'get-project-id'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -e
+        echo "🔎 Finding project for ${_FOLDER_NAME}-${_ENVIRONMENT}..."
+        gcloud projects list \
+          --filter="name~^${_FOLDER_NAME}-${_ENVIRONMENT}" \
+          --format="value(projectId)" \
+          | head -n 1 > /workspace/FIREBASE_PROJECT_ID.txt
+
+        if [ ! -s /workspace/FIREBASE_PROJECT_ID.txt ]; then
+          echo "❌ Project ID not found!"
+          exit 1
+        fi
+
+  # Step 2: Install Firebase CLI
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'install-firebase-cli'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -e
+        echo "⬇️ Installing Firebase CLI..."
+        curl -sL https://firebase.tools | bash
+        mkdir -p /workspace/firebase
+        cp /usr/local/bin/firebase /workspace/firebase/
+        chmod +x /workspace/firebase/firebase
+        echo "✅ Firebase CLI installed."
+
+  # Step 3: Clone source code
+  - name: 'gcr.io/cloud-builders/git'
+    id: 'pull-files'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -ex
+        echo "📦 Cloning from the development branch..."
+        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+
+        echo "📁 Preparing files for seeding regulations..."
+        cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json
+        cp /workspace/soccer/firebase/firestore.rules /workspace/firebase/firestore.rules
+        mkdir -p /workspace/firebase/functions/seed-regulations
+        cp /workspace/soccer/firebase/functions/seed-regulations/package.json /workspace/firebase/functions/seed-regulations/
+        cp /workspace/soccer/firebase/functions/seed-regulations/index.js /workspace/firebase/functions/seed-regulations/
+        mkdir -p /workspace/firebase/seed
+        cp /workspace/soccer/firebase/seed/tournament_rules.json /workspace/firebase/seed/
+
+  # Step 4: Install dependencies
+  - name: 'node:18-slim'
+    id: 'install-deps-seed-regulations'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -ex
+        cd /workspace/firebase/functions/seed-regulations
+        npm install
+        echo "📦 Dependencies installed."
+
+  # Step 5: Execute the seeding script
+  - name: 'node:18-slim'
+    id: 'run-seeding'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -e
+        cd /workspace/firebase/functions/seed-regulations
+        node index.js
+        echo "✅ Regulations document created."
+
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## Summary
- create Cloud Build pipeline to seed "regulations" collection
- add node helper under `functions/seed-regulations`
- update Firestore rules to allow authenticated reads for regulations

## Testing
- `npm install` in `functions/seed-regulations`

------
https://chatgpt.com/codex/tasks/task_e_687a0b6c26f48330b1e90a8b8ba270d3