### PR TITLE
Add empty tournaments notice

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentsActivity.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Toast;
+import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
@@ -36,6 +37,7 @@ public class TournamentsActivity extends AppCompatActivity {
         RecyclerView registeringList = findViewById(R.id.registeringList);
         RecyclerView runningList = findViewById(R.id.runningList);
         RecyclerView endedList = findViewById(R.id.endedList);
+        TextView emptyText = findViewById(R.id.emptyTournaments);
 
         registeringList.setLayoutManager(new LinearLayoutManager(this));
         runningList.setLayoutManager(new LinearLayoutManager(this));
@@ -85,6 +87,11 @@ public class TournamentsActivity extends AppCompatActivity {
         findViewById(R.id.endedHeader).setVisibility(
                 endedAdapter.getItemCount() == 0 ? View.GONE : View.VISIBLE);
 
+        boolean anyInitial = registeringAdapter.getItemCount() > 0
+                || runningAdapter.getItemCount() > 0
+                || endedAdapter.getItemCount() > 0;
+        emptyText.setVisibility(anyInitial ? View.GONE : View.VISIBLE);
+
 
         // ── Firestore ────────────────────────────────────────────────
         FirebaseFirestore db = FirebaseFirestore.getInstance();
@@ -130,6 +137,11 @@ public class TournamentsActivity extends AppCompatActivity {
                     runningAdapter.getItemCount() == 0 ? View.GONE : View.VISIBLE);
             findViewById(R.id.endedHeader).setVisibility(
                     endedAdapter.getItemCount() == 0 ? View.GONE : View.VISIBLE);
+
+            boolean any = registeringAdapter.getItemCount() > 0
+                    || runningAdapter.getItemCount() > 0
+                    || endedAdapter.getItemCount() > 0;
+            emptyText.setVisibility(any ? View.GONE : View.VISIBLE);
 
 
         });

--- a/mobile/app/src/main/res/layout/activity_tournaments.xml
+++ b/mobile/app/src/main/res/layout/activity_tournaments.xml
@@ -73,6 +73,14 @@
             android:minHeight="64dp"
             android:layout_marginBottom="16dp"
             android:nestedScrollingEnabled="false" />
+
+        <TextView
+            android:id="@+id/emptyTournaments"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/no_tournaments"
+            android:visibility="gone"
+            android:layout_marginTop="16dp" />
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
 </LinearLayout>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="add_a_friend">Add a Friend</string>
     <string name="add_friend">Friend added successfully</string>
     <string name="no_friends">No friends added so far…</string>
+    <string name="no_tournaments">No tournaments have been created yet.</string>
     <string name="please_enter_a_nickname">Please enter a nickname.</string>
     <string name="user_not_found">User not found.</string>
     <string name="you_can_t_invite_yourself">You can\'t invite yourself.</string>


### PR DESCRIPTION
## Summary
- show a caption when there are no tournaments
- add UI string and TextView for the empty list

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bd3c4875c8330ac30a73ef2b5b48c