### PR TITLE
Fix read permission for app settings

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -134,6 +134,14 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    // App configuration settings (e.g. ads frequency)
+    match /settings/{docId} {
+      // Only allow reads from authenticated users
+      allow read: if request.auth != null;
+      // No client-side writes permitted
+      allow write: if false;
+    }
+
     // 4. Everything else denied
     match /{document=**} {
       allow read, write: if false;


### PR DESCRIPTION
## Summary
- allow authenticated users to read the `/settings` collection so the app can fetch `adsFreuency`

## Testing
- `npm test` *(fails: Missing script)*
- `./gradlew test` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68853f0bb5788330a16e2fac84b58158