### PR TITLE
Update ads consent checkbox

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
@@ -108,8 +108,9 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     }
 
     private void updateAdsConsentCheckbox(CheckBoxPreference preference) {
-        ConsentInformation ci = UserMessagingPlatform.getConsentInformation(requireContext());
-        boolean hasConsent = ci.getConsentStatus() == ConsentInformation.ConsentStatus.OBTAINED;
-        preference.setChecked(hasConsent);
+        ConsentInformation ci =
+                UserMessagingPlatform.getConsentInformation(requireContext());
+        boolean canRequestAds = ci.canRequestAds();
+        preference.setChecked(canRequestAds);
     }
 }


### PR DESCRIPTION
## Summary
- use `canRequestAds()` to decide the ads consent checkbox state

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68853fba7a948330860e58d69c69c3cb