### PR TITLE
Implement case-insensitive friend search

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/AddFriendActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/AddFriendActivity.java
@@ -67,7 +67,7 @@ public class AddFriendActivity extends AppCompatActivity {
             if (query.length() <= 1) return;
             adapter.clear();
             lastVisible = null;
-            currentQuery = query;
+            currentQuery = query.toLowerCase();
             searchPage();
         });
 
@@ -79,7 +79,7 @@ public class AddFriendActivity extends AppCompatActivity {
 
     private void searchPage() {
         Query q = db.collection("users")
-                .orderBy("nickname")
+                .orderBy("nicknameLowercase")
                 .startAt(currentQuery)
                 .endAt(currentQuery + "\uf8ff")
                 .limit(10);

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
@@ -59,6 +59,7 @@ public class FirebaseAuthManager {
                                 if (existingNick == null || existingNick.isEmpty()) {
                                     if (nickname != null && !nickname.isEmpty()) {
                                         data.put("nickname", nickname);
+                                        data.put("nicknameLowercase", nickname.toLowerCase());
                                         nicknameToStore = nickname;
                                     } else {
                                         nicknameToStore = null;
@@ -195,6 +196,7 @@ public class FirebaseAuthManager {
 
                         Map<String, Object> userData = new HashMap<>();
                         userData.put("nickname", nickname);
+                        userData.put("nicknameLowercase", nickname.toLowerCase());
                         userData.put("email", email); // optional
                         userData.put("online", true); // optional
 

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/PickNicknameActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/PickNicknameActivity.java
@@ -86,7 +86,7 @@ public class PickNicknameActivity extends AppCompatActivity {
         btnConfirm.setEnabled(false);
         FirebaseFirestore db = FirebaseFirestore.getInstance();
         db.collection("users")
-                .whereEqualTo("nickname", nickname)
+                .whereEqualTo("nicknameLowercase", nickname.toLowerCase())
                 .get()
                 .addOnCompleteListener(this, task -> {
                     if (!task.isSuccessful()) {
@@ -106,6 +106,7 @@ public class PickNicknameActivity extends AppCompatActivity {
 
                     Map<String, Object> data = new HashMap<>();
                     data.put("nickname", nickname);
+                    data.put("nicknameLowercase", nickname.toLowerCase());
                     db.collection("users").document(uid)
                             .set(data, SetOptions.merge())
                             .addOnSuccessListener(v -> {

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegisterAccountActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegisterAccountActivity.java
@@ -101,7 +101,7 @@ public class RegisterAccountActivity extends AppCompatActivity {
         btnRegister.setEnabled(false);               // optional: disable while checking
 
         db.collection("users")
-                .whereEqualTo("nickname", nickname)
+                .whereEqualTo("nicknameLowercase", nickname.toLowerCase())
                 .get()
                 .addOnCompleteListener(this, task -> {
                     btnRegister.setEnabled(true);  // re-enable either way


### PR DESCRIPTION
## Summary
- make search query lower-case and use `nicknameLowercase` field
- store `nicknameLowercase` when registering or picking nicknames

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887b1883dd08330b17361b40f7a18b1