### PR TITLE
Fix AdMobAdapter import

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -43,7 +43,7 @@ import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.interstitial.InterstitialAd;
 import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback;
-import com.google.android.gms.ads.mediation.admob.AdMobAdapter;
+import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.ump.ConsentInformation;
 import com.google.android.ump.UserMessagingPlatform;
 


### PR DESCRIPTION
## Summary
- use `com.google.ads.mediation.admob.AdMobAdapter` import in `MenuActivity`

## Testing
- `./gradlew --version`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884b7ea4d608330bd12df19a34d8233