### PR TITLE
Center menu screen elements vertically

### DIFF
--- a/mobile/app/src/main/res/layout/activity_menu.xml
+++ b/mobile/app/src/main/res/layout/activity_menu.xml
@@ -13,6 +13,13 @@
         android:background="?attr/colorPrimary"
         android:title="@string/app_name"
         android:titleTextColor="@color/colorWhite" />
+    <LinearLayout
+        android:id="@+id/menu_center_container"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:gravity="center">
 
     <TextView
         android:id="@+id/nicknameLabel"
@@ -82,6 +89,5 @@
         android:textColor="@color/colorWhite"
         android:textStyle="bold" />
 
-
-
+    </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
## Summary
- wrap the menu layout content in a new LinearLayout
- use layout_weight to fill remaining space and center children vertically

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_687ea8baffe08330bf82b72197dcd6b1