### PR TITLE
Fix auth check before loading regulations

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegulationActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegulationActivity.java
@@ -51,6 +51,14 @@ public class RegulationActivity extends AppCompatActivity {
                     Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
                     ": querying regulation from Firestore, currentUser=" +
                     (authUser != null ? authUser.getUid() : "null"));
+
+            if (authUser == null) {
+                Log.e("TAG_Soccer", getClass().getSimpleName() + "." +
+                        Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
+                        ": user not authenticated – cannot load regulation");
+                Toast.makeText(this, R.string.regulation_auth_required, Toast.LENGTH_LONG).show();
+                return;
+            }
             db.collection("regulations").document(regulationId).get()
                     .addOnSuccessListener(doc -> {
                         if (doc.exists()) {

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -82,4 +82,5 @@
     <string name="decline">Decline</string>
     <string name="regulation_not_found">Regulation not found.</string>
     <string name="regulation_load_error">Failed to load regulation.</string>
+    <string name="regulation_auth_required">Please log in to view the regulation.</string>
 </resources>


### PR DESCRIPTION
## Summary
- ensure RegulationActivity checks for logged-in user before Firestore query
- add localized string for auth requirement

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a92cae5c48330a546f99d4fc264c2