### PR TITLE
Use ConsentUtils for ad settings in MenuActivity

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -50,7 +50,6 @@ import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback;
 import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.ump.ConsentInformation;
 import com.google.android.ump.UserMessagingPlatform;
-import androidx.preference.PreferenceManager;
 
 
 
@@ -353,8 +352,7 @@ public class MenuActivity extends AppCompatActivity {
     private void loadInterstitialAd() {
         AdRequest.Builder builder = new AdRequest.Builder();
 
-        if (!PreferenceManager.getDefaultSharedPreferences(this)
-                .getBoolean("personalised_ads", true)) {
+        if (!ConsentUtils.isPersonalisedAllowed(this)) {
             Bundle extras = new Bundle();
             extras.putString("npa", "1");
             builder.addNetworkExtrasBundle(AdMobAdapter.class, extras);


### PR DESCRIPTION
## Summary
- replace preference check with `ConsentUtils.isPersonalisedAllowed`
- remove unused `PreferenceManager` import

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688790596c9c8330aee626872f43c415