### PR TITLE
Reduce redundant backend checks

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -303,9 +303,7 @@ public class MenuActivity extends AppCompatActivity {
         
         // Get initial backend availability state from the app
         isBackendAvailable = app.isBackendAvailable();
-        
-        // Check backend availability on app launch
-        checkBackendAvailability();
+        // Backend availability check runs in onResume()
 
         runHousekeeping();          // ← always executed, even on cold resume
 

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -176,10 +176,7 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
     @Override public void onStart(@NonNull LifecycleOwner owner) {
         Log.d("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName()
                 + ": APP RETURNS TO FOREGROUND");
-        
-        // Check backend availability when app returns to foreground
-        checkBackendAvailability();
-        
+
         if (userStatusDbRef == null) return;             // ← ADD
         FirebaseDatabase.getInstance().goOnline();
         cancelHeartbeat();


### PR DESCRIPTION
## Summary
- call `checkBackendAvailability()` only from `MenuActivity.onResume`
- remove duplicate calls during startup

## Testing
- `./mobile/gradlew -p mobile test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bad1d64ac8330819b42221d1521f2