### PR TITLE
Filter ranking stats to tournament matches

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RankingActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RankingActivity.java
@@ -44,6 +44,9 @@ public class RankingActivity extends AppCompatActivity {
         db.collectionGroup("matches").get().addOnSuccessListener(snap -> {
             Map<String, RankingEntry> scoreMap = new HashMap<>();
             for (DocumentSnapshot doc : snap.getDocuments()) {
+                // Skip "friendly" matches stored at the top level
+                String path = doc.getReference().getPath();
+                if (!path.startsWith("tournaments/")) continue;
                 String winner = doc.getString("winner");
                 if (winner == null || winner.isEmpty()) continue;
                 RankingEntry e = scoreMap.get(winner);


### PR DESCRIPTION
## Summary
- update RankingActivity to skip friendly matches when aggregating winner data

## Testing
- `./gradlew test --console plain --no-daemon --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f662fee38833081f76fc7a0f38786