### PR TITLE
Fix 403 on service check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Thumbs.db
 /mobile/app/soccer_secret_key
 /mobile/app/src/main/assets/soccer_secret_key
 node_modules/
+**/__pycache__/

--- a/gcp/cloud-build/deploy_cloud_function.yaml
+++ b/gcp/cloud-build/deploy_cloud_function.yaml
@@ -58,5 +58,24 @@ steps:
         }
         echo "Cloud Function '${_FUNCTION_NAME}' deployed successfully."
 
+  # Step 4: Add IAM policy binding to allow allUsers to invoke
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'bind-invoker-role'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -e
+        project_id=$(cat /workspace/project_name.txt)
+
+        echo "Granting invoker role to allUsers for '${_FUNCTION_NAME}'..."
+        gcloud functions add-iam-policy-binding ${_FUNCTION_NAME} \
+          --region=${_REGION} \
+          --project="$project_id" \
+          --member="allUsers" \
+          --role="roles/cloudfunctions.invoker"
+
+        echo "IAM policy binding applied."
+
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## Summary
- allow unauthenticated access for service-check function
- ignore Python bytecode directories

## Testing
- `python -m unittest discover -s gcp/cloud-functions/tests`

------
https://chatgpt.com/codex/tasks/task_e_687e0adfb86483308b9507b038bb8bfe