### PR TITLE
Show message for empty invite list

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
+import android.view.View;
 import android.widget.*;
 
 import androidx.annotation.NonNull;
@@ -28,6 +29,7 @@ import android.content.SharedPreferences;
 public class InvitationsActivity extends AppCompatActivity {
 
     ListView invitesList;
+    TextView emptyText;
     ArrayAdapter<String> adapter;
     final ArrayList<String> inviteDescriptions = new ArrayList<>();
     final ArrayList<String> inviteIds = new ArrayList<>();
@@ -49,6 +51,7 @@ public class InvitationsActivity extends AppCompatActivity {
         setContentView(R.layout.activity_invitations);
 
         invitesList = findViewById(R.id.invitesList);
+        emptyText = findViewById(R.id.emptyInvites);
         adapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, inviteDescriptions);
         invitesList.setAdapter(adapter);
 
@@ -162,6 +165,9 @@ public class InvitationsActivity extends AppCompatActivity {
                                     inviteIds.remove(idx);
                                     inviteDescriptions.remove(idx);
                                     adapter.notifyDataSetChanged();
+                                    if (inviteIds.isEmpty()) {
+                                        emptyText.setVisibility(View.VISIBLE);
+                                    }
                                 }
                             });
 
@@ -189,6 +195,7 @@ public class InvitationsActivity extends AppCompatActivity {
                         inviteDescriptions.clear();
                         inviteIds.clear();
                         adapter.notifyDataSetChanged();
+                        emptyText.setVisibility(View.VISIBLE);
                         Log.e("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName()
                                 + ": Listen failed", e);
                         return;
@@ -225,6 +232,11 @@ public class InvitationsActivity extends AppCompatActivity {
                     }
 
                     adapter.notifyDataSetChanged();
+                    if (inviteIds.isEmpty()) {
+                        emptyText.setVisibility(View.VISIBLE);
+                    } else {
+                        emptyText.setVisibility(View.GONE);
+                    }
                 });
     }
 

--- a/mobile/app/src/main/res/layout/activity_invitations.xml
+++ b/mobile/app/src/main/res/layout/activity_invitations.xml
@@ -14,6 +14,13 @@
         android:layout_height="wrap_content"
         android:textColor="@color/colorGreenDark"/>
 
+    <TextView
+        android:id="@+id/emptyInvites"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/no_pending_invites"
+        android:visibility="gone"
+        android:layout_marginBottom="16dp"/>
 
     <ListView
         android:id="@+id/invitesList"

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="invites_blocked_notification">Other players cannot invite you via \'Invite a Friend\' function. You can change it in Settings.</string>
     <string name="pending_game_invitations">Pending Game Invitations</string>
     <string name="pending_invites">Pending Invites</string>
+    <string name="no_pending_invites">No pending invitations.</string>
     <string name="invite_already_sent">You already have another invite pending.</string>
     <string name="waiting_for_opponent_named">Waiting for %1$s to accept…</string>
     <string name="waiting_for_opponent">Waiting for opponent to accept…</string>


### PR DESCRIPTION
## Summary
- show caption when no invites are available
- add string resource for empty invite list
- include TextView in invitations layout

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bd4154eac833083631d2e5ed9b7eb