### PR TITLE
Read project ID from google-services.json

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/BackendServiceChecker.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/BackendServiceChecker.java
@@ -46,6 +46,9 @@ public class BackendServiceChecker {
     
     private final OkHttpClient httpClient;
     private final Context context;
+    // Project ID configured by the application. This is kept in memory only and
+    // is no longer persisted in SharedPreferences.
+    private String projectId;
     
     public interface ServiceCheckCallback {
         void onServiceAvailable();
@@ -189,13 +192,18 @@ public class BackendServiceChecker {
      * Tries multiple patterns based on the GCP project naming conventions
      */
     private String getProjectId() {
+        if (projectId != null && !projectId.isEmpty()) {
+            return projectId;
+        }
+
         SharedPreferences prefs = context.getSharedPreferences(
                 context.getPackageName() + "_preferences", Context.MODE_PRIVATE);
-        
-        String projectId = prefs.getString("backend_project_id", null);
-        if (projectId != null && !projectId.isEmpty()) {
-            Log.d(TAG, "Using configured project ID: " + projectId);
-            return projectId;
+
+        String storedId = prefs.getString("backend_project_id", null);
+        if (storedId != null && !storedId.isEmpty()) {
+            Log.d(TAG, "Using stored project ID: " + storedId);
+            projectId = storedId;
+            return storedId;
         }
         
         try {
@@ -204,6 +212,7 @@ public class BackendServiceChecker {
                 String firebaseProjectId = app.getOptions().getProjectId();
                 if (firebaseProjectId != null && !firebaseProjectId.isEmpty()) {
                     Log.d(TAG, "Using Firebase project ID: " + firebaseProjectId);
+                    projectId = firebaseProjectId;
                     return firebaseProjectId;
                 }
             }
@@ -260,9 +269,7 @@ public class BackendServiceChecker {
      * Set the project ID for service checks
      */
     public void setProjectId(String projectId) {
-        SharedPreferences prefs = context.getSharedPreferences(
-                context.getPackageName() + "_preferences", Context.MODE_PRIVATE);
-        prefs.edit().putString("backend_project_id", projectId).apply();
+        this.projectId = projectId;
         Log.d(TAG, "Project ID updated: " + projectId);
     }
     

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -358,7 +358,6 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
      */
     private void configureDefaultProjectId() {
         SharedPreferences prefs = getSharedPreferences(getPackageName() + "_preferences", MODE_PRIVATE);
-        String storedProjectId = prefs.getString("backend_project_id", null);
 
         // Always attempt to read the project ID from google-services.json
         String firebaseProjectId = null;
@@ -369,24 +368,23 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
             }
         } catch (IllegalStateException e) {
             Log.w("TAG_Soccer", "FirebaseApp not initialized", e);
+            prefs.edit().remove("backend_project_id").apply();
+            return;
         }
 
         if (firebaseProjectId == null || firebaseProjectId.isEmpty()) {
-            firebaseProjectId = "soccer-dev-1744877837";
+            Log.w("TAG_Soccer", "Project ID missing in google-services.json");
+            prefs.edit().remove("backend_project_id").apply();
+            return;
         }
 
-        if (storedProjectId == null || !storedProjectId.equals(firebaseProjectId)) {
-            serviceChecker.setProjectId(firebaseProjectId);
-            Log.d(
-                    "TAG_Soccer",
-                    getClass().getSimpleName() + ".configureDefaultProjectId: Set project ID to " + firebaseProjectId
-            );
-        } else {
-            Log.d(
-                    "TAG_Soccer",
-                    getClass().getSimpleName() + ".configureDefaultProjectId: Using stored project ID: " + storedProjectId
-            );
-        }
+        serviceChecker.setProjectId(firebaseProjectId);
+        // Clean up any stored value from older versions
+        prefs.edit().remove("backend_project_id").apply();
+        Log.d(
+                "TAG_Soccer",
+                getClass().getSimpleName() + ".configureDefaultProjectId: Set project ID to " + firebaseProjectId
+        );
     }
     
     /**


### PR DESCRIPTION
## Summary
- avoid storing backend project ID in preferences
- read Firebase project ID and remove stored copy when initializing

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b650962348330b72606728e509429