### PR TITLE
Fix addFriend duplicate check and update button width

### DIFF
--- a/firebase/functions/add-friend/index.js
+++ b/firebase/functions/add-friend/index.js
@@ -28,7 +28,15 @@ exports.addFriend = functions
       .collection('users').doc(uid)
       .collection('friends').doc(friendId);
 
-    await ref.set({ addedAt: admin.firestore.FieldValue.serverTimestamp() }, { merge: true });
+    const existing = await ref.get();
+    if (existing.exists) {
+      throw new functions.https.HttpsError('already-exists', 'Friend already added');
+    }
+
+    await ref.set(
+      { addedAt: admin.firestore.FieldValue.serverTimestamp() },
+      { merge: true }
+    );
 
     return { friendId };
   });

--- a/mobile/app/src/main/res/layout/activity_friends_list.xml
+++ b/mobile/app/src/main/res/layout/activity_friends_list.xml
@@ -9,7 +9,7 @@
 
     <Button
         android:id="@+id/addFriendBtn"
-        android:layout_width="wrap_content"
+        android:layout_width="200dp"
         android:layout_height="50dp"
         android:background="@color/colorGreen"
         android:textColor="@color/colorWhite"


### PR DESCRIPTION
## Summary
- widen Add Friend button to 200dp
- guard against adding the same friend twice

## Testing
- `python3 -m unittest discover gcp/cloud-functions/tests`

------
https://chatgpt.com/codex/tasks/task_e_6887a2558e2c8330855110c14db0f11c