### PR TITLE
Add toolbar to Ranking screen

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RankingActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RankingActivity.java
@@ -9,6 +9,7 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -21,6 +22,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class RankingActivity extends AppCompatActivity {
 
@@ -32,6 +34,10 @@ public class RankingActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_ranking);
+
+        Toolbar toolbar = findViewById(R.id.ranking_toolbar);
+        setSupportActionBar(toolbar);
+        Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
 
         RecyclerView list = findViewById(R.id.rankingList);
         list.setLayoutManager(new LinearLayoutManager(this));
@@ -102,6 +108,12 @@ public class RankingActivity extends AppCompatActivity {
             e.medalCategory = category <= 3 ? category : 0;
             prevWins = e.wins;
         }
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish();
+        return true;
     }
 
     static class RankingEntry {

--- a/mobile/app/src/main/res/layout/activity_ranking.xml
+++ b/mobile/app/src/main/res/layout/activity_ranking.xml
@@ -1,20 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
-    android:padding="20dp"
-    android:background="@color/colorWhite"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/rankingTitle"
-        android:textStyle="bold"
-        android:textColor="@color/colorGreenDark"
-        android:gravity="center"
-        android:layout_marginBottom="12dp"
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/ranking_toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/ranking" />
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:title="@string/ranking"
+        android:titleTextColor="@color/colorWhite" />
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:padding="20dp"
+        android:background="@color/colorWhite"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
     <TextView
         android:id="@+id/emptyRanking"
@@ -29,4 +32,6 @@
         android:id="@+id/rankingList"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
+    </LinearLayout>
+
 </LinearLayout>


### PR DESCRIPTION
## Summary
- add Toolbar to ranking layout
- enable up navigation in RankingActivity

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cd274f5708330bba51b6ca20c3404