### PR TITLE
Handle offline ads consent form

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -3,6 +3,10 @@ package piotr_gorczynski.soccer2;
 
 import android.app.Application;
 import android.app.Activity;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.widget.Toast;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Log;
@@ -412,6 +416,19 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
                 getClass().getSimpleName() + ".showAdsConsentForm: showing privacy options"
         );
 
+        if (!isNetworkAvailable(activity)) {
+            Toast.makeText(
+                    activity,
+                    R.string.no_internet_for_privacy_options,
+                    Toast.LENGTH_LONG)
+                    .show();
+            Log.d(
+                    "TAG_Soccer",
+                    getClass().getSimpleName() + ".showAdsConsentForm: no network"
+            );
+            return;
+        }
+
         UserMessagingPlatform.showPrivacyOptionsForm(
                 activity,
                 formError -> {
@@ -482,6 +499,17 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
                 },
                 formError -> Log.w("TAG_Soccer", "UMP: Failed to load consent form: " + formError.getMessage())
         );
+    }
+
+    private static boolean isNetworkAvailable(Context context) {
+        ConnectivityManager cm =
+                (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        if (cm == null) return false;
+        Network network = cm.getActiveNetwork();
+        if (network == null) return false;
+        NetworkCapabilities capabilities = cm.getNetworkCapabilities(network);
+        return capabilities != null
+                && capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
     }
 
 

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -111,4 +111,5 @@
     <string name="login_method_label">Login method: %1$s</string>
     <string name="ads_consent_required">Showing ads is helping to finance infrastructure maintenance. Because you have not agreed to show ads, this option is not available. You can check your consent in settings.</string>
     <string name="confirm">Confirm</string>
+    <string name="no_internet_for_privacy_options">Internet connection required to open privacy options.</string>
 </resources>


### PR DESCRIPTION
## Summary
- prevent `showAdsConsentForm` from running when there's no connectivity
- add a user-facing string for the offline case

## Testing
- `./mobile/gradlew -p mobile assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68854aad1f1483308ab46a3a67bcff8a