### PR TITLE
Fix missing tournament display

### DIFF
--- a/mobile/app/src/main/res/layout/activity_tournaments.xml
+++ b/mobile/app/src/main/res/layout/activity_tournaments.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ScrollView
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:fillViewport="true"
         android:layout_height="match_parent">
@@ -74,5 +74,5 @@
             android:layout_marginBottom="16dp"
             android:nestedScrollingEnabled="false" />
         </LinearLayout>
-    </ScrollView>
+    </androidx.core.widget.NestedScrollView>
 </LinearLayout>


### PR DESCRIPTION
## Summary
- display all tournaments by using NestedScrollView
- revert incorrect status fallback logic

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f6cb5742c8330b217462913162c47