### PR TITLE
Log selected AdMob unit

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -359,6 +359,11 @@ public class MenuActivity extends AppCompatActivity {
 
         AdRequest adRequest = builder.build();
 
+        Log.d(
+                "TAG_Soccer",
+                getClass().getSimpleName() + ".loadInterstitialAd: AD_UNIT_ID=" + BuildConfig.AD_UNIT_ID
+        );
+
         InterstitialAd.load(this, BuildConfig.AD_UNIT_ID, adRequest,
                 new InterstitialAdLoadCallback() {
                     @Override


### PR DESCRIPTION
## Summary
- log the AdMob AD_UNIT_ID when loading interstitial ads

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a87547eb88330b36c01959538ffda