### PR TITLE
Fix commit step in download config

### DIFF
--- a/gcp/cloud-build/download_google_services.yaml
+++ b/gcp/cloud-build/download_google_services.yaml
@@ -105,8 +105,12 @@ steps:
         ssh-keyscan github.com >> /root/.ssh/known_hosts
 
         git add ${_TARGET_PATH}
-        git commit -m "🔄 Update google-services.json from Firebase [CI]"
-        git push origin ${_BRANCH_NAME}
+        if git diff-index --quiet HEAD -- ${_TARGET_PATH}; then
+          echo "No changes to commit"
+        else
+          git commit -m "🔄 Update google-services.json from Firebase [CI]"
+          git push origin ${_BRANCH_NAME}
+        fi
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## Summary
- skip commit errors in download Google services script when nothing changed

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a1fb16b308330a21cb67b158c1968