### PR TITLE
Implement non-personalized ad requests

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -43,6 +43,9 @@ import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.interstitial.InterstitialAd;
 import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback;
+import com.google.android.gms.ads.mediation.admob.AdMobAdapter;
+import com.google.android.ump.ConsentInformation;
+import com.google.android.ump.UserMessagingPlatform;
 
 
 
@@ -247,7 +250,19 @@ public class MenuActivity extends AppCompatActivity {
 
     }
     private void loadInterstitialAd() {
-        AdRequest adRequest = new AdRequest.Builder().build();
+        ConsentInformation consentInformation =
+                UserMessagingPlatform.getConsentInformation(this);
+
+        AdRequest.Builder builder = new AdRequest.Builder();
+
+        if (consentInformation.getConsentStatus()
+                != ConsentInformation.ConsentStatus.OBTAINED) {
+            Bundle extras = new Bundle();
+            extras.putString("npa", "1");
+            builder.addNetworkExtrasBundle(AdMobAdapter.class, extras);
+        }
+
+        AdRequest adRequest = builder.build();
 
         InterstitialAd.load(this, AD_UNIT_ID, adRequest,
                 new InterstitialAdLoadCallback() {


### PR DESCRIPTION
## Summary
- load interstitial ads with the `npa` flag when consent hasn't been obtained
- import UMP and AdMobAdapter APIs

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883eaf936c48330a96aaf9f4e48a259