### PR TITLE
Add env selection to create-tournament tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@ This is very simple game which originates from so called paper soccer
 
 ## Creating tournaments
 
-A helper script is available in `tools/create-tournament.js` for quickly adding tournaments to Firestore. **Run it from the project root** so the relative path is resolved correctly:
+A helper script is available in `tools/create-tournament/create-tournament.js` for quickly adding tournaments to Firestore. **Run it from the project root** so the relative path is resolved correctly:
 
 ```bash
-node tools/create-tournament.js "Summer Cup" 16 "2024-06-01T12:00:00Z" "2024-07-01T12:00:00Z" "regDocId"
+node tools/create-tournament/create-tournament.js dev "Summer Cup" 16 "2024-06-01T12:00:00Z" "2024-07-01T12:00:00Z" "regDocId"
 ```
 
-If you change into the `tools` directory first, drop the folder prefix:
+If you change into the `tools/create-tournament` directory first, drop the folder prefix:
 
 ```bash
-node create-tournament.js "Summer Cup" 16 "2024-06-01T12:00:00Z" "2024-07-01T12:00:00Z" "regDocId"
+node create-tournament.js dev "Summer Cup" 16 "2024-06-01T12:00:00Z" "2024-07-01T12:00:00Z" "regDocId"
 ```
 
 The script also accepts a path to a JSON file containing the fields `name`, `maxParticipants`, `registrationDeadline`, `matchesDeadline` and `regulation`:
 
 ```bash
-node tools/create-tournament.js params.json
+node tools/create-tournament/create-tournament.js dev params.json
 ```

--- a/tools/create-tournament/create-tournament.js
+++ b/tools/create-tournament/create-tournament.js
@@ -1,25 +1,33 @@
-// tools/create-tournament.js
+// tools/create-tournament/create-tournament.js
 const fs   = require('fs');
 const path = require('path');
 const admin = require('firebase-admin');
 
 // ────────────────────────────────────────────────────────────────
-// 1. Load service-account credentials from the secrets folder
-//    (../secrets relative to this script’s directory)
-const serviceAccount = require(path.join(__dirname, '..', 'secrets', 'serviceAccountKey.json'));
-
-// 2. Initialise Firebase Admin with that key
-admin.initializeApp({
-  credential: admin.credential.cert(serviceAccount)
-});
-
-const db = admin.firestore();
+// Service account loading happens after reading the desired environment
+// from the command line. The key files are stored two directories up
+// under `secrets/serviceAccountKey.{env}.json`.
 // ────────────────────────────────────────────────────────────────
 
 // (rest of your original code stays unchanged)
 
 async function main () {
   const args = process.argv.slice(2);
+
+  const env = args.shift();
+  if (!['dev', 'test', 'prod'].includes(env)) {
+    console.error('First argument must specify the environment: dev, test or prod');
+    process.exit(1);
+  }
+
+  const serviceAccountPath = path.join(__dirname, '..', '..', 'secrets', `serviceAccountKey.${env}.json`);
+  const serviceAccount     = require(serviceAccountPath);
+
+  admin.initializeApp({
+    credential: admin.credential.cert(serviceAccount)
+  });
+  const db = admin.firestore();
+
   let params = {};
 
   if (args.length === 1 && args[0].endsWith('.json')) {
@@ -33,8 +41,9 @@ async function main () {
       regulation: args[4]
     };
   } else {
-    console.error('Usage: node create-tournament.js name maxParticipants registrationDeadline matchesDeadline regulation');
-    console.error('   or: node create-tournament.js params.json');
+    console.error('Usage: node create-tournament.js <env> name maxParticipants registrationDeadline matchesDeadline regulation');
+    console.error('   or: node create-tournament.js <env> params.json');
+    console.error('Where <env> is one of: dev, test, prod');
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary
- allow choosing environment for create-tournament
- adjust service account lookup to read serviceAccountKey.{env}.json from secrets
- update README instructions for new path and environment parameter

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_688b61cc761883308e5be23298b676af