### PR TITLE
Handle existing Firestore indexes gracefully

### DIFF
--- a/gcp/cloud-build/deploy_firestore_indexes.yaml
+++ b/gcp/cloud-build/deploy_firestore_indexes.yaml
@@ -65,12 +65,25 @@ steps:
         project_id=$(cat /workspace/FIREBASE_PROJECT_ID.txt)
 
         echo "⬆️  Deploying Firestore indexes..."
-        ./firebase deploy \
+        set +e
+        deploy_output=$(./firebase deploy \
           --only firestore:indexes \
           --project="$project_id" \
-          --force
+          --force 2>&1)
+        deploy_status=$?
+        set -e
 
-        echo "✅ Firestore indexes deployed."
+        if [ $deploy_status -ne 0 ]; then
+          if echo "$deploy_output" | grep -q "index already exists"; then
+            echo "ℹ️ Firestore indexes already exist."
+          else
+            echo "$deploy_output"
+            exit $deploy_status
+          fi
+        else
+          echo "$deploy_output"
+          echo "✅ Firestore indexes deployed."
+        fi
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## Summary
- ensure deploy_firestore_indexes.yaml does not fail if indexes already exist

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a67846b6c833089540ae7898fd5f3