### PR TITLE
Add debug logging for provider login

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
@@ -33,9 +33,15 @@ public class FirebaseAuthManager {
     }
 
     public void loginWithProvider(Activity activity, String providerId, String nickname, LoginCallback callback) {
+        Log.d("TAG_Soccer", getClass().getSimpleName() + "." +
+                Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
+                ": Starting provider login. providerId=" + providerId + ", nickname=" + nickname);
         OAuthProvider.Builder provider = OAuthProvider.newBuilder(providerId);
         firebaseAuth.startActivityForSignInWithProvider(activity, provider.build())
                 .addOnSuccessListener(authResult -> {
+                    Log.d("TAG_Soccer", getClass().getSimpleName() + "." +
+                            Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
+                            ": signInWithProvider success");
                     String uid = authResult.getUser().getUid();
                     String email = authResult.getUser().getEmail();
 
@@ -50,11 +56,19 @@ public class FirebaseAuthManager {
                             .set(userData)
                             .addOnCompleteListener(task -> {
                                 storeUserData(uid, email != null ? email : "", nickname, providerId);
-                                ((SoccerApp) context.getApplicationContext()).syncFcmTokenIfNeeded();
-                                callback.onLoginSuccess();
-                            });
+                            ((SoccerApp) context.getApplicationContext()).syncFcmTokenIfNeeded();
+                            Log.d("TAG_Soccer", getClass().getSimpleName() + "." +
+                                    Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
+                                    ": user data stored for uid=" + uid);
+                            callback.onLoginSuccess();
+                        });
                 })
-                .addOnFailureListener(e -> callback.onLoginFailure(e.getMessage()));
+                .addOnFailureListener(e -> {
+                    Log.e("TAG_Soccer", getClass().getSimpleName() + "." +
+                            Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
+                            ": signInWithProvider FAILED", e);
+                    callback.onLoginFailure(e.getMessage());
+                });
     }
 
     private void storeUserData(String uid, String email, String nickname, String method) {

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/UniversalLoginActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/UniversalLoginActivity.java
@@ -7,6 +7,8 @@ import android.widget.EditText;
 import android.widget.Toast;
 import android.content.SharedPreferences;
 import android.view.View;
+import android.util.Log;
+import java.util.Objects;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
@@ -46,25 +48,45 @@ public class UniversalLoginActivity extends AppCompatActivity {
     }
 
     private void handleProviderLogin(String provider) {
+        Log.d("TAG_Soccer", getClass().getSimpleName() + "." +
+                Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
+                ": Provider selected = " + provider);
+
         String nickname;
         if (storedNickname != null && !storedNickname.isEmpty()) {
             nickname = storedNickname;
+            Log.d("TAG_Soccer", getClass().getSimpleName() + "." +
+                    Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
+                    ": Using stored nickname = " + nickname);
         } else {
             nickname = editNickname.getText().toString().trim();
             if (nickname.isEmpty()) {
                 Toast.makeText(this, "Nickname is required", Toast.LENGTH_SHORT).show();
                 return;
             }
+            Log.d("TAG_Soccer", getClass().getSimpleName() + "." +
+                    Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
+                    ": Entered nickname = " + nickname);
         }
+        Log.d("TAG_Soccer", getClass().getSimpleName() + "." +
+                Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
+                ": Calling authManager.loginWithProvider");
+
         authManager.loginWithProvider(this, provider, nickname, new FirebaseAuthManager.LoginCallback() {
             @Override
             public void onLoginSuccess() {
+                Log.d("TAG_Soccer", getClass().getSimpleName() + "." +
+                        Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
+                        ": onLoginSuccess");
                 Toast.makeText(UniversalLoginActivity.this, "Login successful", Toast.LENGTH_SHORT).show();
                 finish();
             }
 
             @Override
             public void onLoginFailure(String message) {
+                Log.e("TAG_Soccer", getClass().getSimpleName() + "." +
+                        Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
+                        ": onLoginFailure: " + message);
                 Toast.makeText(UniversalLoginActivity.this, "Login failed: " + message, Toast.LENGTH_LONG).show();
             }
         });


### PR DESCRIPTION
## Summary
- add verbose logging to `UniversalLoginActivity` when launching provider login
- log success/failure in `FirebaseAuthManager.loginWithProvider`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883e5b09c2483309bd87c3420ce0522