### PR TITLE
Add auth logging before regulations fetch

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegulationActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegulationActivity.java
@@ -46,9 +46,11 @@ public class RegulationActivity extends AppCompatActivity {
 
         FirebaseFirestore db = FirebaseFirestore.getInstance();
         if (!TextUtils.isEmpty(regulationId)) {
+            FirebaseUser authUser = FirebaseAuth.getInstance().getCurrentUser();
             Log.d("TAG_Soccer", getClass().getSimpleName() + "." +
                     Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
-                    ": querying regulation from Firestore");
+                    ": querying regulation from Firestore, currentUser=" +
+                    (authUser != null ? authUser.getUid() : "null"));
             db.collection("regulations").document(regulationId).get()
                     .addOnSuccessListener(doc -> {
                         if (doc.exists()) {


### PR DESCRIPTION
## Summary
- log the current user UID before fetching regulations in `RegulationActivity`

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a857c57e083309b87a12a6edb3cb7