### PR TITLE
Use Firestore for service status

### DIFF
--- a/gcp/cloud-functions/service-check/main.py
+++ b/gcp/cloud-functions/service-check/main.py
@@ -1,6 +1,7 @@
 from flask import Flask, jsonify, request, Response
 from google.cloud import secretmanager
 from google.cloud import logging as cloud_logging  # Import Google Cloud Logging
+from google.cloud import firestore
 import logging
 
 app = Flask(__name__)
@@ -26,6 +27,23 @@ def get_secret():
         logging.error(f"Failed to retrieve secret: {e}")
         raise
 
+# Function to get service status from Firestore
+def get_service_status():
+    logging.info("Retrieving service status from Firestore...")
+    try:
+        client = firestore.Client()
+        doc = client.collection("settings").document("serviceStatus").get()
+        if doc.exists:
+            data = doc.to_dict()
+            status = data.get("status", "active")
+            logging.info(f"Service status fetched: {status}")
+            return status.lower()
+        logging.warning("serviceStatus document does not exist; defaulting to 'active'")
+        return "active"
+    except Exception as e:
+        logging.error(f"Failed to retrieve service status: {e}")
+        return "active"
+
 # Service check endpoint
 def service_check(request):
     logging.info("Service-check endpoint invoked.")
@@ -46,8 +64,9 @@ def service_check(request):
             logging.warning("Provided X-Secret-Key does not match the secret key")
             return Response(jsonify({"error": "Unauthorized"}).data, status=403, mimetype="application/json")
 
+        status = get_service_status()
         logging.info("Service-check completed successfully.")
-        return Response(jsonify({"status": "Active"}).data, status=200, mimetype="application/json")
+        return Response(jsonify({"status": status}).data, status=200, mimetype="application/json")
     except Exception as e:
         logging.error(f"An error occurred: {e}")
         return Response(jsonify({"error": "Internal server error"}).data, status=500, mimetype="application/json")

--- a/gcp/cloud-functions/tests/test_service_check.py
+++ b/gcp/cloud-functions/tests/test_service_check.py
@@ -21,8 +21,10 @@ class TestServiceCheck(unittest.TestCase):
 
     @patch("main.cloud_logging.Client")
     @patch("main.get_secret")
-    def test_service_check_success(self, mock_get_secret, mock_log_client):
+    @patch("main.get_service_status")
+    def test_service_check_success(self, mock_get_status, mock_get_secret, mock_log_client):
         mock_log_client.return_value = MagicMock(setup_logging=MagicMock())
+        mock_get_status.return_value = "active"
         # Mock the secret key retrieval
         mock_get_secret.return_value = self.secret_key
 
@@ -32,12 +34,14 @@ class TestServiceCheck(unittest.TestCase):
             response = service_check(context.request)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json, {"status": "Active"})
+        self.assertEqual(response.json, {"status": "active"})
 
     @patch("main.cloud_logging.Client")
     @patch("main.get_secret")
-    def test_service_check_missing_header(self, mock_get_secret, mock_log_client):
+    @patch("main.get_service_status")
+    def test_service_check_missing_header(self, mock_get_status, mock_get_secret, mock_log_client):
         mock_log_client.return_value = MagicMock(setup_logging=MagicMock())
+        mock_get_status.return_value = "active"
         # Mock the secret key retrieval
         mock_get_secret.return_value = self.secret_key
 
@@ -50,8 +54,10 @@ class TestServiceCheck(unittest.TestCase):
 
     @patch("main.cloud_logging.Client")
     @patch("main.get_secret")
-    def test_service_check_unauthorized(self, mock_get_secret, mock_log_client):
+    @patch("main.get_service_status")
+    def test_service_check_unauthorized(self, mock_get_status, mock_get_secret, mock_log_client):
         mock_log_client.return_value = MagicMock(setup_logging=MagicMock())
+        mock_get_status.return_value = "active"
         # Mock the secret key retrieval
         mock_get_secret.return_value = self.secret_key
 
@@ -65,8 +71,10 @@ class TestServiceCheck(unittest.TestCase):
 
     @patch("main.cloud_logging.Client")
     @patch("main.get_secret")
-    def test_service_check_internal_error(self, mock_get_secret, mock_log_client):
+    @patch("main.get_service_status")
+    def test_service_check_internal_error(self, mock_get_status, mock_get_secret, mock_log_client):
         mock_log_client.return_value = MagicMock(setup_logging=MagicMock())
+        mock_get_status.return_value = "active"
         # Mock an exception during secret key retrieval
         mock_get_secret.side_effect = Exception("Secret retrieval failed")
 

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/BackendServiceChecker.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/BackendServiceChecker.java
@@ -148,7 +148,7 @@ public class BackendServiceChecker {
                             JSONObject jsonResponse = new JSONObject(responseBody);
                             String status = jsonResponse.optString("status", "");
                             
-                            if ("Active".equals(status)) {
+                            if ("active".equals(status)) {
                                 Log.d(TAG, "Backend service is available");
                                 callback.onServiceAvailable();
                                 return;


### PR DESCRIPTION
## Summary
- fetch service status from Firestore in `service-check`
- expect lowercase `active` in `BackendServiceChecker`
- adjust unit tests for new behaviour
- revert requirements file to previous state

## Testing
- `pip install -r gcp/cloud-functions/service-check/requirements.txt`
- `pip install google-cloud-firestore`
- `pytest -q gcp/cloud-functions/tests/test_service_check.py`


------
https://chatgpt.com/codex/tasks/task_e_688ccf59f5a083309a4e17519e1ec1ff