### PR TITLE
Add consent status logs

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -425,6 +425,13 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
                                 "TAG_Soccer",
                                 getClass().getSimpleName() + ".showAdsConsentForm: form dismissed"
                         );
+                        Log.d(
+                                "TAG_Soccer",
+                                getClass().getSimpleName() +
+                                        ".showAdsConsentForm: consent status=" +
+                                        UserMessagingPlatform.getConsentInformation(activity)
+                                                .getConsentStatus()
+                        );
                     }
                 }
         );
@@ -447,6 +454,13 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
                                         Log.w("TAG_Soccer", "UMP: Consent form error: " + formError.getMessage());
                                     } else {
                                         Log.d("TAG_Soccer", getClass().getSimpleName() + ".loadAndShowConsentForm: form dismissed");
+                                        Log.d(
+                                                "TAG_Soccer",
+                                                getClass().getSimpleName() +
+                                                        ".loadAndShowConsentForm: consent status=" +
+                                                        UserMessagingPlatform.getConsentInformation(activity)
+                                                                .getConsentStatus()
+                                        );
                                     }
                                 });
                     } else {


### PR DESCRIPTION
## Summary
- show the user's consent status when the consent form is dismissed
- log consent status when the full consent dialog is closed

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*
- `pytest gcp/cloud-functions/tests/test_service_check.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688538324a70833096f2b335d8024301