### PR TITLE
Fix NPE in UniversalLoginActivity

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/UniversalLoginActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/UniversalLoginActivity.java
@@ -26,6 +26,8 @@ public class UniversalLoginActivity extends AppCompatActivity {
 
         authManager = new FirebaseAuthManager(this);
 
+        editNickname = findViewById(R.id.editNickname);
+
         SharedPreferences prefs = getSharedPreferences(getPackageName() + "_preferences", MODE_PRIVATE);
         storedNickname = prefs.getString("nickname", null);
         if (storedNickname != null && !storedNickname.isEmpty()) {

--- a/mobile/app/src/main/res/layout/activity_universal_login.xml
+++ b/mobile/app/src/main/res/layout/activity_universal_login.xml
@@ -6,6 +6,14 @@
     android:gravity="center"
     android:orientation="vertical"
     android:padding="20dp">
+    <EditText
+        android:id="@+id/editNickname"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        android:hint="@string/nickname"
+        android:inputType="textPersonName" />
+
     <Button
         android:id="@+id/btnUniversalEmail"
         android:layout_width="200dp"


### PR DESCRIPTION
## Summary
- hook up nickname EditText in UniversalLoginActivity
- add nickname field to universal login layout

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883ebaa6b508330b2a3b3af4ded2df2