### PR TITLE
Hide Facebook and Microsoft login options

### DIFF
--- a/mobile/app/src/main/res/layout/activity_universal_login.xml
+++ b/mobile/app/src/main/res/layout/activity_universal_login.xml
@@ -43,7 +43,8 @@
         android:drawablePadding="8dp"
         android:text="@string/login_facebook"
         android:textAllCaps="false"
-        android:textColor="@color/colorWhite" />
+        android:textColor="@color/colorWhite"
+        android:visibility="gone" />
 
     <Button
         android:id="@+id/btnUniversalMicrosoft"
@@ -56,6 +57,7 @@
         android:drawablePadding="8dp"
         android:text="@string/login_microsoft"
         android:textAllCaps="false"
-        android:textColor="@color/colorWhite" />
+        android:textColor="@color/colorWhite"
+        android:visibility="gone" />
 </LinearLayout>
 


### PR DESCRIPTION
## Summary
- hide Facebook and Microsoft buttons on universal login screen

## Testing
- `./gradlew test --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887df576b1883308b8695986b4e2488