### PR TITLE
Display match outcome in lobby

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MatchAdapter.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MatchAdapter.java
@@ -73,6 +73,7 @@ public class MatchAdapter
     private final String myUid;
 
     private final String tournamentId;
+    private boolean showOutcome = false;
 
     /** return position of the doc that already has this ID, or -1 if none */
     private int indexForId(@NonNull String docId) {
@@ -90,6 +91,10 @@ public class MatchAdapter
         this.tournamentId  = Objects.requireNonNull(tournamentId,
                 "tournamentId must not be null");
         setHasStableIds(true);   // ✅ tell RecyclerView this adapter uses stable IDs
+    }
+
+    void setShowOutcome(boolean value) {
+        this.showOutcome = value;
     }
 
     @Override
@@ -270,12 +275,24 @@ public class MatchAdapter
         }
 
         /* ----------- status label ----------- */
-        String st = m.getString("status");          // scheduled | playing | done
-        h.status.setText(st);
+        String st = m.getString("status");          // scheduled | playing | completed
+
+        String statusLabel = st;
+        if (showOutcome && "completed".equals(st)) {
+            String winner = m.getString("winner");
+            if (winner != null) {
+                statusLabel = winner.equals(myUid)
+                        ? context.getString(R.string.match_completed_win)
+                        : context.getString(R.string.match_completed_lose);
+            }
+        }
+
+        h.status.setText(statusLabel);
+
         int colour = switch (Objects.requireNonNull(st)) {
             case "playing"   -> ContextCompat.getColor(
                     h.itemView.getContext(), R.color.colorAccent);
-            case "done"      -> ContextCompat.getColor(
+            case "done", "completed" -> ContextCompat.getColor(
                     h.itemView.getContext(), R.color.colorGrey);
             default          -> ContextCompat.getColor(
                     h.itemView.getContext(), R.color.colorGreenDark);

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentLobbyActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentLobbyActivity.java
@@ -108,6 +108,7 @@ public class TournamentLobbyActivity extends AppCompatActivity {
                 myUid,
                 requireNonNull(tid)
         );
+        mAdapter.setShowOutcome(true);
         rv.setAdapter(mAdapter);
 
         /* one common handler so we don’t repeat the diff logic */

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -84,6 +84,8 @@
     <string name="target_player_busy">That player is already busy with another invitation.</string>
     <string name="accept">Accept</string>
     <string name="decline">Decline</string>
+    <string name="match_completed_win">completed, you won 🏆</string>
+    <string name="match_completed_lose">completed, you lost 😞</string>
     <string name="regulation_not_found">Regulation not found.</string>
     <string name="regulation_load_error">Failed to load regulation.</string>
     <string name="regulation_auth_required">Please log in to view the regulation.</string>


### PR DESCRIPTION
## Summary
- add ability to show result beside completed matches
- wire the MatchAdapter feature from TournamentLobbyActivity
- add new string resources for completed match result

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f69b1d4108330a261f95acf204f22