### PR TITLE
Fix back navigation handling on nickname screen

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/PickNicknameActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/PickNicknameActivity.java
@@ -10,6 +10,7 @@ import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.activity.OnBackPressedCallback;
 
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.firestore.FirebaseFirestore;
@@ -57,6 +58,12 @@ public class PickNicknameActivity extends AppCompatActivity {
         });
 
         btnConfirm.setOnClickListener(v -> saveNickname());
+
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override public void handleOnBackPressed() {
+                // Disable back button to enforce nickname entry
+            }
+        });
     }
 
     private void saveNickname() {
@@ -120,10 +127,6 @@ public class PickNicknameActivity extends AppCompatActivity {
                 });
     }
 
-    @Override
-    public void onBackPressed() {
-        // Disable back button to enforce nickname entry
-    }
 
     private static final InputFilter NO_LEADING_SPACE = (source, start, end, dest, dstart, dend) -> {
         if (dstart == 0 && start < end && Character.isWhitespace(source.charAt(start))) {


### PR DESCRIPTION
## Summary
- switch to `OnBackPressedCallback` in `PickNicknameActivity` to avoid deprecation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885442ae2708330826a3fd5ef3c04ec