### PR TITLE
Add Ranking Activity

### DIFF
--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -91,6 +91,15 @@
                 android:value=".TournamentsActivity"/>
         </activity>
 
+        <activity
+            android:name=".RankingActivity"
+            android:exported="false"
+            android:parentActivityName=".MenuActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MenuActivity"/>
+        </activity>
+
         <service
             android:name=".notifications.MyFirebaseMessagingService"
             android:exported="false">

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -126,6 +126,7 @@ public class MenuActivity extends AppCompatActivity {
         Button inviteBtn = findViewById(R.id.InviteFriend);
         Button pendingBtn = findViewById(R.id.ShowInvites);
         Button tournamentsBtn = findViewById(R.id.openTournamentsBtn);
+        Button rankingBtn = findViewById(R.id.openRankingBtn);
 
         // Check if backend is available - if not, disable ALL buttons
         if (!isBackendAvailable) {
@@ -133,12 +134,14 @@ public class MenuActivity extends AppCompatActivity {
             inviteBtn.setEnabled(false);
             pendingBtn.setEnabled(false);
             tournamentsBtn.setEnabled(false);
+            rankingBtn.setEnabled(false);
             
             // Visual cue (dim all buttons)
             float disabledAlpha = 0.3f;
             inviteBtn.setAlpha(disabledAlpha);
             pendingBtn.setAlpha(disabledAlpha);
             tournamentsBtn.setAlpha(disabledAlpha);
+            rankingBtn.setAlpha(disabledAlpha);
 
             return; // Skip the normal auth-based logic
         }
@@ -148,12 +151,14 @@ public class MenuActivity extends AppCompatActivity {
         inviteBtn.setEnabled(loggedIn);
         pendingBtn.setEnabled(loggedIn);
         tournamentsBtn.setEnabled(loggedIn);
+        rankingBtn.setEnabled(loggedIn);
 
         // Optional: visual cue (dim when disabled due to not being logged in)
         float alpha = loggedIn ? 1f : 0.4f;
         inviteBtn.setAlpha(alpha);
         pendingBtn.setAlpha(alpha);
         tournamentsBtn.setAlpha(alpha);
+        rankingBtn.setAlpha(alpha);
     }
 
 
@@ -335,6 +340,10 @@ public class MenuActivity extends AppCompatActivity {
 
     public void OpenTournaments(View view) {
         startActivity(new Intent(this, TournamentsActivity.class));
+    }
+
+    public void OpenRanking(View view) {
+        startActivity(new Intent(this, RankingActivity.class));
     }
 
     @Override

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RankingActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RankingActivity.java
@@ -1,0 +1,156 @@
+package piotr_gorczynski.soccer2;
+
+import android.os.Build;
+import android.os.Bundle;
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FieldPath;
+import com.google.firebase.firestore.FirebaseFirestore;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class RankingActivity extends AppCompatActivity {
+
+    private final List<RankingEntry> ranking = new ArrayList<>();
+    private RankingAdapter adapter;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_ranking);
+
+        RecyclerView list = findViewById(R.id.rankingList);
+        list.setLayoutManager(new LinearLayoutManager(this));
+        adapter = new RankingAdapter(ranking);
+        list.setAdapter(adapter);
+
+        loadRanking();
+    }
+
+    private void loadRanking() {
+        FirebaseFirestore db = FirebaseFirestore.getInstance();
+
+        db.collectionGroup("matches").get().addOnSuccessListener(snap -> {
+            Map<String, RankingEntry> scoreMap = new HashMap<>();
+            for (DocumentSnapshot doc : snap.getDocuments()) {
+                String winner = doc.getString("winner");
+                if (winner == null || winner.isEmpty()) continue;
+                RankingEntry e = scoreMap.get(winner);
+                if (e == null) {
+                    e = new RankingEntry(winner);
+                    scoreMap.put(winner, e);
+                }
+                e.wins += 1;
+            }
+
+            List<String> uids = new ArrayList<>(scoreMap.keySet());
+            if (uids.isEmpty()) {
+                ranking.clear();
+                adapter.notifyDataSetChanged();
+                return;
+            }
+
+            db.collection("users").whereIn(FieldPath.documentId(), uids)
+                    .get().addOnSuccessListener(userSnap -> {
+                        for (DocumentSnapshot user : userSnap) {
+                            RankingEntry e = scoreMap.get(user.getId());
+                            if (e != null) {
+                                e.nickname = user.getString("nickname");
+                            }
+                        }
+
+                        ranking.clear();
+                        ranking.addAll(scoreMap.values());
+
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                            ranking.sort(Comparator.comparingInt((RankingEntry e) -> e.wins).reversed());
+                        }
+                        assignMedals(ranking);
+                        adapter.notifyDataSetChanged();
+                    });
+        });
+    }
+
+    private void assignMedals(List<RankingEntry> list) {
+        int category = 1; // 1 gold, 2 silver, 3 bronze
+        int prevWins = -1;
+        for (RankingEntry e : list) {
+            if (prevWins != -1 && e.wins != prevWins) {
+                category += 1;
+            }
+            e.medalCategory = category <= 3 ? category : 0;
+            prevWins = e.wins;
+        }
+    }
+
+    static class RankingEntry {
+        final String uid;
+        String nickname;
+        int wins = 0;
+        int medalCategory = 0; // 0=none,1=gold,2=silver,3=bronze
+
+        RankingEntry(String uid) {
+            this.uid = uid;
+        }
+    }
+
+    static class RankingAdapter extends RecyclerView.Adapter<RankingAdapter.VH> {
+        static class VH extends RecyclerView.ViewHolder {
+            final android.widget.TextView rank, player, points;
+            VH(android.view.View itemView) {
+                super(itemView);
+                rank = itemView.findViewById(R.id.rank);
+                player = itemView.findViewById(R.id.player);
+                points = itemView.findViewById(R.id.points);
+            }
+        }
+
+        private final List<RankingEntry> data;
+        RankingAdapter(List<RankingEntry> data) {
+            this.data = data;
+        }
+
+        @NonNull
+        @Override
+        public VH onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+            android.view.View v = android.view.LayoutInflater.from(parent.getContext())
+                    .inflate(R.layout.item_standing, parent, false);
+            return new VH(v);
+        }
+
+        @Override
+        public void onBindViewHolder(@NonNull VH holder, int position) {
+            RankingEntry entry = data.get(position);
+            String medal = null;
+            switch (entry.medalCategory) {
+                case 1 -> medal = "🥇"; // 🥇
+                case 2 -> medal = "🥈"; // 🥈
+                case 3 -> medal = "🥉"; // 🥉
+            }
+            if (medal != null) {
+                holder.rank.setText(medal);
+            } else {
+                holder.rank.setText(String.valueOf(position + 1));
+            }
+            holder.player.setText(entry.nickname != null ? entry.nickname : entry.uid);
+            Context context = holder.itemView.getContext();
+            String formatted = context.getResources().getQuantityString(R.plurals.wins_format, entry.wins, entry.wins);
+            holder.points.setText(formatted);
+        }
+
+        @Override
+        public int getItemCount() {
+            return data.size();
+        }
+    }
+}

--- a/mobile/app/src/main/res/layout/activity_menu.xml
+++ b/mobile/app/src/main/res/layout/activity_menu.xml
@@ -89,5 +89,17 @@
         android:textColor="@color/colorWhite"
         android:textStyle="bold" />
 
+    <Button
+        android:id="@+id/openRankingBtn"
+        android:layout_width="200dp"
+        android:layout_height="50dp"
+        android:layout_marginTop="10dp"
+        android:background="@color/colorGreen"
+        android:onClick="OpenRanking"
+        android:text="@string/ranking"
+        android:textAllCaps="false"
+        android:textColor="@color/colorWhite"
+        android:textStyle="bold" />
+
     </LinearLayout>
 </LinearLayout>

--- a/mobile/app/src/main/res/layout/activity_ranking.xml
+++ b/mobile/app/src/main/res/layout/activity_ranking.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="20dp"
+    android:background="@color/colorWhite"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/rankingTitle"
+        android:textStyle="bold"
+        android:textColor="@color/colorGreenDark"
+        android:gravity="center"
+        android:layout_marginBottom="12dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/ranking" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rankingList"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</LinearLayout>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="waiting_for_opponent_named">Waiting for %1$s to accept…</string>
     <string name="waiting_for_opponent">Waiting for opponent to accept…</string>
     <string name="tournaments">Tournaments</string>
+    <string name="ranking">Ranking</string>
     <string name="join">Join</string>
     <!-- "%1$d" → first argument (joined), "%2$d" → second (max) -->
     <string name="slots_format">%1$d / %2$d</string>


### PR DESCRIPTION
## Summary
- add RankingActivity to show overall wins across tournaments
- add button on the menu screen to open RankingActivity
- register activity in manifest
- update strings

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f5019144483309300ec3e2759ccbd