### PR TITLE
Use env variable for clone branch

### DIFF
--- a/gcp/cloud-build/deploy_cancel_invite.yaml
+++ b/gcp/cloud-build/deploy_cancel_invite.yaml
@@ -45,8 +45,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Copying Firestore config & cancel-invite function..."
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json


### PR DESCRIPTION
## Summary
- update deploy_cancel_invite cloud build file to clone using `_ENVIRONMENT` variable rather than hardcoding `development`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6887e33948f88330a83ebdc9b3325a30