### PR TITLE
Expand regulations read permissions

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -129,7 +129,10 @@ service cloud.firestore {
     }
 
     // Regulations: read-only for authenticated users
-    match /regulations/{docId} {
+    // Allow reads on the root collection as well as any nested
+    // sub-collection named "regulations" so that lookups work even
+    // if documents are stored deeper in the hierarchy.
+    match /{path=**}/regulations/{docId} {
       allow read: if request.auth != null;
       allow write: if false;
     }


### PR DESCRIPTION
## Summary
- allow reading `regulations` documents even when nested in sub-collections

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a9ef4c57c8330a92fc454627714a5