### PR TITLE
Add explicit logging for ad consent choices

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
@@ -112,5 +112,15 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                 UserMessagingPlatform.getConsentInformation(requireContext());
         boolean canRequestAds = ci.canRequestAds();
         preference.setChecked(canRequestAds);
+        String choice =
+                ci.getConsentStatus() == ConsentInformation.ConsentStatus.OBTAINED
+                        ? "personalized ads"
+                        : "non-personalized ads (NPA)";
+        Log.d(
+                "TAG_Soccer",
+                getClass().getSimpleName()
+                        + ".updateAdsConsentCheckbox: user choice="
+                        + choice
+        );
     }
 }

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -425,12 +425,22 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
                                 "TAG_Soccer",
                                 getClass().getSimpleName() + ".showAdsConsentForm: form dismissed"
                         );
+                        ConsentInformation ci =
+                                UserMessagingPlatform.getConsentInformation(activity);
+                        int status = ci.getConsentStatus();
                         Log.d(
                                 "TAG_Soccer",
                                 getClass().getSimpleName() +
-                                        ".showAdsConsentForm: consent status=" +
-                                        UserMessagingPlatform.getConsentInformation(activity)
-                                                .getConsentStatus()
+                                        ".showAdsConsentForm: consent status=" + status
+                        );
+                        String choice =
+                                status == ConsentInformation.ConsentStatus.OBTAINED
+                                        ? "personalized ads"
+                                        : "non-personalized ads (NPA)";
+                        Log.d(
+                                "TAG_Soccer",
+                                getClass().getSimpleName() +
+                                        ".showAdsConsentForm: user selected " + choice
                         );
                     }
                 }


### PR DESCRIPTION
## Summary
- log when the ads consent checkbox is clicked
- log the resulting consent status and whether it means personalized ads or non‑personalized ads

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688544de552c83308b97107d3bc368fe