### PR TITLE
Enable public nickname availability check

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -133,6 +133,18 @@ service cloud.firestore {
       // no writes here
     }
 
+    // Nicknames collection used for availability checks
+    match /nicknames/{nickname} {
+      // Anyone may read to verify if a nickname is taken
+      allow read: if true;
+
+      // Only signed-in users may reserve a nickname
+      allow create: if request.auth != null;
+
+      // No updates or deletions from clients
+      allow update, delete: if false;
+    }
+
     // Regulations: read-only for authenticated users
     match /regulations/{docId} {
       allow read: if request.auth != null;

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
@@ -214,11 +214,22 @@ public class FirebaseAuthManager {
 
                         db.collection("users").document(uid).set(userData)
                                 .addOnSuccessListener(aVoid ->
-                                    Log.d("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() + ": Nickname saved to Firestore")
+                                        Log.d("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() + ": Nickname saved to Firestore")
                                 )
                                 .addOnFailureListener(e ->
-                                    Log.e("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() + ": Failed to save nickname: " + e.getMessage())
+                                        Log.e("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() + ": Failed to save nickname: " + e.getMessage())
                                 );
+
+                        // Also reserve the nickname for availability checks
+                        Map<String, Object> nickData = new HashMap<>();
+                        nickData.put("uid", uid);
+                        db.collection("nicknames")
+                                .document(nickname.toLowerCase())
+                                .set(nickData)
+                                .addOnSuccessListener(v -> Log.d("TAG_Soccer",
+                                        getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() + ": Nickname reserved"))
+                                .addOnFailureListener(e -> Log.e("TAG_Soccer",
+                                        getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() + ": Failed to reserve nickname: " + e.getMessage()));
 
 
                         // Send verification email

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/PickNicknameActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/PickNicknameActivity.java
@@ -87,8 +87,8 @@ public class PickNicknameActivity extends AppCompatActivity {
 
         btnConfirm.setEnabled(false);
         FirebaseFirestore db = FirebaseFirestore.getInstance();
-        db.collection("users")
-                .whereEqualTo("nicknameLowercase", nickname.toLowerCase())
+        db.collection("nicknames")
+                .document(nickname.toLowerCase())
                 .get()
                 .addOnCompleteListener(this, task -> {
                     if (!task.isSuccessful()) {
@@ -98,7 +98,7 @@ public class PickNicknameActivity extends AppCompatActivity {
                                 Toast.LENGTH_SHORT).show();
                         return;
                     }
-                    if (!task.getResult().isEmpty()) {
+                    if (task.getResult().exists()) {
                         btnConfirm.setEnabled(true);
                         Toast.makeText(PickNicknameActivity.this,
                                 "Nickname already taken — choose another",
@@ -119,7 +119,18 @@ public class PickNicknameActivity extends AppCompatActivity {
                                 Toast.makeText(PickNicknameActivity.this,
                                         "Nickname saved",
                                         Toast.LENGTH_SHORT).show();
-                                finish();
+                                Map<String, Object> nickData = new HashMap<>();
+                                nickData.put("uid", uid);
+                                db.collection("nicknames")
+                                        .document(nickname.toLowerCase())
+                                        .set(nickData)
+                                        .addOnSuccessListener(x -> finish())
+                                        .addOnFailureListener(e -> {
+                                            btnConfirm.setEnabled(true);
+                                            Toast.makeText(PickNicknameActivity.this,
+                                                    "Failed to reserve nickname",
+                                                    Toast.LENGTH_SHORT).show();
+                                        });
                             })
                             .addOnFailureListener(e -> {
                                 btnConfirm.setEnabled(true);

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegisterAccountActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegisterAccountActivity.java
@@ -101,8 +101,8 @@ public class RegisterAccountActivity extends AppCompatActivity {
         FirebaseFirestore db = FirebaseFirestore.getInstance();
         btnRegister.setEnabled(false);               // optional: disable while checking
 
-        db.collection("users")
-                .whereEqualTo("nicknameLowercase", nickname.toLowerCase())
+        db.collection("nicknames")
+                .document(nickname.toLowerCase())
                 .get()
                 .addOnCompleteListener(this, task -> {
                     btnRegister.setEnabled(true);  // re-enable either way
@@ -118,7 +118,7 @@ public class RegisterAccountActivity extends AppCompatActivity {
                         return;
                     }
 
-                    if (!task.getResult().isEmpty()) {
+                    if (task.getResult().exists()) {
                         Toast.makeText(RegisterAccountActivity.this,
                                 "Nickname already taken — choose another",
                                 Toast.LENGTH_SHORT).show();


### PR DESCRIPTION
## Summary
- allow read-access for `/nicknames` documents and add rule for clients to reserve nicknames
- query `nicknames` instead of `users` in nickname selection screens
- reserve nickname documents during user registration

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bd5cc2c98833096d7981ba523ba01