### PR TITLE
Make google services config env specific

### DIFF
--- a/gcp/cloud-build/download_google_services.yaml
+++ b/gcp/cloud-build/download_google_services.yaml
@@ -3,7 +3,7 @@ substitutions:
   _FOLDER_NAME: 'soccer'
   _PRIVATE_REPO: 'git@github.com:piotr-gorczynski/Soccer-private.git'
   _BRANCH_NAME: 'main'
-  _TARGET_PATH: 'google-services.json'  # Save in root folder of private repo
+  _TARGET_PATH: 'google-services.${_ENVIRONMENT}.json'  # Save env-specific config
 
 availableSecrets:
   secretManager:

--- a/mobile/app/build.gradle
+++ b/mobile/app/build.gradle
@@ -95,13 +95,14 @@ import java.nio.file.StandardCopyOption
 // Register custom copy task
 tasks.register("copyGoogleServicesJson") {
     doLast {
-        def source = file("../../secrets/google-services.json")
+        def env = project.findProperty("env") ?: "dev"
+        def source = file("../../secrets/google-services.${env}.json")
         def destination = file("google-services.json")
         if (source.exists()) {
             Files.copy(source.toPath(), destination.toPath(), StandardCopyOption.REPLACE_EXISTING)
-            println("✅ google-services.json copied to app/")
+            println("✅ google-services.json for ${env} copied to app/")
         } else {
-            throw new GradleException("❌ google-services.json not found in secrets/")
+            throw new GradleException("❌ google-services.json for env '${env}' not found in secrets/")
         }
     }
 }


### PR DESCRIPTION
## Summary
- rename downloaded google services config to include environment name
- update Gradle task to copy env-specific google-services files

## Testing
- `python -m pytest gcp/cloud-functions/tests/test_service_check.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687e9b0035748330b5af69620e841763