### PR TITLE
Display tournament name in lobby

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentAdapter.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentAdapter.java
@@ -223,7 +223,8 @@ public class TournamentAdapter
 
             h.joinBtn.setOnClickListener(v -> {
                 Intent i = new Intent(v.getContext(), TournamentLobbyActivity.class)
-                        .putExtra("tournamentId", tid);
+                        .putExtra("tournamentId", tid)
+                        .putExtra("tournamentName", name);
                 v.getContext().startActivity(i);
             });
         }

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentLobbyActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentLobbyActivity.java
@@ -4,6 +4,7 @@ import static java.util.Objects.*;
 
 import android.os.Bundle;
 import android.util.Log;
+import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -24,6 +25,7 @@ public class TournamentLobbyActivity extends AppCompatActivity {
 
     private MatchAdapter mAdapter;
     private ListenerRegistration matchListenerA, matchListenerB;
+    private TextView tournamentName;
 
     /* one common handler so we don’t repeat the diff logic */
     EventListener<QuerySnapshot> makeHandler(String label) {
@@ -81,9 +83,22 @@ public class TournamentLobbyActivity extends AppCompatActivity {
                 + ": Method start");
         setContentView(R.layout.activity_tournament_lobby);
 
+        tournamentName = findViewById(R.id.tournamentName);
+
         String tid   = getIntent().getStringExtra("tournamentId");
+        String nameExtra = getIntent().getStringExtra("tournamentName");
         String myUid = requireNonNull(FirebaseAuth.getInstance().getCurrentUser()).getUid();
         FirebaseFirestore db = FirebaseFirestore.getInstance();
+
+        if (nameExtra != null) {
+            tournamentName.setText(nameExtra);
+        } else if (tid != null) {
+            db.collection("tournaments").document(tid).get()
+                    .addOnSuccessListener(doc -> {
+                        String n = doc.getString("name");
+                        if (n != null) tournamentName.setText(n);
+                    });
+        }
 
         RecyclerView rv = findViewById(R.id.matchesList);
         rv.setLayoutManager(new LinearLayoutManager(this));

--- a/mobile/app/src/main/res/layout/activity_tournament_lobby.xml
+++ b/mobile/app/src/main/res/layout/activity_tournament_lobby.xml
@@ -9,11 +9,13 @@
 
     <!-- banner -->
     <TextView
+        android:id="@+id/tournamentName"
         android:text="@string/lobby_started"
         android:textColor="@color/colorGreenDark"
         android:textStyle="bold"
+        android:gravity="center"
         android:layout_marginBottom="12dp"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"/>
 
     <!-- matches list – fills the rest of the screen -->


### PR DESCRIPTION
## Summary
- update lobby banner to use a TextView with an id
- pass tournament name when opening TournamentLobbyActivity
- fetch tournament name and display it in TournamentLobbyActivity

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687eab2fe5a08330a225d6d74faeed81