### PR TITLE
Fix banner placement in MenuActivity

### DIFF
--- a/mobile/app/src/main/res/layout/activity_menu.xml
+++ b/mobile/app/src/main/res/layout/activity_menu.xml
@@ -4,7 +4,7 @@
     android:layout_height="match_parent"
     android:background="@color/colorWhite"
     android:orientation="vertical"
-    android:gravity="center"
+    android:gravity="center_horizontal"
     android:padding="20dp">
 
     <androidx.appcompat.widget.Toolbar


### PR DESCRIPTION
## Summary
- keep toolbar pinned to the top in MenuActivity

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ea0b56c3083309e1e3d90c09480a8