### PR TITLE
Fix RankingActivity toolbar title

### DIFF
--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -98,7 +98,8 @@
         <activity
             android:name=".RankingActivity"
             android:exported="false"
-            android:parentActivityName=".MenuActivity">
+            android:parentActivityName=".MenuActivity"
+            android:label="@string/ranking">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".MenuActivity"/>

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RankingActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RankingActivity.java
@@ -38,6 +38,7 @@ public class RankingActivity extends AppCompatActivity {
         Toolbar toolbar = findViewById(R.id.ranking_toolbar);
         setSupportActionBar(toolbar);
         Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
+        getSupportActionBar().setTitle(R.string.ranking);
 
         RecyclerView list = findViewById(R.id.rankingList);
         list.setLayoutManager(new LinearLayoutManager(this));


### PR DESCRIPTION
## Summary
- ensure RankingActivity title uses the "Ranking" string by setting the label in AndroidManifest
- explicitly set the action bar title in RankingActivity after setup

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cdb39fa9c833093feb5505e603ab5