### PR TITLE
Add product flavors for AdMob IDs

### DIFF
--- a/mobile/app/build.gradle
+++ b/mobile/app/build.gradle
@@ -25,6 +25,22 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    flavorDimensions "environment"
+    productFlavors {
+        dev {
+            dimension "environment"
+            buildConfigField "String", "AD_UNIT_ID", '"ca-app-pub-3940256099942544/1033173712"'
+        }
+        qa {
+            dimension "environment"
+            buildConfigField "String", "AD_UNIT_ID", '"ca-app-pub-3940256099942544/1033173712"'
+        }
+        prod {
+            dimension "environment"
+            buildConfigField "String", "AD_UNIT_ID", '"ca-app-pub-9113152787055223~3266191463"'
+        }
+    }
     packagingOptions {
         resources {
             excludes += ['META-INF/*.version']

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -54,7 +54,6 @@ import com.google.android.ump.UserMessagingPlatform;
 
 
 public class MenuActivity extends AppCompatActivity {
-    private static final String AD_UNIT_ID = "ca-app-pub-3940256099942544/1033173712"; // test ID
     private InterstitialAd mInterstitialAd;
 
     private static final String PREF_AD_COUNTER = "adsCounter";
@@ -360,7 +359,7 @@ public class MenuActivity extends AppCompatActivity {
 
         AdRequest adRequest = builder.build();
 
-        InterstitialAd.load(this, AD_UNIT_ID, adRequest,
+        InterstitialAd.load(this, BuildConfig.AD_UNIT_ID, adRequest,
                 new InterstitialAdLoadCallback() {
                     @Override
                     public void onAdLoaded(@NonNull InterstitialAd interstitialAd) {


### PR DESCRIPTION
## Summary
- add dev/qa/prod flavors with `AD_UNIT_ID`
- load ads using `BuildConfig.AD_UNIT_ID`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a7c02f8308330ab000e9fa5c1564c