### PR TITLE
Avoid offline call when no user

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/AccountActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/AccountActivity.java
@@ -47,13 +47,13 @@ public class AccountActivity extends AppCompatActivity {
     private void performLogout() {
         String uid = FirebaseAuth.getInstance().getUid();
 
-        // Sign out immediately so the UI updates even if network operations fail
-        FirebaseAuth.getInstance().signOut();
-
-        // Attempt to mark the user offline in the background; no need to wait
+        // Attempt to mark the user offline before signing out so permissions work
         if (uid != null) {
             ((SoccerApp) getApplication()).forceUserOffline(uid);
         }
+
+        // Sign out immediately so the UI updates even if network operations fail
+        FirebaseAuth.getInstance().signOut();
 
         finishLogoutUi();
     }

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -115,10 +115,6 @@ public class MenuActivity extends AppCompatActivity {
                             }.getClass().getEnclosingMethod()).getName()
                             + ": ⚠️ No logged-in user; clearing stored credentials"
             );
-            String lastUid = prefs.getString("uid", null);
-            if (lastUid != null) {
-                ((SoccerApp) getApplication()).forceUserOffline(lastUid);
-            }
             prefs.edit().clear().apply();
             FirebaseMessaging.getInstance().deleteToken();
             FirebaseFirestore.getInstance().clearPersistence();
@@ -216,10 +212,6 @@ public class MenuActivity extends AppCompatActivity {
         String nickname = prefs.getString("nickname", null);
         FirebaseAuth auth = FirebaseAuth.getInstance();
         if (auth.getCurrentUser() == null) {
-            String lastUid = prefs.getString("uid", null);
-            if (lastUid != null) {
-                ((SoccerApp) getApplication()).forceUserOffline(lastUid);
-            }
             prefs.edit().clear().apply();
 
             FirebaseMessaging.getInstance().deleteToken();


### PR DESCRIPTION
## Summary
- skip offline update when there's no logged-in user
- update logout flow to mark the user offline before signing out

## Testing
- `python -m pip install -r gcp/cloud-functions/service-check/requirements.txt`
- `python -m pytest -q gcp/cloud-functions/tests/test_service_check.py`


------
https://chatgpt.com/codex/tasks/task_e_688ba1b1ffc88330b37af92487a4a4df