### PR TITLE
Implement configurable ad frequency

### DIFF
--- a/firebase/functions/seed-ads-frequency/index.js
+++ b/firebase/functions/seed-ads-frequency/index.js
@@ -1,0 +1,13 @@
+const admin = require('firebase-admin');
+admin.initializeApp();
+const db = admin.firestore();
+
+async function main() {
+  await db.collection('settings').doc('adsFreuency').set({
+    value: 10,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp()
+  });
+  console.log('adsFreuency document created.');
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/firebase/functions/seed-ads-frequency/package.json
+++ b/firebase/functions/seed-ads-frequency/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "seed-ads-frequency",
+  "version": "1.0.0",
+  "main": "index.js",
+  "engines": {
+    "node": "18"
+  },
+  "dependencies": {
+    "firebase-admin": "^11.10.1"
+  }
+}

--- a/gcp/cloud-build/seed_ads_frequency.yaml
+++ b/gcp/cloud-build/seed_ads_frequency.yaml
@@ -1,0 +1,85 @@
+substitutions:
+  _ENVIRONMENT: 'dev'
+  _FOLDER_NAME: 'soccer'
+
+steps:
+  # Step 1: Get Firebase project ID
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'get-project-id'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -e
+        echo "🔎 Finding project for ${_FOLDER_NAME}-${_ENVIRONMENT}..."
+        gcloud projects list \
+          --filter="name~^${_FOLDER_NAME}-${_ENVIRONMENT}" \
+          --format="value(projectId)" \
+          | head -n 1 > /workspace/FIREBASE_PROJECT_ID.txt
+
+        if [ ! -s /workspace/FIREBASE_PROJECT_ID.txt ]; then
+          echo "❌ Project ID not found!"
+          exit 1
+        fi
+
+  # Step 2: Install Firebase CLI
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'install-firebase-cli'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -e
+        echo "⬇️ Installing Firebase CLI..."
+        curl -sL https://firebase.tools | bash
+        mkdir -p /workspace/firebase
+        cp /usr/local/bin/firebase /workspace/firebase/
+        chmod +x /workspace/firebase/firebase
+        echo "✅ Firebase CLI installed."
+
+  # Step 3: Clone source code
+  - name: 'gcr.io/cloud-builders/git'
+    id: 'pull-files'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -ex
+        echo "📦 Cloning from the development branch..."
+        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+
+        echo "📁 Preparing files for seeding ads frequency..."
+        cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json
+        cp /workspace/soccer/firebase/firestore.rules /workspace/firebase/firestore.rules
+        mkdir -p /workspace/firebase/functions/seed-ads-frequency
+        cp /workspace/soccer/firebase/functions/seed-ads-frequency/package.json /workspace/firebase/functions/seed-ads-frequency/
+        cp /workspace/soccer/firebase/functions/seed-ads-frequency/index.js /workspace/firebase/functions/seed-ads-frequency/
+
+  # Step 4: Install dependencies
+  - name: 'node:18-slim'
+    id: 'install-deps-seed-ads-frequency'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -ex
+        cd /workspace/firebase/functions/seed-ads-frequency
+        npm install
+        echo "📦 Dependencies installed."
+
+  # Step 5: Execute the seeding script
+  - name: 'node:18-slim'
+    id: 'run-seeding'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -e
+        cd /workspace/firebase/functions/seed-ads-frequency
+        project_id=$(cat /workspace/FIREBASE_PROJECT_ID.txt)
+        export GOOGLE_CLOUD_PROJECT="$project_id"
+        node index.js
+        echo "✅ adsFreuency document created."
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -57,6 +57,10 @@ public class MenuActivity extends AppCompatActivity {
     private static final String AD_UNIT_ID = "ca-app-pub-3940256099942544/1033173712"; // test ID
     private InterstitialAd mInterstitialAd;
 
+    private static final String PREF_AD_COUNTER = "adsCounter";
+    private static final String PREF_AD_FREQUENCY = "adsFrequency";
+    private static final int DEFAULT_AD_FREQUENCY = 10;
+
     private static final int NOTIFICATION_PERMISSION_REQUEST_CODE = 101;
 
     private static final String PREF_FCM_TOKEN = "fcmToken";
@@ -123,6 +127,22 @@ public class MenuActivity extends AppCompatActivity {
             NotificationManager manager = getSystemService(NotificationManager.class);
             manager.createNotificationChannel(channel);
         }
+
+        FirebaseFirestore.getInstance()
+                .collection("settings")
+                .document("adsFreuency")
+                .get()
+                .addOnSuccessListener(doc -> {
+                    Long freq = doc.getLong("value");
+                    if (freq != null) {
+                        prefs.edit().putInt(PREF_AD_FREQUENCY, freq.intValue()).apply();
+                        Log.d("TAG_Soccer", getClass().getSimpleName() + ".runHousekeeping: ads frequency=" + freq);
+                    }
+                })
+                .addOnFailureListener(e ->
+                        Log.e("TAG_Soccer",
+                            getClass().getSimpleName() + ".runHousekeeping: failed to load ads frequency",
+                            e));
 
     }
 
@@ -322,6 +342,16 @@ public class MenuActivity extends AppCompatActivity {
     }
 
     private void showAdThenRun(Runnable action) {
+        SharedPreferences prefs = getSharedPreferences(getPackageName() + "_preferences", MODE_PRIVATE);
+        int frequency = prefs.getInt(PREF_AD_FREQUENCY, DEFAULT_AD_FREQUENCY);
+        int counter = prefs.getInt(PREF_AD_COUNTER, 0) + 1;
+        if (counter < frequency) {
+            prefs.edit().putInt(PREF_AD_COUNTER, counter).apply();
+            action.run();
+            return;
+        }
+        prefs.edit().putInt(PREF_AD_COUNTER, 0).apply();
+
         Log.d(
                 "TAG_Soccer",
                 getClass().getSimpleName() + ".showAdThenRun: Ad ready=" + (mInterstitialAd != null)


### PR DESCRIPTION
## Summary
- add new Node script to seed `settings/adsFreuency`
- provide Cloud Build YAML for the script
- fetch `adsFreuency` on app start and store in prefs
- show ads only every N-th time depending on value stored in Firestore

## Testing
- `pip install Flask google-cloud-secret-manager google-cloud-logging`
- `python3 -m pytest -q gcp/cloud-functions/tests/test_service_check.py` *(fails: CloudLoggingHandler message but tests pass)*
- `./gradlew test` *(fails: missing Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_688537a099bc833084e2d8a6092d66af