### PR TITLE
Disable invite setting when offline or unauthenticated

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
@@ -32,15 +32,24 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         // Setup block invite friend preference
         CheckBoxPreference blockInvitePreference = findPreference("block_invite_friend");
         if (blockInvitePreference != null) {
-            // Load current value from Firestore
-            loadBlockInvitePreference(blockInvitePreference);
+            SoccerApp app = (SoccerApp) requireActivity().getApplication();
+            boolean loggedIn = auth.getCurrentUser() != null;
+            boolean backendAvailable = app.isBackendAvailable();
 
-            // Listen for changes
-            blockInvitePreference.setOnPreferenceChangeListener((preference, newValue) -> {
-                boolean blockInvites = (Boolean) newValue;
-                updateBlockInviteInFirestore(blockInvites);
-                return true;
-            });
+            if (loggedIn && backendAvailable) {
+                // Load current value from Firestore
+                loadBlockInvitePreference(blockInvitePreference);
+
+                // Listen for changes when enabled
+                blockInvitePreference.setOnPreferenceChangeListener((pref, newValue) -> {
+                    boolean blockInvites = (Boolean) newValue;
+                    updateBlockInviteInFirestore(blockInvites);
+                    return true;
+                });
+            } else {
+                // Disable option when user not logged in or backend unavailable
+                blockInvitePreference.setEnabled(false);
+            }
         }
 
         // Setup ad consent preference


### PR DESCRIPTION
## Summary
- only enable *Block Invite Friend* preference when logged in and backend is reachable

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b9ff2ef8483309727429f7149e90c