### PR TITLE
Add search to AddFriendActivity

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/AddFriendActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/AddFriendActivity.java
@@ -1,12 +1,19 @@
 package piotr_gorczynski.soccer2;
 
 import android.os.Bundle;
-import android.widget.*;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.util.Log;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.firestore.*;
@@ -19,8 +26,14 @@ import java.util.Objects;
 public class AddFriendActivity extends AppCompatActivity {
 
     EditText nicknameInput;
-    Button addFriendButton;
+    Button searchButton;
+    Button loadMoreButton;
+    RecyclerView resultsList;
     TextView resultText;
+
+    private UserSearchAdapter adapter;
+    private DocumentSnapshot lastVisible;
+    private String currentQuery;
 
     FirebaseFirestore db;
     FirebaseAuth auth;
@@ -31,47 +44,78 @@ public class AddFriendActivity extends AppCompatActivity {
         setContentView(R.layout.activity_add_friend);
 
         nicknameInput = findViewById(R.id.nicknameInput);
-        addFriendButton = findViewById(R.id.addFriendButton);
+        searchButton = findViewById(R.id.searchButton);
+        loadMoreButton = findViewById(R.id.loadMoreButton);
+        resultsList = findViewById(R.id.searchResults);
         resultText = findViewById(R.id.addFriendResult);
+
+        resultsList.setLayoutManager(new LinearLayoutManager(this));
+        adapter = new UserSearchAdapter(this::searchAndAdd);
+        resultsList.setAdapter(adapter);
+
+        searchButton.setEnabled(false);
+        nicknameInput.addTextChangedListener(new TextWatcher() {
+            @Override public void beforeTextChanged(CharSequence s, int st, int c, int a) {}
+            @Override public void onTextChanged(CharSequence s, int st, int b, int c) {
+                searchButton.setEnabled(s.length() > 1);
+            }
+            @Override public void afterTextChanged(Editable s) {}
+        });
+
+        searchButton.setOnClickListener(v -> {
+            String query = nicknameInput.getText().toString().trim();
+            if (query.length() <= 1) return;
+            adapter.clear();
+            lastVisible = null;
+            currentQuery = query;
+            searchPage();
+        });
+
+        loadMoreButton.setOnClickListener(v -> searchPage());
 
         db = FirebaseFirestore.getInstance();
         auth = FirebaseAuth.getInstance();
-
-        addFriendButton.setOnClickListener(v -> {
-            String nickname = nicknameInput.getText().toString().trim();
-            if (nickname.isEmpty()) {
-                resultText.setText(R.string.please_enter_a_nickname);
-                return;
-            }
-            searchAndAdd(nickname);
-        });
     }
 
-    private void searchAndAdd(String nickname) {
-        db.collection("users")
-                .whereEqualTo("nickname", nickname)
-                .get()
-                .addOnSuccessListener(querySnapshot -> {
-                    if (querySnapshot.isEmpty()) {
+    private void searchPage() {
+        Query q = db.collection("users")
+                .orderBy("nickname")
+                .startAt(currentQuery)
+                .endAt(currentQuery + "\uf8ff")
+                .limit(10);
+        if (lastVisible != null) q = q.startAfter(lastVisible);
+
+        q.get()
+                .addOnSuccessListener(snap -> {
+                    java.util.List<DocumentSnapshot> docs = snap.getDocuments();
+                    adapter.addResults(docs);
+
+                    if (docs.size() == 10) {
+                        lastVisible = docs.get(docs.size() - 1);
+                        loadMoreButton.setVisibility(View.VISIBLE);
+                    } else {
+                        loadMoreButton.setVisibility(View.GONE);
+                    }
+
+                    if (adapter.getItemCount() == 0) {
                         resultText.setText(R.string.user_not_found);
-                        return;
+                    } else {
+                        resultText.setText("");
                     }
-
-                    String currentUserId = Objects.requireNonNull(auth.getCurrentUser()).getUid();
-                    DocumentSnapshot userDoc = querySnapshot.getDocuments().get(0);
-                    String targetUid = userDoc.getId();
-
-                    if (targetUid.equals(currentUserId)) {
-                        resultText.setText(R.string.you_can_t_invite_yourself);
-                        return;
-                    }
-                    sendAddFriendViaCF(currentUserId, targetUid);
                 })
                 .addOnFailureListener(e -> {
                     resultText.setText(R.string.error_searching_user);
-                    Log.e("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName()
-                            + ": User lookup failed", e);
+                    Log.e("TAG_Soccer", getClass().getSimpleName() + ".searchPage: User lookup failed", e);
                 });
+    }
+
+    private void searchAndAdd(String uid) {
+        String currentUserId = Objects.requireNonNull(auth.getCurrentUser()).getUid();
+        if (uid.equals(currentUserId)) {
+            resultText.setText(R.string.you_can_t_invite_yourself);
+            return;
+        }
+        sendAddFriendViaCF(currentUserId, uid);
     }
 
     private void sendAddFriendViaCF(@NonNull String userId, @NonNull String friendId) {

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/UserSearchAdapter.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/UserSearchAdapter.java
@@ -1,0 +1,78 @@
+package piotr_gorczynski.soccer2;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.firebase.firestore.DocumentSnapshot;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class UserSearchAdapter extends RecyclerView.Adapter<UserSearchAdapter.VH> {
+    interface OnAddClick { void onAdd(String uid); }
+
+    static class VH extends RecyclerView.ViewHolder {
+        final TextView nickname;
+        final Button addBtn;
+        String uid;
+        VH(@NonNull View v) {
+            super(v);
+            nickname = v.findViewById(R.id.nickname);
+            addBtn = v.findViewById(R.id.addBtn);
+        }
+    }
+
+    private final List<DocumentSnapshot> data = new ArrayList<>();
+    private final OnAddClick listener;
+
+    UserSearchAdapter(OnAddClick listener) {
+        this.listener = listener;
+        setHasStableIds(true);
+    }
+
+    @NonNull
+    @Override
+    public VH onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View v = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.item_user_search, parent, false);
+        VH h = new VH(v);
+        h.addBtn.setOnClickListener(btn -> {
+            if (h.uid != null) listener.onAdd(h.uid);
+        });
+        return h;
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull VH h, int position) {
+        DocumentSnapshot d = data.get(position);
+        h.uid = d.getId();
+        String nick = d.getString("nickname");
+        if (nick == null) nick = h.uid.substring(0, 6);
+        h.nickname.setText(nick);
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return data.get(position).getId().hashCode() & 0xffffffffL;
+    }
+
+    @Override
+    public int getItemCount() { return data.size(); }
+
+    void addResults(List<DocumentSnapshot> docs) {
+        int start = data.size();
+        data.addAll(docs);
+        notifyItemRangeInserted(start, docs.size());
+    }
+
+    void clear() {
+        data.clear();
+        notifyDataSetChanged();
+    }
+}

--- a/mobile/app/src/main/res/layout/activity_add_friend.xml
+++ b/mobile/app/src/main/res/layout/activity_add_friend.xml
@@ -8,29 +8,47 @@
     android:orientation="vertical">
 
     <TextView
-        android:text="@string/enter_nickname_to_add"
+        android:text="@string/enter_nickname_to_search"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"/>
 
-    <EditText
-        android:id="@+id/nicknameInput"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/friend_s_nickname"
-        android:autofillHints="Enter friend's nickname"
-        android:inputType="textPersonName"
-        android:layout_marginTop="10dp"/>
+        android:orientation="horizontal"
+        android:layout_marginTop="10dp">
+
+        <EditText
+            android:id="@+id/nicknameInput"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="@string/friend_s_nickname"
+            android:autofillHints="Enter friend's nickname"
+            android:inputType="textPersonName"/>
+
+        <Button
+            android:id="@+id/searchButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/search"
+            android:enabled="false"/>
+    </LinearLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/searchResults"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:layout_marginTop="20dp"/>
 
     <Button
-        android:id="@+id/addFriendButton"
+        android:id="@+id/loadMoreButton"
         android:layout_width="wrap_content"
-        android:background="@color/colorGreen"
-        android:textColor="@color/colorWhite"
-        android:textStyle="bold"
-        android:layout_height="50dp"
-        android:textAllCaps="false"
-        android:text="@string/add_friend"
-        android:layout_marginTop="20dp"/>
+        android:layout_height="wrap_content"
+        android:text="@string/load_more"
+        android:visibility="gone"
+        android:layout_marginTop="8dp"/>
 
     <TextView
         android:id="@+id/addFriendResult"

--- a/mobile/app/src/main/res/layout/item_user_search.xml
+++ b/mobile/app/src/main/res/layout/item_user_search.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/nickname"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:textStyle="bold" />
+
+    <Button
+        android:id="@+id/addBtn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/add_friend_label" />
+</LinearLayout>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -43,7 +43,7 @@
     <string name="nickname">Nickname</string>
     <string name="settings">Settings</string>
     <string name="enter_nickname_to_invite">Enter nickname to invite:</string>
-    <string name="enter_nickname_to_add">Enter nickname to add:</string>
+    <string name="enter_nickname_to_search">Enter nickname to search:</string>
     <string name="friend_s_nickname">Friend\'s nickname</string>
     <string name="send_invitation">Send Invitation</string>
     <string name="invite_a_friend">Invite a Friend</string>
@@ -56,6 +56,9 @@
     <string name="error_searching_user">Error searching user.</string>
     <string name="invitation_sent">Invitation sent!</string>
     <string name="failed_to_send_invite">Failed to send invite.</string>
+    <string name="search">Search</string>
+    <string name="load_more">Load more</string>
+    <string name="add_friend_label">Add</string>
     <string name="invite_blocked">%1$s blocked invites.</string>
     <string name="invites_blocked_notification">Other players cannot invite you via \'Invite a Friend\' function</string>
     <string name="pending_game_invitations">Pending Game Invitations</string>


### PR DESCRIPTION
## Summary
- support searching users to add instead of single nick
- display results and load more with pagination
- add UserSearchAdapter and layout
- update strings and activity layout

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887a7c495ec8330942de344b72d246e