### PR TITLE
Handle inconsistent status strings

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentsActivity.java
@@ -100,9 +100,15 @@ public class TournamentsActivity extends AppCompatActivity {
 
             for (DocumentSnapshot doc : snap.getDocuments()) {
                 String status = doc.getString("status");
-                if ("registering".equals(status)) registeringDocs.add(doc);
-                else if ("running".equals(status)) runningDocs.add(doc);
-                else if ("ended".equals(status)) endedDocs.add(doc);
+                if (status != null) status = status.trim().toLowerCase();
+
+                if ("registering".equals(status)) {
+                    registeringDocs.add(doc);
+                } else if ("running".equals(status)) {
+                    runningDocs.add(doc);
+                } else if ("ended".equals(status)) {
+                    endedDocs.add(doc);
+                }
             }
 
             registeringAdapter.notifyDataSetChanged();


### PR DESCRIPTION
## Summary
- trim and lowercase tournament status strings before checking

## Testing
- `python -m pytest -q gcp/cloud-functions/tests/test_service_check.py`

------
https://chatgpt.com/codex/tasks/task_e_687f4ffa34088330bb7dacf8e9743080