### PR TITLE
Add ad consent check before backend features

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
@@ -5,6 +5,8 @@ import android.util.Log;
 import androidx.preference.CheckBoxPreference;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
+import androidx.preference.PreferenceCategory;
 
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.firestore.FirebaseFirestore;
@@ -28,11 +30,21 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         if (blockInvitePreference != null) {
             // Load current value from Firestore
             loadBlockInvitePreference(blockInvitePreference);
-            
+
             // Listen for changes
             blockInvitePreference.setOnPreferenceChangeListener((preference, newValue) -> {
                 boolean blockInvites = (Boolean) newValue;
                 updateBlockInviteInFirestore(blockInvites);
+                return true;
+            });
+        }
+
+        // Setup ad consent preference
+        Preference adsConsentPref = findPreference("ads_consent");
+        if (adsConsentPref != null) {
+            adsConsentPref.setOnPreferenceClickListener(pref -> {
+                SoccerApp app = (SoccerApp) requireActivity().getApplication();
+                app.requestConsent(requireActivity());
                 return true;
             });
         }

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -10,6 +10,8 @@
     <string name="pref_title_level">Android level</string>
     <string name="pref_title_block_invite_friend">Block \'Invite a Friend\' requests</string>
     <string name="pref_summary_block_invite_friend">Other players cannot invite you via \'Invite a Friend\' (tournaments not affected)</string>
+    <string name="pref_title_ads_consent">Consent for showing ads</string>
+    <string name="pref_summary_ads_consent">Review or change your consent for displaying ads</string>
     <string-array name="pref_level_titles">
         <item>Easy</item>
         <item>Medium</item>
@@ -107,4 +109,5 @@
     <string name="login_facebook">Login with Facebook</string>
     <string name="login_microsoft">Login with Microsoft</string>
     <string name="login_method_label">Login method: %1$s</string>
+    <string name="ads_consent_required">Showing ads is helping to finance infrastructure maintenance. Because you have not agreed to show ads, this option is not available. You can check your consent in settings.</string>
 </resources>

--- a/mobile/app/src/main/res/xml/pref_android_level.xml
+++ b/mobile/app/src/main/res/xml/pref_android_level.xml
@@ -16,4 +16,10 @@
             android:defaultValue="false"
             android:icon="@drawable/ic_block" />
 
+        <Preference
+            android:key="ads_consent"
+            android:title="@string/pref_title_ads_consent"
+            android:summary="@string/pref_summary_ads_consent"
+            android:icon="@android:drawable/ic_dialog_info" />
+
 </PreferenceScreen>


### PR DESCRIPTION
## Summary
- add preference for ad consent in settings
- allow settings to launch consent form
- check ad consent before backend activities and show info dialog if denied
- show an interstitial ad when consented before opening backend activities

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884bc4f70788330a50ade1e8588ad2d