### PR TITLE
Add consent revocation link

### DIFF
--- a/firebase-hosting/public/privacy.html
+++ b/firebase-hosting/public/privacy.html
@@ -38,6 +38,7 @@
 
     <h2>Your Choices</h2>
     <p>You may update or delete your account information by contacting us. You can opt out of personalized ads through your device settings.</p>
+    <p><a href="https://myconsentprivacyplatform.gstatic.com/cmp/revoke?app_id=ca-app-pub-9113152787055223~3266191463">Change consent settings</a></p>
 
     <h2>Children's Privacy</h2>
     <p>The Service is not directed to children under 13. We do not knowingly collect personal data from children.</p>


### PR DESCRIPTION
## Summary
- update privacy policy with a consent revocation link using the provided AdMob ID

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_687ea24b9c9c83308334d0ea12a31422