### PR TITLE
Handle network failure when loading nickname

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -99,7 +99,17 @@ public class MenuActivity extends AppCompatActivity {
                         onMissing.run();
                     }
                 })
-                .addOnFailureListener(e -> onMissing.run());
+                .addOnFailureListener(e -> {
+                    Log.w(
+                            "TAG_Soccer",
+                            getClass().getSimpleName() + ".fetchNicknameFromFirestore: failed", e
+                    );
+                    Toast.makeText(
+                            this,
+                            R.string.failed_to_load_nickname,
+                            Toast.LENGTH_SHORT
+                    ).show();
+                });
     }
 
     /* ───────────── misc tasks that must always run on launch ───────────── */

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
     <string name="failed_to_send_invite">Failed to send invite.</string>
     <string name="failed_to_add_friend">Failed to add friend.</string>
     <string name="failed_to_add_friend_reason">Failed to add friend: %1$s</string>
+    <string name="failed_to_load_nickname">Failed to load nickname.</string>
     <string name="search">Search</string>
     <string name="load_more">Load more</string>
     <string name="add_friend_label">Add</string>


### PR DESCRIPTION
## Summary
- prevent nickname picker from opening on network failure
- show a short toast when nickname cannot be loaded
- add a string resource for the new message

## Testing
- `./gradlew assemble_devDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bc42530e48330b36404b65eef1a13