### PR TITLE
Fix ambiguous constructor call

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentsActivity.java
@@ -38,8 +38,14 @@ public class TournamentsActivity extends AppCompatActivity {
         List<DocumentSnapshot> runningDocs = new ArrayList<>();
         List<DocumentSnapshot> endedDocs = new ArrayList<>();
 
-        TournamentAdapter registeringAdapter = new TournamentAdapter(registeringDocs, this::joinTournament);
-        TournamentAdapter runningAdapter = new TournamentAdapter(runningDocs, this::joinTournament);
+        TournamentAdapter registeringAdapter = new TournamentAdapter(
+                registeringDocs,
+                (TournamentAdapter.OnJoinClick) this::joinTournament
+        );
+        TournamentAdapter runningAdapter = new TournamentAdapter(
+                runningDocs,
+                (TournamentAdapter.OnJoinClick) this::joinTournament
+        );
         TournamentAdapter endedAdapter = new TournamentAdapter(
                 endedDocs,
                 (TournamentAdapter.OnEndedClick) doc -> {


### PR DESCRIPTION
## Summary
- fix ambiguous constructor call for TournamentAdapter

## Testing
- `pytest gcp/cloud-functions/tests/test_service_check.py` *(fails: DefaultCredentialsError)*

------
https://chatgpt.com/codex/tasks/task_e_687a6aa195d883308bbb91000bf5e8c9