### PR TITLE
Fix flow after choosing nickname

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/PickNicknameActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/PickNicknameActivity.java
@@ -119,6 +119,11 @@ public class PickNicknameActivity extends AppCompatActivity {
                                 Toast.makeText(PickNicknameActivity.this,
                                         "Nickname saved",
                                         Toast.LENGTH_SHORT).show();
+                                if (isTaskRoot()) {
+                                    startActivity(new Intent(
+                                            PickNicknameActivity.this,
+                                            MenuActivity.class));
+                                }
                                 finish();
                             })
                             .addOnFailureListener(e -> {


### PR DESCRIPTION
## Summary
- after saving nickname, open MenuActivity if no parent activity exists

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bd6226e088330a9b3f362830fc16f