### PR TITLE
Remove secret values from logs

### DIFF
--- a/gcp/cloud-build/test_service_check.yaml
+++ b/gcp/cloud-build/test_service_check.yaml
@@ -37,7 +37,7 @@ steps:
           echo "Error: Failed to retrieve secret key. Ensure the secret exists and permissions are configured correctly."
           exit 1
         fi
-        echo "Secret key retrieved successfully: $(cat /workspace/secret_key.txt)"
+        echo "Secret key retrieved successfully"
 
   # Step 3: Generate identity token and test the service-check endpoint
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
@@ -58,7 +58,7 @@ steps:
           exit 1
         fi
 
-        echo "Generated identity token: $(cat /workspace/identity_token.txt)"
+        echo "Generated identity token"
 
         # Use the secret key and identity token directly in the curl command
         curl --http1.1 -X GET "https://us-central1-$(cat /workspace/project_name.txt).cloudfunctions.net/service-check" \
@@ -66,8 +66,7 @@ steps:
           -H "X-Secret-Key: $(cat /workspace/secret_key.txt)" \
           -H "Cache-Control: no-cache, no-store, must-revalidate" \
           -H "Pragma: no-cache" \
-          -H "Connection: close" \
-          -v
+          -H "Connection: close"
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/gcp/cloud-functions/service-check/main.py
+++ b/gcp/cloud-functions/service-check/main.py
@@ -20,7 +20,7 @@ def get_secret():
         name = "projects/690882718361/secrets/soccer_secret_key/versions/latest"
         response = client.access_secret_version(name=name)
         secret = response.payload.data.decode("UTF-8").strip()
-        logging.info(f"Retrieved secret key successfully: |{secret}|")  
+        logging.info("Retrieved secret key successfully")
         return secret
     except Exception as e:
         logging.error(f"Failed to retrieve secret: {e}")
@@ -37,9 +37,9 @@ def service_check(request):
             logging.warning("X-Secret-Key header is missing")
             return Response(jsonify({"error": "Missing secret key"}).data, status=400, mimetype="application/json")
 
-        # Log the provided secret key from headers
+        # Retrieve the provided secret key from headers
         provided_key = request.headers['X-Secret-Key']
-        logging.info(f"X-Secret-Key from headers: |{provided_key}|")
+        logging.info("X-Secret-Key header received")
 
         # Verify the provided key
         if provided_key != secret_key:

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/BackendServiceChecker.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/BackendServiceChecker.java
@@ -90,7 +90,7 @@ public class BackendServiceChecker {
         String secretKey = getSecretKey();
         if (secretKey != null && !secretKey.isEmpty()) {
             requestBuilder.addHeader("X-Secret-Key", secretKey);
-            Log.d(TAG, "Added X-Secret-Key header using key: " + secretKey);
+            Log.d(TAG, "Added X-Secret-Key header");
         } else {
             Log.d(TAG, "No secret key available, proceeding without authentication");
         }
@@ -231,7 +231,6 @@ public class BackendServiceChecker {
             }
             if (!trimmed.isEmpty()) {
                 Log.d(TAG, "Retrieved secret key of length " + trimmed.length());
-                Log.d(TAG, "Secret key value: " + trimmed);
                 return trimmed;
             }
             Log.d(TAG, "Secret key was empty after trimming");
@@ -244,7 +243,7 @@ public class BackendServiceChecker {
                     String trimmed = line.trim();
                     if (!trimmed.isEmpty()) {
                         prefs.edit().putString("backend_secret_key", trimmed).apply();
-                        Log.d(TAG, "Loaded secret key from asset: " + trimmed);
+                        Log.d(TAG, "Loaded secret key from asset");
                         return trimmed;
                     }
                 }
@@ -278,7 +277,7 @@ public class BackendServiceChecker {
         if (trimmed != null && !trimmed.equals(secretKey)) {
             Log.d(TAG, "Secret key trimmed before saving");
         }
-        Log.d(TAG, "Secret key updated: " + trimmed);
+        Log.d(TAG, "Secret key updated");
     }
     
     /**


### PR DESCRIPTION
## Summary
- sanitize logging around secret keys for mobile app
- drop secret values from service-check function
- avoid logging secrets in cloud build

## Testing
- `python -m unittest discover -s gcp/cloud-functions/tests`

------
https://chatgpt.com/codex/tasks/task_e_687e243fb0d4833098ae2ae245174519