### PR TITLE
Fix toolbar title color

### DIFF
--- a/mobile/app/src/main/res/layout/activity_menu.xml
+++ b/mobile/app/src/main/res/layout/activity_menu.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/colorWhite"
@@ -12,7 +13,7 @@
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
         android:title="@string/app_name"
-        android:titleTextColor="@color/colorWhite" />
+        app:titleTextColor="@android:color/white" />
     <LinearLayout
         android:id="@+id/menu_center_container"
         android:layout_width="match_parent"


### PR DESCRIPTION
## Summary
- ensure `activity_menu.xml` toolbar title displays in white

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688badff6998833096c2875e461a616a