### PR TITLE
Improve credential cleanup and nickname sync

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -68,6 +68,30 @@ public class MenuActivity extends AppCompatActivity {
     private BackendServiceChecker serviceChecker;
     private Menu optionsMenu; // Hold reference to menu for updating warning icon
 
+    /** Helper to fetch nickname from Firestore and update prefs/UI */
+    private void fetchNicknameFromFirestore(@NonNull String uid,
+                                            @NonNull SharedPreferences prefs,
+                                            @NonNull Runnable onMissing) {
+        FirebaseFirestore.getInstance().collection("users").document(uid)
+                .get()
+                .addOnSuccessListener(doc -> {
+                    String remoteNick = doc.getString("nickname");
+                    if (remoteNick != null && !remoteNick.isEmpty()) {
+                        String local = prefs.getString("nickname", null);
+                        if (local == null || !local.equals(remoteNick)) {
+                            prefs.edit().putString("nickname", remoteNick).apply();
+                            TextView nicknameLabel = findViewById(R.id.nicknameLabel);
+                            nicknameLabel.setText(getString(R.string.hello_nickname, remoteNick));
+                        }
+                        updateUiForAuthState();
+                        checkAndUpdateBlockedInviteWarning();
+                    } else {
+                        onMissing.run();
+                    }
+                })
+                .addOnFailureListener(e -> onMissing.run());
+    }
+
     /* ───────────── misc tasks that must always run on launch ───────────── */
     private void runHousekeeping() {
         String uid = FirebaseAuth.getInstance().getUid();
@@ -85,38 +109,8 @@ public class MenuActivity extends AppCompatActivity {
             return;
         }
 
-        // 🔄 Sync nickname from Firestore if it differs from local prefs
-        String localNick = prefs.getString("nickname", null);
-        FirebaseFirestore.getInstance().collection("users").document(uid)
-                .get()
-                .addOnSuccessListener(doc -> {
-                    if (doc.exists()) {
-                        String remoteNick = doc.getString("nickname");
-                        if (remoteNick != null && !remoteNick.equals(localNick)) {
-                            prefs.edit().putString("nickname", remoteNick).apply();
-                            Log.d(
-                                    "TAG_Soccer",
-                                    getClass().getSimpleName() + "." +
-                                            Objects.requireNonNull(new Object() {
-                                            }.getClass().getEnclosingMethod()).getName() +
-                                            ": 🔄 Nickname updated from Firestore to " + remoteNick);
-                            runOnUiThread(() -> {
-                                TextView nicknameLabel = findViewById(R.id.nicknameLabel);
-                                nicknameLabel.setText(getString(R.string.hello_nickname, remoteNick));
-                            });
-                        }
-                    }
-                })
-                .addOnFailureListener(
-                        e ->
-                                Log.e(
-                                        "TAG_Soccer",
-                                        getClass().getSimpleName()
-                                                + "."
-                                                + Objects.requireNonNull(new Object() {
-                                                }.getClass().getEnclosingMethod()).getName()
-                                                + ": ❌ Failed to fetch nickname from Firestore",
-                                        e));
+        // 🔄 Sync nickname from Firestore
+        fetchNicknameFromFirestore(uid, prefs, () -> {});
 
         FirebaseMessaging.getInstance().getToken().addOnCompleteListener(task -> {
             if (!task.isSuccessful()) {
@@ -204,31 +198,26 @@ public class MenuActivity extends AppCompatActivity {
         
         SharedPreferences prefs = getSharedPreferences(getPackageName() + "_preferences", MODE_PRIVATE);
         String nickname = prefs.getString("nickname", null);
-        if (FirebaseAuth.getInstance().getCurrentUser() == null) {
+        FirebaseAuth auth = FirebaseAuth.getInstance();
+        if (auth.getCurrentUser() == null) {
+            String lastUid = prefs.getString("uid", null);
+            if (lastUid != null) {
+                ((SoccerApp) getApplication()).forceUserOffline(lastUid);
+            }
             prefs.edit().clear().apply();
+            FirebaseFirestore.getInstance().clearPersistence();
             nickname = null;
-        } else if (nickname == null || nickname.isEmpty()) {
-            String uid = FirebaseAuth.getInstance().getUid();
+        } else {
+            String uid = auth.getUid();
             if (uid != null) {
-                FirebaseFirestore.getInstance().collection("users").document(uid)
-                        .get()
-                        .addOnSuccessListener(doc -> {
-                            String remoteNick = doc.getString("nickname");
-                            if (remoteNick != null && !remoteNick.isEmpty()) {
-                                prefs.edit().putString("nickname", remoteNick).apply();
-                                TextView nicknameLabel = findViewById(R.id.nicknameLabel);
-                                nicknameLabel.setText(getString(R.string.hello_nickname, remoteNick));
-                                updateUiForAuthState();
-                                checkAndUpdateBlockedInviteWarning();
-                            } else {
-                                startActivity(new Intent(this, PickNicknameActivity.class));
-                            }
-                        })
-                        .addOnFailureListener(e -> startActivity(new Intent(this, PickNicknameActivity.class)));
-                return;
-            } else {
-                startActivity(new Intent(this, PickNicknameActivity.class));
-                return;
+                Runnable pickNick = () -> startActivity(new Intent(this, PickNicknameActivity.class));
+                if (nickname == null || nickname.isEmpty()) {
+                    fetchNicknameFromFirestore(uid, prefs, pickNick);
+                    return;
+                } else {
+                    // Refresh nickname in the background to keep prefs in sync
+                    fetchNicknameFromFirestore(uid, prefs, () -> {});
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- add helper to sync nickname from Firestore
- call helper from housekeeping and onResume
- when no Firebase user, mark last user offline, clear prefs and persistence
- refresh nickname when logged in

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*
- `python3 -m unittest discover gcp/cloud-functions/tests`

------
https://chatgpt.com/codex/tasks/task_e_688b73be679c8330a04cdc63f7945be4