### PR TITLE
Add logs for Firebase nickname

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
@@ -73,6 +73,10 @@ public class FirebaseAuthManager {
                                             .addOnCompleteListener(task -> {
                                                 storeUserData(uid, email != null ? email : "", finalNickname != null ? finalNickname : "", providerId);
                                                 ((SoccerApp) context.getApplicationContext()).syncFcmTokenIfNeeded();
+                                                Log.d("TAG_Soccer", getClass().getSimpleName() + "." +
+                                                        Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
+                                                        ": login success uid=" + uid + ", nickname=" +
+                                                        (finalNickname != null ? finalNickname : "null"));
                                                 callback.onLoginSuccess();
                                             });
                                 } else {
@@ -80,6 +84,10 @@ public class FirebaseAuthManager {
                                             .addOnCompleteListener(task -> {
                                                 storeUserData(uid, email != null ? email : "", finalNickname != null ? finalNickname : "", providerId);
                                                 ((SoccerApp) context.getApplicationContext()).syncFcmTokenIfNeeded();
+                                                Log.d("TAG_Soccer", getClass().getSimpleName() + "." +
+                                                        Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
+                                                        ": login success uid=" + uid + ", nickname=" +
+                                                        (finalNickname != null ? finalNickname : "null"));
                                                 callback.onLoginSuccess();
                                             });
                                 }
@@ -129,11 +137,18 @@ public class FirebaseAuthManager {
                                             storeUserData(uid, email, nickname != null ? nickname : "Unknown", method);
                                             ((SoccerApp) context.getApplicationContext())
                                                     .syncFcmTokenIfNeeded();   // new helper (see below)
+                                            Log.d("TAG_Soccer", getClass().getSimpleName() + "." +
+                                                    Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
+                                                    ": login success uid=" + uid + ", nickname=" +
+                                                    (nickname != null ? nickname : "null"));
                                             callback.onLoginSuccess();
                                         })
                                         .addOnFailureListener(e -> {
                                             Log.e("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() + ": ⚠️ Failed to load nickname from Firestore", e);
                                             storeUserData(uid, email, "Unknown", "email");
+                                            Log.d("TAG_Soccer", getClass().getSimpleName() + "." +
+                                                    Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
+                                                    ": login success uid=" + uid + ", nickname=null");
                                             callback.onLoginSuccess();
                                         });
                             } else {


### PR DESCRIPTION
## Summary
- log user ID and nickname after login succeeds

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688545fc35b083308420fc18e0f57eab