### PR TITLE
Add logs for consent form debugging

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
@@ -43,6 +43,10 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         Preference adsConsentPref = findPreference("ads_consent");
         if (adsConsentPref != null) {
             adsConsentPref.setOnPreferenceClickListener(pref -> {
+                Log.d(
+                        "TAG_Soccer",
+                        getClass().getSimpleName() + ".onCreatePreferences: ads_consent clicked"
+                );
                 SoccerApp app = (SoccerApp) requireActivity().getApplication();
                 app.requestConsent(requireActivity());
                 return true;

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -377,6 +377,11 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
     }
 
     public void requestConsent(Activity activity) {
+        Log.d(
+                "TAG_Soccer",
+                getClass().getSimpleName() + ".requestConsent: starting"
+        );
+
         ConsentRequestParameters params = new ConsentRequestParameters
                 .Builder()
                 .setTagForUnderAgeOfConsent(false)
@@ -387,6 +392,10 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
                 activity,
                 params,
                 () -> {
+                    Log.d(
+                            "TAG_Soccer",
+                            getClass().getSimpleName() + ".requestConsent: consent info updated. form available=" + consentInformation.isConsentFormAvailable()
+                    );
                     if (consentInformation.isConsentFormAvailable()) {
                         loadAndShowConsentForm(activity);
                     }
@@ -399,6 +408,10 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
         UserMessagingPlatform.loadConsentForm(
                 activity,
                 consentForm -> {
+                    Log.d(
+                            "TAG_Soccer",
+                            getClass().getSimpleName() + ".loadAndShowConsentForm: form loaded"
+                    );
                     if (UserMessagingPlatform.getConsentInformation(activity).getConsentStatus()
                             == ConsentInformation.ConsentStatus.REQUIRED) {
                         consentForm.show(
@@ -406,8 +419,15 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
                                 formError -> {
                                     if (formError != null) {
                                         Log.w("TAG_Soccer", "UMP: Consent form error: " + formError.getMessage());
+                                    } else {
+                                        Log.d("TAG_Soccer", getClass().getSimpleName() + ".loadAndShowConsentForm: form dismissed");
                                     }
                                 });
+                    } else {
+                        Log.d(
+                                "TAG_Soccer",
+                                getClass().getSimpleName() + ".loadAndShowConsentForm: consent not required"
+                        );
                     }
                 },
                 formError -> Log.w("TAG_Soccer", "UMP: Failed to load consent form: " + formError.getMessage())


### PR DESCRIPTION
## Summary
- log when the consent preference is clicked
- add detailed logging for consent flow

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68850512d390833087f15828dbcaadae