### PR TITLE
Update email registration flow

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
@@ -10,7 +10,6 @@ import androidx.appcompat.app.AlertDialog;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.OAuthProvider;
 
-import com.google.firebase.auth.UserProfileChangeRequest;
 import androidx.annotation.Nullable;
 
 import com.google.firebase.firestore.FirebaseFirestore;
@@ -175,7 +174,7 @@ public class FirebaseAuthManager {
 
 
 
-    public void registerUser(String email, String password, String nickname) {
+    public void registerUser(String email, String password) {
         firebaseAuth.createUserWithEmailAndPassword(email, password)
                 .addOnCompleteListener(task -> {
                     if (task.isSuccessful()) {
@@ -183,27 +182,11 @@ public class FirebaseAuthManager {
                         Toast.makeText(context, "Registered as: " + firebaseAuth.getCurrentUser().getEmail(), Toast.LENGTH_SHORT).show();
 
                         ((SoccerApp) context.getApplicationContext()).enableFcmAutoInit();
-
-                        // Set display name
-                        firebaseAuth.getCurrentUser().updateProfile(
-                                new UserProfileChangeRequest.Builder()
-                                        .setDisplayName(nickname)
-                                        .build()
-                        ).addOnCompleteListener(profileTask -> {
-                            if (profileTask.isSuccessful()) {
-                                Log.d("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() + ": Nickname set to: " + nickname);
-                            } else {
-                                Log.e("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() + ": Failed to set nickname: " + Objects.requireNonNull(profileTask.getException()).getMessage());
-                            }
-                        });
-
-                        // Store nickname in Firestore
+                        // Store basic user data in Firestore
                         String uid = firebaseAuth.getCurrentUser().getUid();
                         FirebaseFirestore db = FirebaseFirestore.getInstance();
 
                         Map<String, Object> userData = new HashMap<>();
-                        userData.put("nickname", nickname);
-                        userData.put("nicknameLowercase", nickname.toLowerCase());
                         userData.put("email", email); // optional
                         userData.put("online", true); // optional
 
@@ -211,25 +194,10 @@ public class FirebaseAuthManager {
 
                         userData.put("method", "email");
 
-
-                        db.collection("users").document(uid).set(userData)
-                                .addOnSuccessListener(aVoid ->
-                                        Log.d("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() + ": Nickname saved to Firestore")
-                                )
+                        db.collection("users").document(uid).set(userData, SetOptions.merge())
                                 .addOnFailureListener(e ->
-                                        Log.e("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() + ": Failed to save nickname: " + e.getMessage())
+                                        Log.e("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() + ": Failed to save user data: " + e.getMessage())
                                 );
-
-                        // Also reserve the nickname for availability checks
-                        Map<String, Object> nickData = new HashMap<>();
-                        nickData.put("uid", uid);
-                        db.collection("nicknames")
-                                .document(nickname.toLowerCase())
-                                .set(nickData)
-                                .addOnSuccessListener(v -> Log.d("TAG_Soccer",
-                                        getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() + ": Nickname reserved"))
-                                .addOnFailureListener(e -> Log.e("TAG_Soccer",
-                                        getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() + ": Failed to reserve nickname: " + e.getMessage()));
 
 
                         // Send verification email
@@ -241,6 +209,7 @@ public class FirebaseAuthManager {
                                                 .setMessage("Please check your email to verify your account.")
                                                 .setPositiveButton("OK", (dialog, which) -> {
                                                     // Close the current activity
+                                                    firebaseAuth.signOut();
                                                     ((Activity) context).finish();
                                                 })
                                                 .show();
@@ -254,7 +223,7 @@ public class FirebaseAuthManager {
                                                 .setPositiveButton("OK", null)
                                                 .show();
                                     }
-                                });
+                        });
 
                     } else {
                         String errorMsg = task.getException() != null ? task.getException().getMessage() : "Unknown error occurred";

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegisterAccountActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegisterAccountActivity.java
@@ -6,11 +6,7 @@ import android.widget.EditText;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
-import android.text.InputFilter;
-import android.text.TextWatcher;
-import android.text.Editable;
-import android.util.Log;
-import com.google.firebase.firestore.FirebaseFirestore;
+
 
 public class RegisterAccountActivity extends AppCompatActivity {
 
@@ -19,11 +15,7 @@ public class RegisterAccountActivity extends AppCompatActivity {
 
     private EditText editConfirmPassword;
 
-    private EditText editNickname;
-    private static final int NICK_MAX = 20;          // ← single source of truth
-
-    // optional live counter
-    private Toast nickToast;                         // keep one toast instance
+    // Nickname removed from registration
 
     Button btnRegister;
 
@@ -38,34 +30,6 @@ public class RegisterAccountActivity extends AppCompatActivity {
         editPassword = findViewById(R.id.editPassword);
         btnRegister = findViewById(R.id.btnRegister);
         editConfirmPassword = findViewById(R.id.editConfirmPassword);
-        editNickname = findViewById(R.id.editNickname);
-        // 1. hard limit (cuts extra keystrokes)
-        editNickname.setFilters(new InputFilter[]{
-                new InputFilter.LengthFilter(NICK_MAX),
-                NO_LEADING_SPACE
-        });
-        // 2. live counter + gentle warning at limit
-        editNickname.addTextChangedListener(new TextWatcher() {
-            @Override public void beforeTextChanged(CharSequence s,int st,int c,int a) {}
-            @Override public void onTextChanged(CharSequence s,int st,int b,int c) {}
-            @Override public void afterTextChanged(Editable s) {
-                int len = s.length();
-                // show “12 / 20” as the hint
-                editNickname.setHint(len + " / " + NICK_MAX);
-                // if they just reached the limit, show a short toast
-                if (len == NICK_MAX) {
-                    if (nickToast != null) nickToast.cancel();
-                    nickToast = Toast.makeText(
-                            RegisterAccountActivity.this,
-                            "Maximum 20 characters reached",
-                            Toast.LENGTH_SHORT);
-                    nickToast.show();
-                } else if (len < NICK_MAX && nickToast != null) {
-                    nickToast.cancel();
-                    nickToast = null;
-                }
-            }
-        });
         btnRegister.setOnClickListener(v -> registerUser());
     }
 
@@ -85,63 +49,10 @@ public class RegisterAccountActivity extends AppCompatActivity {
             return;
         }
 
-        String nickname = editNickname.getText().toString().trim();
-        if (nickname.isEmpty()) {
-            Toast.makeText(this, "Nickname is required", Toast.LENGTH_SHORT).show();
-            return;
-        }
-        if (nickname.length() > NICK_MAX) {   // server-side / DB safety net
-            Toast.makeText(this, "Nickname must be 20 characters or less",
-                    Toast.LENGTH_SHORT).show();
-            return;
-        }
-        //------------------------------------------
-        //  Firestore: is this nickname already used?
-        //------------------------------------------
-        FirebaseFirestore db = FirebaseFirestore.getInstance();
-        btnRegister.setEnabled(false);               // optional: disable while checking
-
-        db.collection("nicknames")
-                .document(nickname.toLowerCase())
-                .get()
-                .addOnCompleteListener(this, task -> {
-                    btnRegister.setEnabled(true);  // re-enable either way
-                    if (!task.isSuccessful()) {
-                        Log.e(
-                            "TAG_Soccer",
-                            getClass().getSimpleName() + ".registerUser: Nickname check failed",
-                            task.getException()
-                        );
-                        Toast.makeText(RegisterAccountActivity.this,
-                                "Network error while checking nickname",
-                                Toast.LENGTH_SHORT).show();
-                        return;
-                    }
-
-                    if (task.getResult().exists()) {
-                        Toast.makeText(RegisterAccountActivity.this,
-                                "Nickname already taken — choose another",
-                                Toast.LENGTH_SHORT).show();
-                        return;
-                    }
-
-                    // 100 % unique → proceed with auth
-                    authManager.registerUser(email, password, nickname);
-                    Toast.makeText(RegisterAccountActivity.this,
-                            "Registration attempt in progress...",
-                            Toast.LENGTH_SHORT).show();
-                });
-        //------------------------------------------
-        //  End of Firestore nickname check
-        //------------------------------------------
+        authManager.registerUser(email, password);
+        Toast.makeText(RegisterAccountActivity.this,
+                "Registration attempt in progress...",
+                Toast.LENGTH_SHORT).show();
     }
 
-    private static final InputFilter NO_LEADING_SPACE = (source, start, end,
-                                                         dest, dstart, dend) -> {
-        // If the user is inserting at position 0 and the first inserted char is a space → reject
-        if (dstart == 0 && start < end && Character.isWhitespace(source.charAt(start))) {
-            return "";
-        }
-        return null;   // accept everything else
-    };
-}
+    }

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/UniversalLoginActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/UniversalLoginActivity.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import com.google.firebase.auth.FirebaseAuth;
 
 public class UniversalLoginActivity extends AppCompatActivity {
 
@@ -38,6 +39,14 @@ public class UniversalLoginActivity extends AppCompatActivity {
         btnGoogle.setOnClickListener(v -> handleProviderLogin("google.com"));
         btnFacebook.setOnClickListener(v -> handleProviderLogin("facebook.com"));
         btnMicrosoft.setOnClickListener(v -> handleProviderLogin("microsoft.com"));
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (FirebaseAuth.getInstance().getCurrentUser() != null) {
+            finish();
+        }
     }
 
     private void handleProviderLogin(String provider) {

--- a/mobile/app/src/main/res/layout/activity_register_account.xml
+++ b/mobile/app/src/main/res/layout/activity_register_account.xml
@@ -38,16 +38,6 @@
         android:inputType="textPassword"
         tools:ignore="VisualLintTextFieldSize" />
 
-    <EditText
-        android:id="@+id/editNickname"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
-        android:autofillHints="Enter nickname"
-        android:hint="@string/nickname"
-        android:inputType="textPersonName" />
-
-
     <Button
         android:id="@+id/btnRegister"
         android:layout_width="wrap_content"


### PR DESCRIPTION
## Summary
- drop nickname field from RegisterAccountActivity and XML layout
- simplify email registration in FirebaseAuthManager and sign out until verification
- automatically close UniversalLoginActivity after successful login

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688be4a2f4848330a38aa0158fdb3b11