### PR TITLE
Fix case-insensitive search in AddFriendActivity

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/AddFriendActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/AddFriendActivity.java
@@ -87,10 +87,12 @@ public class AddFriendActivity extends AppCompatActivity {
 
         Query q;
         if (fallbackMode) {
+            String normalized = originalQuery.substring(0, 1).toUpperCase() +
+                    originalQuery.substring(1).toLowerCase();
             q = db.collection("users")
                     .orderBy("nickname")
-                    .startAt(originalQuery)
-                    .endAt(originalQuery + "\uf8ff")
+                    .startAt(normalized)
+                    .endAt(normalized + "\uf8ff")
                     .limit(10);
         } else {
             q = db.collection("users")


### PR DESCRIPTION
## Summary
- ensure AddFriendActivity searches regardless of letter casing

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887b97e3470833085be07cb04da86f3