### PR TITLE
Fix tournaments list order

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentsActivity.java
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.Query;
 import com.google.firebase.functions.FirebaseFunctions;
 import com.google.firebase.functions.FirebaseFunctionsException;
 
@@ -85,7 +86,9 @@ public class TournamentsActivity extends AppCompatActivity {
         // ── Firestore ────────────────────────────────────────────────
         FirebaseFirestore db = FirebaseFirestore.getInstance();
 
-        db.collection("tournaments").addSnapshotListener((snap, e) -> {
+        db.collection("tournaments")
+                .orderBy("createdAt", Query.Direction.DESCENDING)
+                .addSnapshotListener((snap, e) -> {
             if (e != null || snap == null) return;
 
             // Clear and repopulate each list (simpler than tracking diffs for 3 views)


### PR DESCRIPTION
## Summary
- ensure all tournaments are loaded

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ab3986c9c8330945521254c23d54c