### PR TITLE
Fix missing nickname input for universal login

### DIFF
--- a/mobile/app/src/main/res/layout/activity_universal_login.xml
+++ b/mobile/app/src/main/res/layout/activity_universal_login.xml
@@ -7,6 +7,14 @@
     android:orientation="vertical"
     android:padding="20dp">
 
+    <EditText
+        android:id="@+id/editUniversalNickname"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:autofillHints="Enter nickname"
+        android:hint="@string/nickname"
+        android:inputType="textPersonName" />
+
 
     <Button
         android:id="@+id/btnUniversalEmail"


### PR DESCRIPTION
## Summary
- add missing nickname `EditText` to the `activity_universal_login.xml` layout

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688291f1010083308b861750d48158d8