### PR TITLE
Fix Cloud Function deploy script

### DIFF
--- a/gcp/cloud-build/deploy_cloud_function.yaml
+++ b/gcp/cloud-build/deploy_cloud_function.yaml
@@ -50,6 +50,7 @@ steps:
             --entry-point=service_check \
             --runtime=${_RUNTIME} \
             --trigger-http \
+            --gen2 \
             --region=${_REGION} \
             --source=${_SOURCE_PATH} \
             --timeout=540s || {
@@ -69,11 +70,10 @@ steps:
         project_id=$(cat /workspace/project_name.txt)
 
         echo "Granting invoker role to allUsers for '${_FUNCTION_NAME}'..."
-        gcloud functions add-iam-policy-binding ${_FUNCTION_NAME} \
+        gcloud functions add-invoker-policy-binding ${_FUNCTION_NAME} \
           --region=${_REGION} \
           --project="$project_id" \
-          --member="allUsers" \
-          --role="roles/cloudfunctions.invoker"
+          --member="allUsers"
 
         echo "IAM policy binding applied."
 


### PR DESCRIPTION
## Summary
- ensure gcloud uses gen2 for the service-check function
- grant Cloud Run invoker role after deploy

## Testing
- `python -m unittest discover -s gcp/cloud-functions/tests`

------
https://chatgpt.com/codex/tasks/task_e_687e17a9c7b08330b53851222cd227dd