### PR TITLE
Fix nickname variable handling

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
@@ -55,15 +55,18 @@ public class FirebaseAuthManager {
                                 if (email != null) data.put("email", email);
                                 data.put("method", providerId);
 
-                                String finalNickname = nickname;
+                                String nicknameToStore;
                                 if (existingNick == null || existingNick.isEmpty()) {
-                                    if (finalNickname != null && !finalNickname.isEmpty()) {
-                                        data.put("nickname", finalNickname);
-                                        existingNick = finalNickname;
+                                    if (nickname != null && !nickname.isEmpty()) {
+                                        data.put("nickname", nickname);
+                                        nicknameToStore = nickname;
+                                    } else {
+                                        nicknameToStore = null;
                                     }
                                 } else {
-                                    finalNickname = existingNick;
+                                    nicknameToStore = existingNick;
                                 }
+                                final String finalNickname = nicknameToStore;
 
                                 if (doc.exists()) {
                                     db.collection("users").document(uid).set(data, SetOptions.merge())


### PR DESCRIPTION
## Summary
- fix `FirebaseAuthManager` nickname variable so lambdas compile

## Testing
- `npm test` *(fails: Missing script)*
- `./mobile/gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68854285d7788330b6ccf4be022ea0bb