### PR TITLE
Add regulation validation when creating tournaments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,23 @@
 # Soccer
 
 This is very simple game which originates from so called paper soccer
+
 ## Creating tournaments
 
-A helper script is available in `tools/create-tournament.js` for quickly adding
-tournaments to Firestore. **Run it from the project root** so the relative path
-is resolved correctly:
+A helper script is available in `tools/create-tournament.js` for quickly adding tournaments to Firestore. **Run it from the project root** so the relative path is resolved correctly:
 
 ```bash
-node tools/create-tournament.js "Summer Cup" 16 "2024-06-01T12:00:00Z" "2024-07-01T12:00:00Z"
+node tools/create-tournament.js "Summer Cup" 16 "2024-06-01T12:00:00Z" "2024-07-01T12:00:00Z" "regDocId"
 ```
 
 If you change into the `tools` directory first, drop the folder prefix:
 
 ```bash
-node create-tournament.js "Summer Cup" 16 "2024-06-01T12:00:00Z" "2024-07-01T12:00:00Z"
-=======
-A helper script is available in `tools/create-tournament.js` for quickly adding tournaments to Firestore.
-
-```
-node tools/create-tournament.js "Summer Cup" 16 "2024-06-01T12:00:00Z" "2024-07-01T12:00:00Z"
-
+node create-tournament.js "Summer Cup" 16 "2024-06-01T12:00:00Z" "2024-07-01T12:00:00Z" "regDocId"
 ```
 
-The script also accepts a path to a JSON file containing the fields `name`, `maxParticipants`, `registrationDeadline` and `matchesDeadline`:
+The script also accepts a path to a JSON file containing the fields `name`, `maxParticipants`, `registrationDeadline`, `matchesDeadline` and `regulation`:
 
-```
+```bash
 node tools/create-tournament.js params.json
 ```

--- a/tools/create-tournament.js
+++ b/tools/create-tournament.js
@@ -24,21 +24,22 @@ async function main () {
 
   if (args.length === 1 && args[0].endsWith('.json')) {
     params = JSON.parse(fs.readFileSync(path.resolve(args[0]), 'utf8'));
-  } else if (args.length === 4) {
+  } else if (args.length === 5) {
     params = {
       name: args[0],
       maxParticipants: Number(args[1]),
       registrationDeadline: args[2],
-      matchesDeadline: args[3]
+      matchesDeadline: args[3],
+      regulation: args[4]
     };
   } else {
-    console.error('Usage: node create-tournament.js name maxParticipants registrationDeadline matchesDeadline');
+    console.error('Usage: node create-tournament.js name maxParticipants registrationDeadline matchesDeadline regulation');
     console.error('   or: node create-tournament.js params.json');
     process.exit(1);
   }
 
-  const { name, maxParticipants, registrationDeadline, matchesDeadline } = params;
-  if (!name || !maxParticipants || !registrationDeadline || !matchesDeadline) {
+  const { name, maxParticipants, registrationDeadline, matchesDeadline, regulation } = params;
+  if (!name || !maxParticipants || !registrationDeadline || !matchesDeadline || !regulation) {
     console.error('Missing required parameters.');
     process.exit(1);
   }
@@ -47,12 +48,23 @@ async function main () {
   const regDeadline   = Timestamp.fromDate(new Date(registrationDeadline));
   const matchDeadline = Timestamp.fromDate(new Date(matchesDeadline));
 
+  const regSnap = await db.collection('regulations').doc(regulation).get();
+  if (!regSnap.exists) {
+    console.error('Regulation document not found:', regulation);
+    process.exit(1);
+  }
+  if (regSnap.data().status !== 'active') {
+    console.error('Regulation is not active:', regulation);
+    process.exit(1);
+  }
+
   try {
     const doc = await db.collection('tournaments').add({
       name,
       maxParticipants,
       registrationDeadline: regDeadline,
       matchesDeadline: matchDeadline,
+      regulation,
       format: 'RoundRobin',
       status: 'registering',
       participantsCount: 0,


### PR DESCRIPTION
## Summary
- allow `create-tournament.js` to accept a `regulation` argument
- verify that the referenced regulation exists and is active before creating a tournament
- document the new parameter in `README.md`

## Testing
- `node --check tools/create-tournament.js`


------
https://chatgpt.com/codex/tasks/task_e_687aaeb3c6e88330bd28f1d05f934260