### PR TITLE
Handle empty ranking state

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RankingActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RankingActivity.java
@@ -3,7 +3,9 @@ package piotr_gorczynski.soccer2;
 import android.os.Build;
 import android.os.Bundle;
 import android.content.Context;
+import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
@@ -24,6 +26,7 @@ public class RankingActivity extends AppCompatActivity {
 
     private final List<RankingEntry> ranking = new ArrayList<>();
     private RankingAdapter adapter;
+    private TextView emptyRanking;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -34,12 +37,14 @@ public class RankingActivity extends AppCompatActivity {
         list.setLayoutManager(new LinearLayoutManager(this));
         adapter = new RankingAdapter(ranking);
         list.setAdapter(adapter);
+        emptyRanking = findViewById(R.id.emptyRanking);
 
         loadRanking();
     }
 
     private void loadRanking() {
         FirebaseFirestore db = FirebaseFirestore.getInstance();
+        emptyRanking.setVisibility(View.GONE);
 
         db.collectionGroup("matches").get().addOnSuccessListener(snap -> {
             Map<String, RankingEntry> scoreMap = new HashMap<>();
@@ -61,6 +66,7 @@ public class RankingActivity extends AppCompatActivity {
             if (uids.isEmpty()) {
                 ranking.clear();
                 adapter.notifyDataSetChanged();
+                emptyRanking.setVisibility(View.VISIBLE);
                 return;
             }
 
@@ -81,6 +87,7 @@ public class RankingActivity extends AppCompatActivity {
                         }
                         assignMedals(ranking);
                         adapter.notifyDataSetChanged();
+                        emptyRanking.setVisibility(View.GONE);
                     });
         });
     }

--- a/mobile/app/src/main/res/layout/activity_ranking.xml
+++ b/mobile/app/src/main/res/layout/activity_ranking.xml
@@ -16,6 +16,15 @@
         android:layout_height="wrap_content"
         android:text="@string/ranking" />
 
+    <TextView
+        android:id="@+id/emptyRanking"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:layout_marginBottom="12dp"
+        android:gravity="center"
+        android:text="@string/no_ranking_yet" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rankingList"
         android:layout_width="match_parent"

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -71,6 +71,7 @@
     <string name="waiting_for_opponent">Waiting for opponent to accept…</string>
     <string name="tournaments">Tournaments</string>
     <string name="ranking">Ranking</string>
+    <string name="no_ranking_yet">No tournaments were completed to show ranking yet.</string>
     <string name="join">Join</string>
     <!-- "%1$d" → first argument (joined), "%2$d" → second (max) -->
     <string name="slots_format">%1$d / %2$d</string>


### PR DESCRIPTION
## Summary
- show placeholder text in Ranking screen when there are no completed tournaments
- add string resource for the empty ranking message

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bd36b6eb88330af6a49c4c2394216