### PR TITLE
Allow changing ads consent

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
@@ -48,7 +48,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                         getClass().getSimpleName() + ".onCreatePreferences: ads_consent clicked"
                 );
                 SoccerApp app = (SoccerApp) requireActivity().getApplication();
-                app.requestConsent(requireActivity());
+                app.showAdsConsentForm(requireActivity());
                 return true;
             });
         }

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -404,6 +404,40 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
         );
     }
 
+    public void showAdsConsentForm(Activity activity) {
+        ConsentInformation consentInformation =
+                UserMessagingPlatform.getConsentInformation(activity);
+
+        if (consentInformation.getPrivacyOptionsRequirementStatus()
+                == ConsentInformation.PrivacyOptionsRequirementStatus.REQUIRED) {
+            Log.d(
+                    "TAG_Soccer",
+                    getClass().getSimpleName() + ".showAdsConsentForm: showing privacy options"
+            );
+            UserMessagingPlatform.showPrivacyOptionsForm(
+                    activity,
+                    formError -> {
+                        if (formError != null) {
+                            Log.w("TAG_Soccer",
+                                    "UMP: Privacy options form error: " + formError.getMessage());
+                        } else {
+                            Log.d(
+                                    "TAG_Soccer",
+                                    getClass().getSimpleName() + ".showAdsConsentForm: form dismissed"
+                            );
+                        }
+                    }
+            );
+        } else {
+            Log.d(
+                    "TAG_Soccer",
+                    getClass().getSimpleName() + ".showAdsConsentForm: privacy options not required, resetting"
+            );
+            consentInformation.reset();
+            requestConsent(activity);
+        }
+    }
+
     private void loadAndShowConsentForm(Activity activity) {
         UserMessagingPlatform.loadConsentForm(
                 activity,


### PR DESCRIPTION
## Summary
- allow users to open the UMP privacy options screen via settings
- fall back to resetting consent if privacy options are not required

## Testing
- `./gradlew test -x lint --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68850b43579883309acc8041a12f5fb9