### PR TITLE
Add Firebase Admin SDK key creation step

### DIFF
--- a/gcp/cloud-build/final-instructions.yaml
+++ b/gcp/cloud-build/final-instructions.yaml
@@ -46,6 +46,12 @@ steps:
         echo ""
         echo "Console path:"
         echo "  APIs & Services → Credentials → OAuth 2.0 Client IDs → Soccer 2"
+        echo ""
+        echo "Then generate a new Firebase Admin SDK private key for:"
+        echo "  firebase-adminsdk-fbsvc@${firebase_project_id}.iam.gserviceaccount.com"
+        echo "Console path:"
+        echo "  Firebase → Project Settings → Service accounts"
+        echo "Store the downloaded key in Secrets."
         echo "──────────────────────────────────────────────────────────"
         echo ""
 options:


### PR DESCRIPTION
## Summary
- update final-instructions Cloud Build step with console path for Firebase Admin SDK key generation

## Testing
- `npm test --silent` *(fails: script not found)*
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_688be2bb67108330945f5ec251ac75e8