### PR TITLE
Add seed-service-status function

### DIFF
--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -77,6 +77,10 @@
     {
       "source": "functions/seed-ads-frequency",
       "codebase": "seed-ads-frequency"
+    },
+    {
+      "source": "functions/seed-service-status",
+      "codebase": "seed-service-status"
     }
   ],
   "firestore": {

--- a/firebase/functions/seed-service-status/index.js
+++ b/firebase/functions/seed-service-status/index.js
@@ -1,0 +1,18 @@
+const admin = require('firebase-admin');
+admin.initializeApp();
+const db = admin.firestore();
+
+async function main() {
+  const status = process.argv[2];
+  if (!status) {
+    console.error('Usage: node index.js <status>');
+    process.exit(1);
+  }
+  await db.collection('settings').doc('serviceStatus').set({
+    status,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+  console.log('serviceStatus document created.');
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/firebase/functions/seed-service-status/package.json
+++ b/firebase/functions/seed-service-status/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "seed-service-status",
+  "version": "1.0.0",
+  "main": "index.js",
+  "engines": {
+    "node": "18"
+  },
+  "dependencies": {
+    "firebase-admin": "^11.10.1"
+  }
+}

--- a/gcp/cloud-build/seed_service_status.yaml
+++ b/gcp/cloud-build/seed_service_status.yaml
@@ -1,0 +1,85 @@
+substitutions:
+  _ENVIRONMENT: 'dev'
+  _FOLDER_NAME: 'soccer'
+
+steps:
+  # Step 1: Get Firebase project ID
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'get-project-id'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -e
+        echo "🔎 Finding project for ${_FOLDER_NAME}-${_ENVIRONMENT}..."
+        gcloud projects list \
+          --filter="name~^${_FOLDER_NAME}-${_ENVIRONMENT}" \
+          --format="value(projectId)" \
+          | head -n 1 > /workspace/FIREBASE_PROJECT_ID.txt
+
+        if [ ! -s /workspace/FIREBASE_PROJECT_ID.txt ]; then
+          echo "❌ Project ID not found!"
+          exit 1
+        fi
+
+  # Step 2: Install Firebase CLI
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'install-firebase-cli'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -e
+        echo "⬇️ Installing Firebase CLI..."
+        curl -sL https://firebase.tools | bash
+        mkdir -p /workspace/firebase
+        cp /usr/local/bin/firebase /workspace/firebase/
+        chmod +x /workspace/firebase/firebase
+        echo "✅ Firebase CLI installed."
+
+  # Step 3: Clone source code
+  - name: 'gcr.io/cloud-builders/git'
+    id: 'pull-files'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -ex
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+
+        echo "📁 Preparing files for seeding service status..."
+        cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json
+        cp /workspace/soccer/firebase/firestore.rules /workspace/firebase/firestore.rules
+        mkdir -p /workspace/firebase/functions/seed-service-status
+        cp /workspace/soccer/firebase/functions/seed-service-status/package.json /workspace/firebase/functions/seed-service-status/
+        cp /workspace/soccer/firebase/functions/seed-service-status/index.js /workspace/firebase/functions/seed-service-status/
+
+  # Step 4: Install dependencies
+  - name: 'node:18-slim'
+    id: 'install-deps-seed-service-status'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -ex
+        cd /workspace/firebase/functions/seed-service-status
+        npm install
+        echo "📦 Dependencies installed."
+
+  # Step 5: Execute the seeding script
+  - name: 'node:18-slim'
+    id: 'run-seeding'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -e
+        cd /workspace/firebase/functions/seed-service-status
+        project_id=$(cat /workspace/FIREBASE_PROJECT_ID.txt)
+        export GOOGLE_CLOUD_PROJECT="$project_id"
+        node index.js active
+        echo "✅ serviceStatus document created."
+
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## Summary
- create a new `seed-service-status` function for Firestore
- add Cloud Build config `seed_service_status.yaml` to invoke it
- update `firebase.json` so Cloud Build can access the new seeding script

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_688cb25345848330843977e8bdc182dc