### PR TITLE
Fix nickname closure

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
@@ -55,26 +55,27 @@ public class FirebaseAuthManager {
                                 if (email != null) data.put("email", email);
                                 data.put("method", providerId);
 
+                                String finalNickname = nickname;
                                 if (existingNick == null || existingNick.isEmpty()) {
-                                    if (nickname != null && !nickname.isEmpty()) {
-                                        data.put("nickname", nickname);
-                                        existingNick = nickname;
+                                    if (finalNickname != null && !finalNickname.isEmpty()) {
+                                        data.put("nickname", finalNickname);
+                                        existingNick = finalNickname;
                                     }
                                 } else {
-                                    nickname = existingNick;
+                                    finalNickname = existingNick;
                                 }
 
                                 if (doc.exists()) {
                                     db.collection("users").document(uid).set(data, SetOptions.merge())
                                             .addOnCompleteListener(task -> {
-                                                storeUserData(uid, email != null ? email : "", nickname != null ? nickname : "", providerId);
+                                                storeUserData(uid, email != null ? email : "", finalNickname != null ? finalNickname : "", providerId);
                                                 ((SoccerApp) context.getApplicationContext()).syncFcmTokenIfNeeded();
                                                 callback.onLoginSuccess();
                                             });
                                 } else {
                                     db.collection("users").document(uid).set(data)
                                             .addOnCompleteListener(task -> {
-                                                storeUserData(uid, email != null ? email : "", nickname != null ? nickname : "", providerId);
+                                                storeUserData(uid, email != null ? email : "", finalNickname != null ? finalNickname : "", providerId);
                                                 ((SoccerApp) context.getApplicationContext()).syncFcmTokenIfNeeded();
                                                 callback.onLoginSuccess();
                                             });


### PR DESCRIPTION
## Summary
- fix nickname variable mutability inside `FirebaseAuthManager.loginWithProvider`

## Testing
- `python -m unittest discover -s gcp/cloud-functions/tests`

------
https://chatgpt.com/codex/tasks/task_e_688540f076e08330a7e9e8da904c7fd2