### PR TITLE
Fix auth provider setup

### DIFF
--- a/gcp/cloud-build/deploy_firebase_with_auth.yaml
+++ b/gcp/cloud-build/deploy_firebase_with_auth.yaml
@@ -120,7 +120,7 @@ steps:
             -H "Authorization: Bearer $access_token" \
             -H "X-Goog-User-Project: $firebase_project_id" \
             -H "Content-Type: application/json" \
-            "https://identitytoolkit.googleapis.com/v2/projects/$firebase_project_id/defaultSupportedIdpConfigs/$provider?updateMask=enabled" \
+            "https://identitytoolkit.googleapis.com/admin/v2/projects/$firebase_project_id/defaultSupportedIdpConfigs/$provider?updateMask=enabled" \
             -d "{\"enabled\": true}")
 
           code=$(echo "$resp" | tail -n1)


### PR DESCRIPTION
## Summary
- fix Identity Platform provider URL in deploy script

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688004cc1dc483308a12f37e0bb43517