### PR TITLE
Store user ad consent flag

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/ConsentUtils.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/ConsentUtils.java
@@ -1,0 +1,23 @@
+package piotr_gorczynski.soccer2;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+public class ConsentUtils {
+
+    /**
+     * Determine if the user allowed personalised ads based on the
+     * Transparency & Consent Framework string stored by UMP.
+     */
+    public static boolean isPersonalisedAllowed(Context ctx) {
+        SharedPreferences sp = ctx.getSharedPreferences(
+                "com.google.android.ump.pref", Context.MODE_PRIVATE);
+        String purposes = sp.getString("IABTCF_PurposeConsents", "");
+        // purposes are 1-based, so purpose 4 is index 3
+        return purposes.length() >= 4 && purposes.charAt(3) == '1';
+    }
+
+    private ConsentUtils() {
+        // no instances
+    }
+}

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -50,6 +50,7 @@ import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback;
 import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.ump.ConsentInformation;
 import com.google.android.ump.UserMessagingPlatform;
+import androidx.preference.PreferenceManager;
 
 
 
@@ -350,13 +351,10 @@ public class MenuActivity extends AppCompatActivity {
 
     }
     private void loadInterstitialAd() {
-        ConsentInformation consentInformation =
-                UserMessagingPlatform.getConsentInformation(this);
-
         AdRequest.Builder builder = new AdRequest.Builder();
 
-        if (consentInformation.getConsentStatus()
-                != ConsentInformation.ConsentStatus.OBTAINED) {
+        if (!PreferenceManager.getDefaultSharedPreferences(this)
+                .getBoolean("personalised_ads", true)) {
             Bundle extras = new Bundle();
             extras.putString("npa", "1");
             builder.addNetworkExtrasBundle(AdMobAdapter.class, extras);

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
@@ -6,8 +6,7 @@ import androidx.preference.CheckBoxPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 
-import com.google.android.ump.ConsentInformation;
-import com.google.android.ump.UserMessagingPlatform;
+import androidx.preference.PreferenceManager;
 
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.firestore.FirebaseFirestore;
@@ -108,19 +107,17 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     }
 
     private void updateAdsConsentCheckbox(CheckBoxPreference preference) {
-        ConsentInformation ci =
-                UserMessagingPlatform.getConsentInformation(requireContext());
-        boolean canRequestAds = ci.canRequestAds();
-        preference.setChecked(canRequestAds);
-        String choice =
-                ci.getConsentStatus() == ConsentInformation.ConsentStatus.OBTAINED
-                        ? "personalized ads"
-                        : "non-personalized ads (NPA)";
+        boolean personalised =
+                PreferenceManager.getDefaultSharedPreferences(requireContext())
+                        .getBoolean("personalised_ads", false);
+
+        preference.setChecked(personalised);
+
         Log.d(
                 "TAG_Soccer",
                 getClass().getSimpleName()
-                        + ".updateAdsConsentCheckbox: user choice="
-                        + choice
+                        + ".updateAdsConsentCheckbox: user chose "
+                        + (personalised ? "PERSONALISED" : "NPA")
         );
     }
 }

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -36,6 +36,7 @@ import com.google.android.ump.ConsentRequestParameters;
 import com.google.android.ump.UserMessagingPlatform;
 import com.google.android.ump.ConsentForm;
 import com.google.android.ump.FormError;
+import androidx.preference.PreferenceManager;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -452,26 +453,19 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
                                         + status
                         );
 
-                        String choice;
-                        switch (ci.getConsentType()) {
-                            case ConsentInformation.ConsentType.PERSONALIZED:
-                                choice = "personalized ads";
-                                break;
-                            case ConsentInformation.ConsentType.NON_PERSONALIZED:
-                                choice = "non-personalized ads (NPA)";
-                                break;
-                            case ConsentInformation.ConsentType.AD_FREE:
-                                choice = "ad-free";
-                                break;
-                            default:
-                                choice = "unknown";
-                                break;
-                        }
+                        String choice =
+                                status == ConsentInformation.ConsentStatus.OBTAINED
+                                        ? "personalized ads"
+                                        : "non-personalized ads (NPA)";
                         Log.d(
                                 "TAG_Soccer",
                                 getClass().getSimpleName() +
                                         ".showAdsConsentForm: user selected " + choice
                         );
+
+                        boolean personalised = ConsentUtils.isPersonalisedAllowed(activity);
+                        PreferenceManager.getDefaultSharedPreferences(activity)
+                                .edit().putBoolean("personalised_ads", personalised).apply();
                     }
                 }
         );
@@ -501,6 +495,9 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
                                                         UserMessagingPlatform.getConsentInformation(activity)
                                                                 .getConsentStatus()
                                         );
+                                        boolean personalised = ConsentUtils.isPersonalisedAllowed(activity);
+                                        PreferenceManager.getDefaultSharedPreferences(activity)
+                                                .edit().putBoolean("personalised_ads", personalised).apply();
                                     }
                                 });
                     } else {


### PR DESCRIPTION
## Summary
- add `ConsentUtils` helper
- persist personalised ad choice when consent forms close
- read stored value in Settings screen
- build ad requests based on `personalised_ads` preference

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688683f7cb90833082295ed7dc459773