### PR TITLE
Add Facebook community link in settings

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
@@ -2,6 +2,8 @@ package piotr_gorczynski.soccer2;
 
 import android.os.Bundle;
 import android.util.Log;
+import android.content.Intent;
+import android.net.Uri;
 import androidx.preference.CheckBoxPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
@@ -52,6 +54,18 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                 app.showAdsConsentForm(requireActivity());
                 // keep current value until consent form result is reflected
                 return false;
+            });
+        }
+
+        Preference fbPref = findPreference("facebook_community");
+        if (fbPref != null) {
+            fbPref.setOnPreferenceClickListener(pref -> {
+                Intent intent = new Intent(
+                        Intent.ACTION_VIEW,
+                        Uri.parse("https://www.facebook.com/profile.php?id=61578949554301")
+                );
+                startActivity(intent);
+                return true;
             });
         }
     }

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -109,6 +109,8 @@
     <string name="login_facebook">Login with Facebook</string>
     <string name="login_microsoft">Login with Microsoft</string>
     <string name="login_method_label">Login method: %1$s</string>
+    <string name="pref_title_facebook">Facebook community</string>
+    <string name="pref_summary_facebook">Open our community page on Facebook</string>
     <string name="ads_consent_required">Showing ads is helping to finance infrastructure maintenance. Because you have not agreed to show ads, this option is not available. You can check your consent in settings.</string>
     <string name="confirm">Confirm</string>
     <string name="no_internet_for_privacy_options">Internet connection required to open privacy options.</string>

--- a/mobile/app/src/main/res/xml/pref_android_level.xml
+++ b/mobile/app/src/main/res/xml/pref_android_level.xml
@@ -23,4 +23,10 @@
             android:defaultValue="false"
             android:icon="@android:drawable/ic_dialog_info" />
 
+        <Preference
+            android:key="facebook_community"
+            android:title="@string/pref_title_facebook"
+            android:summary="@string/pref_summary_facebook"
+            android:icon="@drawable/ic_facebook" />
+
 </PreferenceScreen>


### PR DESCRIPTION
## Summary
- add strings for a Facebook link
- expose a Facebook link in the Settings screen

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68868f5d2dd88330ae48c1d886c13ab8