### PR TITLE
Add release signing properties support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ google-services.*.json
 /mobile/app/src/main/assets/soccer_secret_key
 node_modules/
 **/__pycache__/
+
+# Signing configuration (local only)
+secrets/keystore.properties

--- a/README.md
+++ b/README.md
@@ -21,3 +21,19 @@ The script also accepts a path to a JSON file containing the fields `name`, `max
 ```bash
 node tools/create-tournament/create-tournament.js dev params.json
 ```
+
+## Android release signing
+
+The production keystore and passwords are kept outside of version control.
+Create a `keystore.properties` file inside the `secrets/` directory with your
+release signing details:
+
+```properties
+KEYSTORE_FILE=secrets/keystore.jks
+KEYSTORE_PASSWORD=your_store_password
+KEY_ALIAS=your_key_alias
+KEY_PASSWORD=your_key_password
+```
+
+`secrets/keystore.properties` is ignored by Git so your credentials remain
+private.

--- a/mobile/app/build.gradle
+++ b/mobile/app/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services'
 
+import java.util.Properties
+import java.io.FileInputStream
+
 // Determine the environment based on -Penv or the build variant being run
 def detectEnvFromTasks = {
     for (String taskName : gradle.startParameter.taskNames) {
@@ -15,6 +18,13 @@ def detectEnvFromTasks = {
 ext.buildEnv = project.findProperty("env") ?: detectEnvFromTasks() ?: ""
 def buildEnv = ext.buildEnv
 println "\n🛠️ Gradle build invoked with env='${buildEnv}'\n"
+
+// Load signing properties if available
+def signingProps = new Properties()
+def signingPropsFile = new File(rootProject.rootDir.parentFile, "secrets/keystore.properties")
+if (signingPropsFile.exists()) {
+    signingProps.load(new FileInputStream(signingPropsFile))
+}
 
 android {
 
@@ -34,8 +44,20 @@ android {
         buildConfig true          // <- make sure this is present or omit the block
     }
 
+    signingConfigs {
+        release {
+            if (signingPropsFile.exists()) {
+                storeFile file(new File(rootProject.rootDir.parentFile, signingProps['KEYSTORE_FILE']))
+                storePassword signingProps['KEYSTORE_PASSWORD']
+                keyAlias signingProps['KEY_ALIAS']
+                keyPassword signingProps['KEY_PASSWORD']
+            }
+        }
+    }
+
     buildTypes {
         release {
+            signingConfig signingConfigs.release
             minifyEnabled = true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }


### PR DESCRIPTION
## Summary
- ignore local signing credentials
- document release keystore properties in README
- load keystore properties from `secrets/` in Gradle build

## Testing
- `./gradlew tasks --all`

------
https://chatgpt.com/codex/tasks/task_e_688c8d9ae21c833099342c26ff076683