### PR TITLE
Implement custom Firebase auth app

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/AccountActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/AccountActivity.java
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
 import com.google.firebase.auth.FirebaseAuth;
+import piotr_gorczynski.soccer2.AuthProvider;
 
 import java.util.Objects;
 
@@ -43,10 +44,10 @@ public class AccountActivity extends AppCompatActivity {
     }
 
     private void performLogout() {
-        String uid = FirebaseAuth.getInstance().getUid();
+        String uid = AuthProvider.getAuth().getUid();
 
         // Sign out immediately so the UI updates even if network operations fail
-        FirebaseAuth.getInstance().signOut();
+        AuthProvider.getAuth().signOut();
 
         // Attempt to mark the user offline in the background; no need to wait
         if (uid != null) {

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/AuthProvider.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/AuthProvider.java
@@ -1,0 +1,21 @@
+package piotr_gorczynski.soccer2;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.auth.FirebaseAuth;
+
+/**
+ * Provides FirebaseAuth from the custom FirebaseApp.
+ */
+public final class AuthProvider {
+    private AuthProvider() { }
+
+    public static FirebaseAuth getAuth() {
+        try {
+            FirebaseApp app = FirebaseApp.getInstance("custom");
+            return FirebaseAuth.getInstance(app);
+        } catch (IllegalStateException e) {
+            // Fallback if the custom app isn't initialized
+            return FirebaseAuth.getInstance();
+        }
+    }
+}

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/BackendServiceChecker.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/BackendServiceChecker.java
@@ -11,6 +11,7 @@ import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
+import piotr_gorczynski.soccer2.AuthProvider;
 
 import org.json.JSONObject;
 
@@ -95,7 +96,7 @@ public class BackendServiceChecker {
             Log.d(TAG, "No secret key available, proceeding without authentication");
         }
         
-        FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+        FirebaseUser user = AuthProvider.getAuth().getCurrentUser();
         if (user != null) {
             Log.d(TAG, "Fetching ID token for authenticated request");
             user.getIdToken(false)

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/CustomFirebaseApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/CustomFirebaseApp.java
@@ -1,0 +1,37 @@
+package piotr_gorczynski.soccer2;
+
+import android.content.Context;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+
+/**
+ * Utility class to provide a FirebaseApp instance with a custom auth domain.
+ */
+public class CustomFirebaseApp {
+    private static final String CUSTOM_APP_NAME = "custom";
+    private static FirebaseApp customApp;
+
+    public static synchronized FirebaseApp getApp(Context context) {
+        if (customApp != null) return customApp;
+
+        FirebaseApp defaultApp = FirebaseApp.initializeApp(context);
+        if (defaultApp == null) {
+            throw new IllegalStateException("Default FirebaseApp not initialized");
+        }
+
+        FirebaseOptions original = defaultApp.getOptions();
+
+        FirebaseOptions options = new FirebaseOptions.Builder()
+                .setApiKey(original.getApiKey())
+                .setApplicationId(original.getApplicationId())
+                .setProjectId(original.getProjectId())
+                .setDatabaseUrl(original.getDatabaseUrl())
+                .setStorageBucket(original.getStorageBucket())
+                .setGcmSenderId(original.getGcmSenderId())
+                .setAuthDomain("piotr-gorczynski.com")
+                .build();
+
+        customApp = FirebaseApp.initializeApp(context, options, CUSTOM_APP_NAME);
+        return customApp;
+    }
+}

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
@@ -9,6 +9,10 @@ import androidx.appcompat.app.AlertDialog;
 
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.OAuthProvider;
+import com.google.firebase.FirebaseApp;
+
+// Custom FirebaseApp with overridden authDomain
+import piotr_gorczynski.soccer2.CustomFirebaseApp;
 
 import com.google.firebase.auth.UserProfileChangeRequest;
 
@@ -24,7 +28,8 @@ public class FirebaseAuthManager {
 
     public FirebaseAuthManager(Context context) {
         this.context = context;
-        this.firebaseAuth = FirebaseAuth.getInstance();
+        FirebaseApp customApp = CustomFirebaseApp.getApp(context);
+        this.firebaseAuth = FirebaseAuth.getInstance(customApp);
     }
 
     public interface LoginCallback {

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/GameActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/GameActivity.java
@@ -22,6 +22,7 @@ import android.widget.Toast;
 
 import com.google.firebase.Timestamp;
 import com.google.firebase.auth.FirebaseAuth;
+import piotr_gorczynski.soccer2.AuthProvider;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentReference;
@@ -271,7 +272,7 @@ public class GameActivity extends AppCompatActivity {
                 return;
             }
 
-            FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+            FirebaseUser user = AuthProvider.getAuth().getCurrentUser();
             if (user == null) {
                 Log.e("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() + ": User not signed in");
                 Toast.makeText(this, "Please log in to continue.", Toast.LENGTH_LONG).show();
@@ -641,7 +642,7 @@ public class GameActivity extends AppCompatActivity {
                         .setMessage("Are you sure you want to exit? This will count as a forfeit.")
                         .setPositiveButton("Yes", (dialog, which) -> {
                             if (matchPath != null) {
-                                String loserUid = Objects.requireNonNull(FirebaseAuth.getInstance().getCurrentUser()).getUid();
+                                String loserUid = Objects.requireNonNull(AuthProvider.getAuth().getCurrentUser()).getUid();
                                 String winnerUid = loserUid.equals(player0Uid) ? player1Uid : player0Uid;
 
                                 Map<String, Object> update = new HashMap<>();

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
@@ -17,6 +17,7 @@ import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.firestore.*;
 import com.google.firebase.functions.FirebaseFunctions;
 import com.google.firebase.functions.FirebaseFunctionsException;
+import piotr_gorczynski.soccer2.AuthProvider;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -53,7 +54,7 @@ public class InvitationsActivity extends AppCompatActivity {
         invitesList.setAdapter(adapter);
 
         db = FirebaseFirestore.getInstance();
-        auth = FirebaseAuth.getInstance();
+        auth = AuthProvider.getAuth();
 
         listenForInvites();
 
@@ -86,7 +87,7 @@ public class InvitationsActivity extends AppCompatActivity {
             return;
         }
 
-        FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+        FirebaseUser user = AuthProvider.getAuth().getCurrentUser();
         if (user == null) {
             Log.e("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() + ": User not signed-in");
             Toast.makeText(this, "You must be logged in to accept invites.",

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/InviteFriendActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/InviteFriendActivity.java
@@ -11,6 +11,7 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.firestore.*;
+import piotr_gorczynski.soccer2.AuthProvider;
 import com.google.firebase.functions.FirebaseFunctions;
 import com.google.firebase.functions.FirebaseFunctionsException;
 
@@ -37,7 +38,7 @@ public class InviteFriendActivity extends AppCompatActivity {
         resultText = findViewById(R.id.inviteResult);
 
         db = FirebaseFirestore.getInstance();
-        auth = FirebaseAuth.getInstance();
+        auth = AuthProvider.getAuth();
 
         sendInviteButton.setOnClickListener(view -> {
             String nickname = nicknameInput.getText().toString().trim();

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -24,6 +24,7 @@ import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.auth.FirebaseAuth;
+import piotr_gorczynski.soccer2.AuthProvider;
 
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
@@ -64,7 +65,7 @@ public class MenuActivity extends AppCompatActivity {
 
     /* ───────────── misc tasks that must always run on launch ───────────── */
     private void runHousekeeping() {
-        String uid = FirebaseAuth.getInstance().getUid();
+        String uid = AuthProvider.getAuth().getUid();
         if (uid == null) {
             Log.w("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object() {
             }.getClass().getEnclosingMethod()).getName() + ": ⚠️ No logged-in user; token not saved");
@@ -137,7 +138,7 @@ public class MenuActivity extends AppCompatActivity {
     }
 
     private void updateUiForAuthState() {
-        boolean loggedIn = FirebaseAuth.getInstance().getCurrentUser() != null;
+        boolean loggedIn = AuthProvider.getAuth().getCurrentUser() != null;
 
         Button inviteBtn = findViewById(R.id.InviteFriend);
         Button pendingBtn = findViewById(R.id.ShowInvites);
@@ -208,9 +209,9 @@ public class MenuActivity extends AppCompatActivity {
 
         /* ───────────── 1️⃣  Look for any ACTIVE match involving this user ───────────── */
         SharedPreferences prefs = getSharedPreferences(getPackageName() + "_preferences", MODE_PRIVATE);
-        String uid = FirebaseAuth.getInstance().getUid();
+        String uid = AuthProvider.getAuth().getUid();
         Log.d("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object() {
-        }.getClass().getEnclosingMethod()).getName() + ": Auth UID at match-lookup = " + FirebaseAuth.getInstance().getUid());
+        }.getClass().getEnclosingMethod()).getName() + ": Auth UID at match-lookup = " + AuthProvider.getAuth().getUid());
 
         if (uid != null) {
             FirebaseFirestore db = FirebaseFirestore.getInstance();
@@ -344,7 +345,7 @@ public class MenuActivity extends AppCompatActivity {
 
     /*  🔻  old waiting-invite code moved unchanged into a helper  */
     private void continueWithInviteRestore() {
-        String uid = FirebaseAuth.getInstance().getUid();
+        String uid = AuthProvider.getAuth().getUid();
         if (uid == null) return;
 
         FirebaseFirestore db = FirebaseFirestore.getInstance();
@@ -493,7 +494,7 @@ public class MenuActivity extends AppCompatActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         int id = item.getItemId();
         if (id == R.id.action_account) {
-            if (FirebaseAuth.getInstance().getCurrentUser() == null) {
+            if (AuthProvider.getAuth().getCurrentUser() == null) {
                 startActivity(new Intent(this, UniversalLoginActivity.class));
             } else {
                 startActivity(new Intent(this, AccountActivity.class));
@@ -575,7 +576,7 @@ public class MenuActivity extends AppCompatActivity {
     private void checkAndUpdateBlockedInviteWarning() {
         if (optionsMenu == null) return; // Menu not created yet
         
-        String uid = FirebaseAuth.getInstance().getUid();
+        String uid = AuthProvider.getAuth().getUid();
         if (uid == null) {
             // No user logged in, hide warning
             MenuItem warningItem = optionsMenu.findItem(R.id.action_invite_blocked_warning);

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegulationActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegulationActivity.java
@@ -15,6 +15,7 @@ import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.functions.FirebaseFunctions;
 import com.google.firebase.functions.FirebaseFunctionsException;
+import piotr_gorczynski.soccer2.AuthProvider;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -46,7 +47,7 @@ public class RegulationActivity extends AppCompatActivity {
 
         FirebaseFirestore db = FirebaseFirestore.getInstance();
         if (!TextUtils.isEmpty(regulationId)) {
-            FirebaseUser authUser = FirebaseAuth.getInstance().getCurrentUser();
+            FirebaseUser authUser = AuthProvider.getAuth().getCurrentUser();
             Log.d("TAG_Soccer", getClass().getSimpleName() + "." +
                     Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
                     ": querying regulation from Firestore, currentUser=" +
@@ -127,7 +128,7 @@ public class RegulationActivity extends AppCompatActivity {
             Toast.makeText(this, "Tournament not found.", Toast.LENGTH_LONG).show();
             return;
         }
-        FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+        FirebaseUser user = AuthProvider.getAuth().getCurrentUser();
         if (user == null) {
             Log.e("TAG_Soccer", getClass().getSimpleName() + "." +
                     Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
@@ -10,6 +10,7 @@ import androidx.preference.PreferenceCategory;
 
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.firestore.FirebaseFirestore;
+import piotr_gorczynski.soccer2.AuthProvider;
 
 import java.util.Objects;
 
@@ -23,7 +24,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         setPreferencesFromResource(R.xml.pref_android_level, rootKey);
         
         db = FirebaseFirestore.getInstance();
-        auth = FirebaseAuth.getInstance();
+        auth = AuthProvider.getAuth();
         
         // Setup block invite friend preference
         CheckBoxPreference blockInvitePreference = findPreference("block_invite_friend");

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -21,6 +21,8 @@ import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.auth.FirebaseAuth;
+import piotr_gorczynski.soccer2.CustomFirebaseApp;
+import piotr_gorczynski.soccer2.AuthProvider;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
 import com.google.firebase.database.ServerValue;
@@ -78,6 +80,9 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
 
         Thread.setDefaultUncaughtExceptionHandler(new ExceptionHandler());
 
+        // Initialize custom FirebaseApp with overridden authDomain
+        CustomFirebaseApp.getApp(this);
+
 
         // Initialize backend service checker
         serviceChecker = new BackendServiceChecker(this);
@@ -99,7 +104,7 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
                     .getLifecycle()
                     .addObserver(this);
 
-            FirebaseAuth auth = FirebaseAuth.getInstance();
+            FirebaseAuth auth = AuthProvider.getAuth();
             auth.addAuthStateListener(a -> {
                 if (a.getCurrentUser() != null) {
                     startPresence(a.getCurrentUser().getUid());
@@ -118,7 +123,7 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
         MobileAds.initialize(this, initializationStatus -> {});
     }
     public void syncFcmTokenIfNeeded() {
-        String uid = FirebaseAuth.getInstance().getUid();
+        String uid = AuthProvider.getAuth().getUid();
         if (uid == null) return;
 
         FirebaseMessaging.getInstance().getToken()
@@ -236,7 +241,7 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
         @NonNull
         @Override
         public Result doWork() {
-            String uid = FirebaseAuth.getInstance().getUid();
+            String uid = AuthProvider.getAuth().getUid();
             if (uid == null) return Result.success();
 
             /* open connection just long enough for the write */

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentAdapter.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentAdapter.java
@@ -15,6 +15,7 @@ import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.auth.FirebaseAuth;
+import piotr_gorczynski.soccer2.AuthProvider;
 
 import java.util.Date;
 import java.util.List;
@@ -140,8 +141,8 @@ public class TournamentAdapter
             h.leaveBtn.setEnabled(false);
             h.leaveBtn.setVisibility(View.VISIBLE);
 
-            String uid = FirebaseAuth.getInstance().getCurrentUser() != null
-                    ? FirebaseAuth.getInstance().getCurrentUser().getUid()
+            String uid = AuthProvider.getAuth().getCurrentUser() != null
+                    ? AuthProvider.getAuth().getCurrentUser().getUid()
                     : null;
             if (uid != null) {
                 FirebaseFirestore.getInstance()
@@ -196,8 +197,8 @@ public class TournamentAdapter
             h.leaveBtn.setVisibility(View.GONE);
             h.joinBtn.setEnabled(false);
 
-            String uid = FirebaseAuth.getInstance().getCurrentUser() != null
-                    ? FirebaseAuth.getInstance().getCurrentUser().getUid()
+            String uid = AuthProvider.getAuth().getCurrentUser() != null
+                    ? AuthProvider.getAuth().getCurrentUser().getUid()
                     : null;
 
             if (uid != null) {

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentLobbyActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentLobbyActivity.java
@@ -18,6 +18,7 @@ import com.google.firebase.firestore.EventListener;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.ListenerRegistration;
 import com.google.firebase.firestore.Filter;
+import piotr_gorczynski.soccer2.AuthProvider;
 import com.google.firebase.firestore.QuerySnapshot;
 
 
@@ -89,7 +90,7 @@ public class TournamentLobbyActivity extends AppCompatActivity {
 
         String tid   = getIntent().getStringExtra("tournamentId");
         String nameExtra = getIntent().getStringExtra("tournamentName");
-        String myUid = requireNonNull(FirebaseAuth.getInstance().getCurrentUser()).getUid();
+        String myUid = requireNonNull(AuthProvider.getAuth().getCurrentUser()).getUid();
         FirebaseFirestore db = FirebaseFirestore.getInstance();
 
         if (nameExtra != null) {

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/notifications/MyFirebaseMessagingService.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/notifications/MyFirebaseMessagingService.java
@@ -19,6 +19,7 @@ import com.google.firebase.firestore.Source;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 import com.google.firebase.auth.FirebaseAuth;
+import piotr_gorczynski.soccer2.AuthProvider;
 import com.google.firebase.firestore.FirebaseFirestore;
 
 import piotr_gorczynski.soccer2.GameActivity;
@@ -71,8 +72,8 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
         super.onNewToken(token);
         Log.d("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() + ": 🔐 New FCM token: " + token);
 
-        String uid = FirebaseAuth.getInstance().getCurrentUser() != null
-                ? FirebaseAuth.getInstance().getCurrentUser().getUid()
+        String uid = AuthProvider.getAuth().getCurrentUser() != null
+                ? AuthProvider.getAuth().getCurrentUser().getUid()
                 : null;
 
         if (uid != null) {


### PR DESCRIPTION
## Summary
- add `CustomFirebaseApp` with overridden authDomain
- provide `AuthProvider` helper that returns `FirebaseAuth` from the custom app
- initialize the custom app in `SoccerApp`
- update authentication calls to use the custom app via `AuthProvider`

## Testing
- `./gradlew test --no-daemon --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884e76d493c83309411a7f6996e895b