### PR TITLE
Improve Firestore error logging

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegisterAccountActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegisterAccountActivity.java
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import android.text.InputFilter;
 import android.text.TextWatcher;
 import android.text.Editable;
+import android.util.Log;
 import com.google.firebase.firestore.FirebaseFirestore;
 
 public class RegisterAccountActivity extends AppCompatActivity {
@@ -106,7 +107,12 @@ public class RegisterAccountActivity extends AppCompatActivity {
                 .addOnCompleteListener(this, task -> {
                     btnRegister.setEnabled(true);  // re-enable either way
                     if (!task.isSuccessful()) {
-                       Toast.makeText(RegisterAccountActivity.this,
+                        Log.e(
+                            "TAG_Soccer",
+                            getClass().getSimpleName() + ".registerUser: Nickname check failed",
+                            task.getException()
+                        );
+                        Toast.makeText(RegisterAccountActivity.this,
                                 "Network error while checking nickname",
                                 Toast.LENGTH_SHORT).show();
                         return;


### PR DESCRIPTION
## Summary
- import `Log` into `RegisterAccountActivity`
- log the underlying Firestore exception when nickname check fails

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bcaf5369483309d0a3f19aae8d571