### PR TITLE
Delay FCM auto-init until user login

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/AccountActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/AccountActivity.java
@@ -74,6 +74,7 @@ public class AccountActivity extends AppCompatActivity {
                         Log.w("TAG_Soccer", getClass().getSimpleName() + ".finishLogoutUi: \u274C Failed to delete FCM token", t.getException());
                     }
                 });
+        FirebaseMessaging.getInstance().setAutoInitEnabled(false);
 
         Toast.makeText(this, R.string.logged_out, Toast.LENGTH_SHORT).show();
         finish();

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
@@ -73,7 +73,7 @@ public class FirebaseAuthManager {
                                     db.collection("users").document(uid).set(data, SetOptions.merge())
                                             .addOnCompleteListener(task -> {
                                                 storeUserData(uid, email != null ? email : "", finalNickname != null ? finalNickname : "", providerId);
-                                                ((SoccerApp) context.getApplicationContext()).syncFcmTokenIfNeeded();
+                                                ((SoccerApp) context.getApplicationContext()).enableFcmAutoInit();
                                                 Log.d("TAG_Soccer", getClass().getSimpleName() + "." +
                                                         Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
                                                         ": login success uid=" + uid + ", nickname=" +
@@ -84,7 +84,7 @@ public class FirebaseAuthManager {
                                     db.collection("users").document(uid).set(data)
                                             .addOnCompleteListener(task -> {
                                                 storeUserData(uid, email != null ? email : "", finalNickname != null ? finalNickname : "", providerId);
-                                                ((SoccerApp) context.getApplicationContext()).syncFcmTokenIfNeeded();
+                                                ((SoccerApp) context.getApplicationContext()).enableFcmAutoInit();
                                                 Log.d("TAG_Soccer", getClass().getSimpleName() + "." +
                                                         Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
                                                         ": login success uid=" + uid + ", nickname=" +
@@ -137,7 +137,7 @@ public class FirebaseAuthManager {
                                             if (method == null) method = "email";
                                             storeUserData(uid, email, nickname != null ? nickname : "Unknown", method);
                                             ((SoccerApp) context.getApplicationContext())
-                                                    .syncFcmTokenIfNeeded();   // new helper (see below)
+                                                    .enableFcmAutoInit();
                                             Log.d("TAG_Soccer", getClass().getSimpleName() + "." +
                                                     Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
                                                     ": login success uid=" + uid + ", nickname=" +
@@ -176,6 +176,8 @@ public class FirebaseAuthManager {
                     if (task.isSuccessful()) {
                         Log.d("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() + ": User registered: " + Objects.requireNonNull(firebaseAuth.getCurrentUser()).getEmail());
                         Toast.makeText(context, "Registered as: " + firebaseAuth.getCurrentUser().getEmail(), Toast.LENGTH_SHORT).show();
+
+                        ((SoccerApp) context.getApplicationContext()).enableFcmAutoInit();
 
                         // Set display name
                         firebaseAuth.getCurrentUser().updateProfile(

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -117,6 +117,7 @@ public class MenuActivity extends AppCompatActivity {
             );
             prefs.edit().clear().apply();
             FirebaseMessaging.getInstance().deleteToken();
+            FirebaseMessaging.getInstance().setAutoInitEnabled(false);
             FirebaseFirestore.getInstance().clearPersistence();
             return;
         }
@@ -215,6 +216,7 @@ public class MenuActivity extends AppCompatActivity {
             prefs.edit().clear().apply();
 
             FirebaseMessaging.getInstance().deleteToken();
+            FirebaseMessaging.getInstance().setAutoInitEnabled(false);
 
             FirebaseFirestore.getInstance().clearPersistence();
             nickname = null;

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -83,6 +83,9 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
     public void onCreate() {
         super.onCreate();
 
+        // Disable FCM auto-init until a user signs in
+        FirebaseMessaging.getInstance().setAutoInitEnabled(false);
+
         Thread.setDefaultUncaughtExceptionHandler(new ExceptionHandler());
 
 
@@ -110,15 +113,17 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
             auth.addAuthStateListener(a -> {
                 if (a.getCurrentUser() != null) {
                     startPresence(a.getCurrentUser().getUid());
-                    syncFcmTokenIfNeeded();
+                    enableFcmAutoInit();
                 } else {
                     stopPresence();
+                    disableFcmAutoInit();
                 }
             });
 
             // handle “already signed-in” on cold start
             if (auth.getCurrentUser() != null) {
                 startPresence(auth.getCurrentUser().getUid());
+                enableFcmAutoInit();
             }
         });
 
@@ -142,6 +147,15 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
                             .addOnSuccessListener(v ->
                                     prefs.edit().putString("fcmToken", newToken).apply());
                 });
+    }
+
+    public void disableFcmAutoInit() {
+        FirebaseMessaging.getInstance().setAutoInitEnabled(false);
+    }
+
+    public void enableFcmAutoInit() {
+        FirebaseMessaging.getInstance().setAutoInitEnabled(true);
+        syncFcmTokenIfNeeded();
     }
 
     /* ---------------- central place to start presence tracking ---------- */


### PR DESCRIPTION
## Summary
- disable FCM auto initialization on app start
- enable FCM only after user authentication
- disable FCM when logging out

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bac4f98e483309a04d97f4d89a19a