### PR TITLE
Increase Cloud Build timeout

### DIFF
--- a/gcp/cloud-build/cloudbuild.yaml
+++ b/gcp/cloud-build/cloudbuild.yaml
@@ -67,7 +67,7 @@ steps:
           done
         done < /workspace/sorted_triggers.txt
 
-timeout: '3600s' # Timeout for the entire build
+timeout: '7200s' # Timeout for the entire build doubled to allow longer pipelines
 options:
   logging: CLOUD_LOGGING_ONLY
   substitutionOption: ALLOW_LOOSE


### PR DESCRIPTION
## Summary
- extend `cloudbuild.yaml` timeout to 7200s

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_688a0e0da7888330a913bdf2b70f2a05