### PR TITLE
Store nickname only in users collection

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -133,17 +133,6 @@ service cloud.firestore {
       // no writes here
     }
 
-    // Nicknames collection used for availability checks
-    match /nicknames/{nickname} {
-      // Anyone may read to verify if a nickname is taken
-      allow read: if true;
-
-      // Only signed-in users may reserve a nickname
-      allow create: if request.auth != null;
-
-      // No updates or deletions from clients
-      allow update, delete: if false;
-    }
 
     // Regulations: read-only for authenticated users
     match /regulations/{docId} {

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/PickNicknameActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/PickNicknameActivity.java
@@ -88,8 +88,9 @@ public class PickNicknameActivity extends AppCompatActivity {
 
         btnConfirm.setEnabled(false);
         FirebaseFirestore db = FirebaseFirestore.getInstance();
-        db.collection("nicknames")
-                .document(nickname.toLowerCase())
+
+        db.collection("users")
+                .whereEqualTo("nicknameLowercase", nickname.toLowerCase())
                 .get()
                 .addOnCompleteListener(this, task -> {
                     if (!task.isSuccessful()) {
@@ -100,7 +101,7 @@ public class PickNicknameActivity extends AppCompatActivity {
                                 Toast.LENGTH_SHORT).show();
                         return;
                     }
-                    if (task.getResult().exists()) {
+                    if (!task.getResult().isEmpty()) {
                         btnConfirm.setEnabled(true);
                         Log.e("TAG_Soccer", "Nickname already exists: " + nickname);
                         Toast.makeText(PickNicknameActivity.this,
@@ -122,25 +123,12 @@ public class PickNicknameActivity extends AppCompatActivity {
                                 Toast.makeText(PickNicknameActivity.this,
                                         "Nickname saved",
                                         Toast.LENGTH_SHORT).show();
-                                Map<String, Object> nickData = new HashMap<>();
-                                nickData.put("uid", uid);
-                                db.collection("nicknames")
-                                        .document(nickname.toLowerCase())
-                                        .set(nickData)
-                                        .addOnSuccessListener(x -> {
-                                            if (isTaskRoot()) {
-                                                startActivity(new Intent(
-                                                        PickNicknameActivity.this,
-                                                        MenuActivity.class));
-                                            }
-                                            finish();
-                                        })
-                                        .addOnFailureListener(e -> {
-                                            btnConfirm.setEnabled(true);
-                                            Toast.makeText(PickNicknameActivity.this,
-                                                    "Failed to reserve nickname",
-                                                    Toast.LENGTH_SHORT).show();
-                                        });
+                                if (isTaskRoot()) {
+                                    startActivity(new Intent(
+                                            PickNicknameActivity.this,
+                                            MenuActivity.class));
+                                }
+                                finish();
                             })
                             .addOnFailureListener(e -> {
                                 btnConfirm.setEnabled(true);


### PR DESCRIPTION
## Summary
- remove `/nicknames` rules
- save nickname uniqueness check against `users` collection
- store nickname only in the user document

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cccc3b09083308ff4a0e93f692a77