### PR TITLE
Fix FCM token persistence after provider login

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -27,6 +27,7 @@ import com.google.firebase.auth.FirebaseAuth;
 
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.SetOptions;
 import com.google.firebase.firestore.QuerySnapshot;
 import com.google.firebase.messaging.FirebaseMessaging;
 
@@ -88,12 +89,15 @@ public class MenuActivity extends AppCompatActivity {
                 return;                     // ← exit early
             }
 
-            FirebaseFirestore.getInstance().collection("users").document(uid).update("fcmToken", newToken).addOnSuccessListener(v -> {
-                Log.d("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object() {
-                }.getClass().getEnclosingMethod()).getName() + ": ✅ FCM token saved");
-                prefs.edit().putString(PREF_FCM_TOKEN, newToken).apply();
-            }).addOnFailureListener(e -> Log.e("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object() {
-            }.getClass().getEnclosingMethod()).getName() + ": ❌ Failed to save FCM token", e));
+            FirebaseFirestore.getInstance().collection("users").document(uid)
+                    .set(Map.of("fcmToken", newToken), SetOptions.merge())
+                    .addOnSuccessListener(v -> {
+                        Log.d("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object() {
+                        }.getClass().getEnclosingMethod()).getName() + ": ✅ FCM token saved");
+                        prefs.edit().putString(PREF_FCM_TOKEN, newToken).apply();
+                    })
+                    .addOnFailureListener(e -> Log.e("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object() {
+                    }.getClass().getEnclosingMethod()).getName() + ": ❌ Failed to save FCM token", e));
         });
 
         // ✅ Call permission request

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -25,6 +25,7 @@ import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
 import com.google.firebase.database.ServerValue;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.SetOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.android.ump.ConsentInformation;
 import com.google.android.ump.ConsentRequestParameters;
@@ -129,8 +130,9 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
                     if (saved != null && saved.equals(newToken)) return;
 
                     FirebaseFirestore.getInstance()
-                            .collection("users").document(uid)
-                            .update("fcmToken", newToken)
+                            .collection("users")
+                            .document(uid)
+                            .set(Map.of("fcmToken", newToken), SetOptions.merge())
                             .addOnSuccessListener(v ->
                                     prefs.edit().putString("fcmToken", newToken).apply());
                 });


### PR DESCRIPTION
## Summary
- use SetOptions.merge when persisting FCM token so documents are created if missing
- import SetOptions in SoccerApp and MenuActivity

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68850d5754a48330a26ae97715220014