### PR TITLE
Add debug logging of secret key

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/BackendServiceChecker.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/BackendServiceChecker.java
@@ -86,7 +86,7 @@ public class BackendServiceChecker {
         String secretKey = getSecretKey();
         if (secretKey != null && !secretKey.isEmpty()) {
             requestBuilder.addHeader("X-Secret-Key", secretKey);
-            Log.d(TAG, "Added X-Secret-Key header");
+            Log.d(TAG, "Added X-Secret-Key header using key: " + secretKey);
         } else {
             Log.d(TAG, "No secret key available, proceeding without authentication");
         }
@@ -227,6 +227,7 @@ public class BackendServiceChecker {
             }
             if (!trimmed.isEmpty()) {
                 Log.d(TAG, "Retrieved secret key of length " + trimmed.length());
+                Log.d(TAG, "Secret key value: " + trimmed);
                 return trimmed;
             }
             Log.d(TAG, "Secret key was empty after trimming");
@@ -239,7 +240,7 @@ public class BackendServiceChecker {
                     String trimmed = line.trim();
                     if (!trimmed.isEmpty()) {
                         prefs.edit().putString("backend_secret_key", trimmed).apply();
-                        Log.d(TAG, "Loaded secret key from asset");
+                        Log.d(TAG, "Loaded secret key from asset: " + trimmed);
                         return trimmed;
                     }
                 }
@@ -248,6 +249,7 @@ public class BackendServiceChecker {
                 Log.d(TAG, "soccer_secret_key asset not found", e);
             }
         }
+        Log.d(TAG, "Secret key could not be found");
         return null;
     }
     
@@ -272,7 +274,7 @@ public class BackendServiceChecker {
         if (trimmed != null && !trimmed.equals(secretKey)) {
             Log.d(TAG, "Secret key trimmed before saving");
         }
-        Log.d(TAG, "Secret key updated");
+        Log.d(TAG, "Secret key updated: " + trimmed);
     }
     
     /**


### PR DESCRIPTION
## Summary
- add extra debug logging for BackendServiceChecker
- print the secret key when loading and when adding request headers

## Testing
- `python -m unittest discover gcp/cloud-functions/tests`


------
https://chatgpt.com/codex/tasks/task_e_687d43b023d883308ee88960043caacf