### PR TITLE
Improve regulation loading handling

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegulationActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegulationActivity.java
@@ -64,8 +64,16 @@ public class RegulationActivity extends AppCompatActivity {
                                     bodyTv.setText(bodyJson);
                                 }
                             }
+                        } else {
+                            bodyTv.setText(R.string.regulation_not_found);
                         }
+                    })
+                    .addOnFailureListener(e -> {
+                        Log.e("TAG_Soccer", "Failed to load regulation", e);
+                        Toast.makeText(this, R.string.regulation_load_error, Toast.LENGTH_LONG).show();
                     });
+        } else {
+            bodyTv.setText(R.string.regulation_not_found);
         }
 
         declineBtn.setOnClickListener(v -> finish());

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -80,4 +80,6 @@
     <string name="target_player_busy">That player is already busy with another invitation.</string>
     <string name="accept">Accept</string>
     <string name="decline">Decline</string>
+    <string name="regulation_not_found">Regulation not found.</string>
+    <string name="regulation_load_error">Failed to load regulation.</string>
 </resources>


### PR DESCRIPTION
## Summary
- show error feedback if regulation document can't load
- add user-facing strings for missing or failed regulations

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a74319dc88330a5c72b46056996ac