### PR TITLE
Add background circle for ball

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -340,6 +340,10 @@ public class Field {
         float cx = w2x(flipX(last.X));
         float cy = h2y(flipY(last.Y));
         float radius = dotSize * 4;
+        // Background circle behind the ball
+        float radiusBackground = dotSize * 5;
+        canvas.drawCircle(cx, cy, radiusBackground, movePaint);
+
         RectF dst = new RectF(cx - radius, cy - radius, cx + radius, cy + radius);
         canvas.drawBitmap(ballBitmap, null, dst, null);
 


### PR DESCRIPTION
## Summary
- draw a circular highlight behind the ball

## Testing
- `./gradlew test -Penv=test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bd4f38c108330a839b1ee96ab7e01