### PR TITLE
Add regulation acceptance flow

### DIFF
--- a/firebase/functions/join-tournament/index.js
+++ b/firebase/functions/join-tournament/index.js
@@ -11,6 +11,7 @@ const db        = admin.firestore();
 exports.joinTournament = functions.https.onCall(async (data, context) => {
   const uid = context.auth?.uid;
   const tid = data?.tournamentId;
+  const regulationStatus = data?.regulation;
 
   /* ─── 1. Basic guards ─── */
   if (!uid) {
@@ -62,10 +63,12 @@ exports.joinTournament = functions.https.onCall(async (data, context) => {
     }
 
     /* 2-c: write participant + increment counter atomically */
-    tx.set(pRef, {
+    const payload = {
       seed: Math.random(),                              // for bracket seeding
       joinedAt: admin.firestore.FieldValue.serverTimestamp()
-    });
+    };
+    if (regulationStatus) payload.regulation = regulationStatus;
+    tx.set(pRef, payload);
     tx.update(tRef, {
       participantsCount: admin.firestore.FieldValue.increment(1)
     });

--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -61,6 +61,15 @@
         </activity>
 
         <activity
+            android:name=".RegulationActivity"
+            android:exported="false"
+            android:parentActivityName=".TournamentsActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".TournamentsActivity"/>
+        </activity>
+
+        <activity
             android:name=".TournamentLobbyActivity"
             android:exported="false"
             android:parentActivityName=".TournamentsActivity">

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegulationActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegulationActivity.java
@@ -1,0 +1,110 @@
+package piotr_gorczynski.soccer2;
+
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.util.Log;
+import android.widget.Button;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.functions.FirebaseFunctions;
+import com.google.firebase.functions.FirebaseFunctionsException;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class RegulationActivity extends AppCompatActivity {
+
+    private String tournamentId;
+    private String regulationId;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_regulation);
+
+        TextView nameTv = findViewById(R.id.regulationName);
+        TextView bodyTv = findViewById(R.id.regulationBody);
+        Button acceptBtn = findViewById(R.id.acceptRegulation);
+        Button declineBtn = findViewById(R.id.declineRegulation);
+
+        tournamentId = getIntent().getStringExtra("tournamentId");
+        regulationId = getIntent().getStringExtra("regulationId");
+
+        FirebaseFirestore db = FirebaseFirestore.getInstance();
+        if (!TextUtils.isEmpty(regulationId)) {
+            db.collection("regulations").document(regulationId).get()
+                    .addOnSuccessListener(doc -> {
+                        if (doc.exists()) {
+                            nameTv.setText(doc.getString("name"));
+                            String bodyJson = doc.getString("body");
+                            if (bodyJson != null) {
+                                try {
+                                    JSONObject obj = new JSONObject(bodyJson);
+                                    JSONArray rules = obj.optJSONArray("rules");
+                                    if (rules != null) {
+                                        StringBuilder sb = new StringBuilder();
+                                        for (int i = 0; i < rules.length(); i++) {
+                                            sb.append("• ").append(rules.getString(i)).append("\n\n");
+                                        }
+                                        bodyTv.setText(sb.toString().trim());
+                                    } else {
+                                        bodyTv.setText(bodyJson);
+                                    }
+                                } catch (Exception e) {
+                                    bodyTv.setText(bodyJson);
+                                }
+                            }
+                        }
+                    });
+        }
+
+        declineBtn.setOnClickListener(v -> finish());
+
+        acceptBtn.setOnClickListener(v -> acceptAndJoin());
+    }
+
+    private void acceptAndJoin() {
+        if (TextUtils.isEmpty(tournamentId)) {
+            Toast.makeText(this, "Tournament not found.", Toast.LENGTH_LONG).show();
+            return;
+        }
+        FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+        if (user == null) {
+            Toast.makeText(this, "You must be logged-in.", Toast.LENGTH_LONG).show();
+            return;
+        }
+
+        user.getIdToken(true).addOnSuccessListener(tokenRes -> {
+            FirebaseFunctions functions = FirebaseFunctions.getInstance("us-central1");
+            Map<String,Object> data = Map.of(
+                    "tournamentId", tournamentId,
+                    "regulation", "accepted"
+            );
+            functions.getHttpsCallable("joinTournament")
+                    .call(data)
+                    .addOnSuccessListener(r -> {
+                        Toast.makeText(this, "Joined! Wait for the bracket to start.", Toast.LENGTH_SHORT).show();
+                        finish();
+                    })
+                    .addOnFailureListener(e -> {
+                        if (e instanceof FirebaseFunctionsException ffe) {
+                            Log.e("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName()
+                                    + ": code=" + ffe.getCode()
+                                    + "  msg=" + ffe.getMessage()
+                                    + "  details=" + ffe.getDetails());
+                        }
+                        Toast.makeText(this, e.getMessage(), Toast.LENGTH_LONG).show();
+                    });
+        });
+    }
+}

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentAdapter.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentAdapter.java
@@ -23,7 +23,7 @@ public class TournamentAdapter
 
     /** callback for the Join button */
     @SuppressWarnings("unused")
-    public interface OnJoinClick { void onJoin(String tournamentId); }
+    public interface OnJoinClick { void onJoin(DocumentSnapshot tournamentDoc); }
 
     public interface OnEndedClick {
         void onEnded(DocumentSnapshot tournamentDoc);
@@ -124,7 +124,7 @@ public class TournamentAdapter
             boolean closed = mLeft <= 0;
             h.joinBtn.setEnabled(!full && !closed);
             h.joinBtn.setText(R.string.join);
-            h.joinBtn.setOnClickListener(v -> Objects.requireNonNull(listener).onJoin(tid));
+            h.joinBtn.setOnClickListener(v -> Objects.requireNonNull(listener).onJoin(doc));
 
         } else {   // == "running"
 

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentsActivity.java
@@ -3,8 +3,6 @@ package piotr_gorczynski.soccer2;
 import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.os.Bundle;
-import android.text.TextUtils;
-import android.util.Log;
 import android.view.View;
 import android.widget.Toast;
 
@@ -13,18 +11,11 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.google.firebase.auth.FirebaseAuth;
-import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
-import com.google.firebase.functions.FirebaseFunctions;
-import com.google.firebase.functions.FirebaseFunctionsException;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 
 public class TournamentsActivity extends AppCompatActivity {
 
@@ -123,48 +114,16 @@ public class TournamentsActivity extends AppCompatActivity {
     }
 
     /** Calls your Cloud Function `joinTournament` (see blueprint) */
-    private void joinTournament(String tournamentId) {
+    private void joinTournament(DocumentSnapshot tournamentDoc) {
+        if (tournamentDoc == null || !tournamentDoc.exists()) return;
 
-        if (TextUtils.isEmpty(tournamentId)) {
-            Toast.makeText(this, "Tournament not found.", Toast.LENGTH_LONG).show();
-            return;
-        }
+        String tid = tournamentDoc.getId();
+        String regId = tournamentDoc.getString("regulation");
 
-        FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
-        if (user == null) {
-            Toast.makeText(this, "You must be logged-in.", Toast.LENGTH_LONG).show();
-            return;
-        }
-
-        // 🔄 force-refresh the ID-token so App Check / IAM always passes
-        user.getIdToken(true).addOnSuccessListener(tokenRes -> {
-
-            FirebaseFunctions functions = FirebaseFunctions.getInstance("us-central1");
-            Map<String,Object> data     = Collections.singletonMap("tournamentId", tournamentId);
-
-            functions
-                    .getHttpsCallable("joinTournament")
-                    .call(data)
-
-                    /* ───── success ───── */
-                    .addOnSuccessListener(r -> {Toast
-                            .makeText(this, "Joined! Wait for the bracket to start.",
-                                    Toast.LENGTH_SHORT).show();
-                            Log.d("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() + ": Joined");
-
-                    })
-
-                    /* ───── failure ───── */
-                    .addOnFailureListener(e -> {
-                        if (e instanceof FirebaseFunctionsException ffe) {
-                            Log.e("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName()
-                                    + ": code=" + ffe.getCode()
-                                    + "  msg=" + ffe.getMessage()
-                                    + "  details=" + ffe.getDetails());
-                        }
-                        Toast.makeText(this, e.getMessage(), Toast.LENGTH_LONG).show();
-                    });
-        });
+        Intent i = new Intent(this, RegulationActivity.class)
+                .putExtra("tournamentId", tid)
+                .putExtra("regulationId", regId);
+        startActivity(i);
     }
 }
 

--- a/mobile/app/src/main/res/layout/activity_regulation.xml
+++ b/mobile/app/src/main/res/layout/activity_regulation.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="20dp"
+    android:gravity="center"
+    android:background="@color/colorWhite"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/regulationName"
+        android:textStyle="bold"
+        android:textColor="@color/colorGreenDark"
+        android:layout_marginBottom="12dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+        <TextView
+            android:id="@+id/regulationBody"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </ScrollView>
+
+    <LinearLayout
+        android:orientation="horizontal"
+        android:gravity="end"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp">
+
+        <Button
+            android:id="@+id/declineRegulation"
+            android:text="@string/decline"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <Button
+            android:id="@+id/acceptRegulation"
+            android:text="@string/accept"
+            android:layout_marginStart="16dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -78,4 +78,6 @@
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="target_player_busy">That player is already busy with another invitation.</string>
+    <string name="accept">Accept</string>
+    <string name="decline">Decline</string>
 </resources>


### PR DESCRIPTION
## Summary
- prompt user to accept tournament regulations before joining
- record acceptance in joinTournament Cloud Function
- show regulation body and provide Accept/Decline buttons

## Testing
- `bash gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a4321ce108330aa95c12282ac404f