### PR TITLE
Fix Firestore seeding project

### DIFF
--- a/gcp/cloud-build/seed_regulations.yaml
+++ b/gcp/cloud-build/seed_regulations.yaml
@@ -78,6 +78,8 @@ steps:
       - |
         set -e
         cd /workspace/firebase/functions/seed-regulations
+        project_id=$(cat /workspace/FIREBASE_PROJECT_ID.txt)
+        export GOOGLE_CLOUD_PROJECT="$project_id"
         node index.js
         echo "✅ Regulations document created."
 


### PR DESCRIPTION
## Summary
- ensure `seed_regulations.yaml` uses the correct Firestore project during seeding

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a149c3bb483309e2bcd339f9f9ef8