### PR TITLE
Fix FCM token sync after Google login

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -120,6 +120,9 @@ public class MenuActivity extends AppCompatActivity {
         
         // Check backend availability when activity resumes
         checkBackendAvailability();
+
+        // Ensure the FCM token is stored after login
+        ((SoccerApp) getApplication()).syncFcmTokenIfNeeded();
         
         SharedPreferences prefs = getSharedPreferences(getPackageName() + "_preferences", MODE_PRIVATE);
         String nickname = prefs.getString("nickname", null);


### PR DESCRIPTION
## Summary
- ensure the user's FCM token is saved after logging in with a provider

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688507a906108330a32eb934bfe6182c