### PR TITLE
Improve add friend error handling

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/AddFriendActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/AddFriendActivity.java
@@ -130,12 +130,17 @@ public class AddFriendActivity extends AppCompatActivity {
                     resultText.setText(R.string.add_friend);
                 })
                 .addOnFailureListener(e -> {
-                    resultText.setText(R.string.failed_to_send_invite);
+                    String text = getString(R.string.failed_to_add_friend);
                     if (e instanceof FirebaseFunctionsException ffe) {
-                        Log.e("TAG_Soccer", "addFriend failed: " + ffe.getMessage(), ffe);
+                        String reason = ffe.getMessage();
+                        Log.e("TAG_Soccer", "addFriend failed: " + reason, ffe);
+                        if (reason != null && !reason.isEmpty()) {
+                            text = getString(R.string.failed_to_add_friend_reason, reason);
+                        }
                     } else {
                         Log.e("TAG_Soccer", "addFriend failed", e);
                     }
+                    resultText.setText(text);
                 });
     }
 }

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -56,6 +56,8 @@
     <string name="error_searching_user">Error searching user.</string>
     <string name="invitation_sent">Invitation sent!</string>
     <string name="failed_to_send_invite">Failed to send invite.</string>
+    <string name="failed_to_add_friend">Failed to add friend.</string>
+    <string name="failed_to_add_friend_reason">Failed to add friend: %1$s</string>
     <string name="search">Search</string>
     <string name="load_more">Load more</string>
     <string name="add_friend_label">Add</string>


### PR DESCRIPTION
## Summary
- display message returned by cloud function when adding a friend fails
- add new string resources for friend-add failure

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887ad1edf908330805c43d57be23bde