### PR TITLE
Use env var for Cloud Build clone branch

### DIFF
--- a/gcp/cloud-build/deploy-force-start-stuck-matches.yaml
+++ b/gcp/cloud-build/deploy-force-start-stuck-matches.yaml
@@ -45,8 +45,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Copying Firestore config & force-start-stuck-matches function..."
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json

--- a/gcp/cloud-build/deploy_accept_invite.yaml
+++ b/gcp/cloud-build/deploy_accept_invite.yaml
@@ -45,8 +45,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Copying Firestore config & accept-invite function..."
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json

--- a/gcp/cloud-build/deploy_add_friend.yaml
+++ b/gcp/cloud-build/deploy_add_friend.yaml
@@ -45,8 +45,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Copying Firestore config & add-friend function..."
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json

--- a/gcp/cloud-build/deploy_change_player_turn.yaml
+++ b/gcp/cloud-build/deploy_change_player_turn.yaml
@@ -48,8 +48,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Copying Firestore config & change-player-turn function..."
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json

--- a/gcp/cloud-build/deploy_clock_timeout.yaml
+++ b/gcp/cloud-build/deploy_clock_timeout.yaml
@@ -45,8 +45,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Copying Firestore config & clock-timeout function..."
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json

--- a/gcp/cloud-build/deploy_create_invite.yaml
+++ b/gcp/cloud-build/deploy_create_invite.yaml
@@ -45,8 +45,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Copying Firestore config & create-invite function..."
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json

--- a/gcp/cloud-build/deploy_delete_unverified_users.yaml
+++ b/gcp/cloud-build/deploy_delete_unverified_users.yaml
@@ -45,8 +45,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Copying Firestore config & function to workspace..."
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json

--- a/gcp/cloud-build/deploy_end_tournament.yaml
+++ b/gcp/cloud-build/deploy_end_tournament.yaml
@@ -45,8 +45,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Copying Firestore config & end-tournament function..."
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json

--- a/gcp/cloud-build/deploy_expire_invite.yaml
+++ b/gcp/cloud-build/deploy_expire_invite.yaml
@@ -45,8 +45,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Copying Firestore config & expire-invite function..."
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json

--- a/gcp/cloud-build/deploy_expire_presence.yaml
+++ b/gcp/cloud-build/deploy_expire_presence.yaml
@@ -45,8 +45,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Copying Firestore config & expire-presence function..."
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json

--- a/gcp/cloud-build/deploy_expire_stale_invites.yaml
+++ b/gcp/cloud-build/deploy_expire_stale_invites.yaml
@@ -45,8 +45,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Copying Firestore config & expire-stale-invites function..."
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json

--- a/gcp/cloud-build/deploy_expire_stale_matches.yaml
+++ b/gcp/cloud-build/deploy_expire_stale_matches.yaml
@@ -45,8 +45,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Copying Firestore config & expire-stale-matches function..."
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json

--- a/gcp/cloud-build/deploy_firestore_indexes.yaml
+++ b/gcp/cloud-build/deploy_firestore_indexes.yaml
@@ -45,8 +45,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Copying Firestore config"
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json

--- a/gcp/cloud-build/deploy_firestore_rules.yaml
+++ b/gcp/cloud-build/deploy_firestore_rules.yaml
@@ -44,8 +44,8 @@ steps:
       - '-c'
       - |
         set -e
-        echo "🔁 Cloning development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "🔁 Cloning ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📂 Copying Firestore rules and firebase.json..."
         mkdir -p /workspace/firebase

--- a/gcp/cloud-build/deploy_join_tournament.yaml
+++ b/gcp/cloud-build/deploy_join_tournament.yaml
@@ -45,8 +45,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Copying Firestore config & join-tournament function..."
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json

--- a/gcp/cloud-build/deploy_leave_tournament.yaml
+++ b/gcp/cloud-build/deploy_leave_tournament.yaml
@@ -45,8 +45,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Copying Firestore config & leave-tournament function..."
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json

--- a/gcp/cloud-build/deploy_realtime_db_locked.yaml
+++ b/gcp/cloud-build/deploy_realtime_db_locked.yaml
@@ -96,7 +96,7 @@ steps:
     - '-c'
     - |
       set -ex
-      git clone -b development --single-branch \
+      git clone -b ${_ENVIRONMENT} --single-branch \
         https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
       cp /workspace/soccer/gcp/cloud-build/firebase.json    /workspace/firebase.json
       cp /workspace/soccer/gcp/cloud-build/database.rules.json /workspace/database.rules.json

--- a/gcp/cloud-build/deploy_remove_friend.yaml
+++ b/gcp/cloud-build/deploy_remove_friend.yaml
@@ -45,8 +45,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Copying Firestore config & remove-friend function..."
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json

--- a/gcp/cloud-build/deploy_send_invite_notification.yaml
+++ b/gcp/cloud-build/deploy_send_invite_notification.yaml
@@ -62,8 +62,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Copying Firestore config & send-invite-notification function..."
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json

--- a/gcp/cloud-build/deploy_start_tournament.yaml
+++ b/gcp/cloud-build/deploy_start_tournament.yaml
@@ -45,8 +45,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Copying Firestore config & start-tournament function..."
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json

--- a/gcp/cloud-build/seed_ads_frequency.yaml
+++ b/gcp/cloud-build/seed_ads_frequency.yaml
@@ -45,8 +45,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Preparing files for seeding ads frequency..."
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json

--- a/gcp/cloud-build/seed_regulations.yaml
+++ b/gcp/cloud-build/seed_regulations.yaml
@@ -45,8 +45,8 @@ steps:
       - '-c'
       - |
         set -ex
-        echo "📦 Cloning from the development branch..."
-        git clone -b development --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
 
         echo "📁 Preparing files for seeding regulations..."
         cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json


### PR DESCRIPTION
## Summary
- update Cloud Build YAMLs to use `_ENVIRONMENT` for git clone branch

## Testing
- `npm test` *(fails: Missing script)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887eb6638448330882cf6768408d655