### PR TITLE
Update ads consent preference

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
@@ -7,7 +7,7 @@ import android.net.Uri;
 import androidx.preference.CheckBoxPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
-
+import android.content.SharedPreferences;
 import androidx.preference.PreferenceManager;
 
 import com.google.firebase.auth.FirebaseAuth;
@@ -18,6 +18,8 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     
     private FirebaseFirestore db;
     private FirebaseAuth auth;
+    private SharedPreferences prefs;
+    private SharedPreferences.OnSharedPreferenceChangeListener consentChangeListener;
     
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
@@ -25,6 +27,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         
         db = FirebaseFirestore.getInstance();
         auth = FirebaseAuth.getInstance();
+        prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         
         // Setup block invite friend preference
         CheckBoxPreference blockInvitePreference = findPreference("block_invite_friend");
@@ -54,6 +57,13 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                 // keep current value until consent form result is reflected
                 return false;
             });
+
+            consentChangeListener = (sharedPreferences, key) -> {
+                if ("personalised_ads".equals(key)) {
+                    updateAdsConsentCheckbox(adsConsentPref);
+                }
+            };
+            prefs.registerOnSharedPreferenceChangeListener(consentChangeListener);
         }
 
         Preference fbPref = findPreference("facebook_community");
@@ -117,6 +127,14 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         CheckBoxPreference adsConsentPref = findPreference("ads_consent");
         if (adsConsentPref != null) {
             updateAdsConsentCheckbox(adsConsentPref);
+        }
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if (prefs != null && consentChangeListener != null) {
+            prefs.unregisterOnSharedPreferenceChangeListener(consentChangeListener);
         }
     }
 

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="pref_title_level">Android level</string>
     <string name="pref_title_block_invite_friend">Block \'Invite a Friend\' requests</string>
     <string name="pref_summary_block_invite_friend">Other players cannot invite you via \'Invite a Friend\' (tournaments not affected)</string>
-    <string name="pref_title_ads_consent">Consent for showing ads</string>
+    <string name="pref_title_ads_consent">Consent for showing personalized ads</string>
     <string name="pref_summary_ads_consent">Review or change your consent for displaying ads</string>
     <string-array name="pref_level_titles">
         <item>Easy</item>


### PR DESCRIPTION
## Summary
- rename the ads consent title
- reflect user choice by updating checkbox via preference change listener

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68878b6306048330a52583a68078a5a5