### PR TITLE
Fix menu layout padding

### DIFF
--- a/mobile/app/src/main/res/layout/activity_menu.xml
+++ b/mobile/app/src/main/res/layout/activity_menu.xml
@@ -4,8 +4,7 @@
     android:layout_height="match_parent"
     android:background="@color/colorWhite"
     android:orientation="vertical"
-    android:gravity="center_horizontal"
-    android:padding="20dp">
+    android:gravity="center_horizontal">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/menu_toolbar"


### PR DESCRIPTION
## Summary
- remove extra padding from the menu layout so the toolbar touches the edges

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ea375afb08330adbd0e08d2fc71f1