### PR TITLE
Fix consent form Activity parameter

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -388,21 +388,21 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
                 params,
                 () -> {
                     if (consentInformation.isConsentFormAvailable()) {
-                        loadAndShowConsentForm();
+                        loadAndShowConsentForm(activity);
                     }
                 },
                 formError -> Log.w("TAG_Soccer", "UMP: Failed to update consent info: " + formError.getMessage())
         );
     }
 
-    private void loadAndShowConsentForm() {
+    private void loadAndShowConsentForm(Activity activity) {
         UserMessagingPlatform.loadConsentForm(
-                this,
+                activity,
                 consentForm -> {
-                    if (UserMessagingPlatform.getConsentInformation(this).getConsentStatus()
+                    if (UserMessagingPlatform.getConsentInformation(activity).getConsentStatus()
                             == ConsentInformation.ConsentStatus.REQUIRED) {
                         consentForm.show(
-                                this,
+                                activity,
                                 formError -> {
                                     if (formError != null) {
                                         Log.w("TAG_Soccer", "UMP: Consent form error: " + formError.getMessage());


### PR DESCRIPTION
## Summary
- pass the caller `Activity` when loading consent form

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883e6d6d4b883308bcbf8b2148ce0cc