### PR TITLE
Update triggers to override branch

### DIFF
--- a/gcp/cloud-build/cloudbuild.yaml
+++ b/gcp/cloud-build/cloudbuild.yaml
@@ -34,6 +34,7 @@ steps:
           echo "Starting trigger: $(cat /workspace/trigger_name.txt) with ID: $(cat /workspace/trigger_id.txt)..."
           gcloud beta builds triggers run $(cat /workspace/trigger_id.txt) \
             --project=org-service-account-001 \
+            --branch=${_ENVIRONMENT} \
             --substitutions=_ENVIRONMENT=${_ENVIRONMENT} \
             --format="value(metadata.build.id)" > /workspace/build_id.txt
 


### PR DESCRIPTION
## Summary
- update cloudbuild pipeline to run each trigger on the branch named after the `_ENVIRONMENT` substitution

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6887f1241764833099ef39b26e035b46