### PR TITLE
Add toolbar to invitations screen

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
@@ -11,6 +11,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 
 import com.google.firebase.Timestamp;
 import com.google.firebase.auth.FirebaseAuth;
@@ -49,6 +50,11 @@ public class InvitationsActivity extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_invitations);
+
+        Toolbar toolbar = findViewById(R.id.invitations_toolbar);
+        setSupportActionBar(toolbar);
+        Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
+        getSupportActionBar().setTitle(R.string.pending_game_invitations);
 
         invitesList = findViewById(R.id.invitesList);
         emptyText = findViewById(R.id.emptyInvites);
@@ -243,6 +249,12 @@ public class InvitationsActivity extends AppCompatActivity {
     @Override protected void onDestroy() {
         super.onDestroy();
         if (invitesSub != null) invitesSub.remove();
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish();
+        return true;
     }
 
 }

--- a/mobile/app/src/main/res/layout/activity_invitations.xml
+++ b/mobile/app/src/main/res/layout/activity_invitations.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:padding="20dp"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/colorWhite"
-    android:gravity="center"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <TextView
-        android:text="@string/pending_game_invitations"
-        android:layout_marginBottom="20dp"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textColor="@color/colorGreenDark"/>
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/invitations_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:title="@string/pending_game_invitations"
+        app:titleTextColor="@color/colorWhite" />
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:padding="20dp"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/colorWhite"
+        android:gravity="center_horizontal">
 
     <TextView
         android:id="@+id/emptyInvites"
@@ -26,4 +33,6 @@
         android:id="@+id/invitesList"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
+    </LinearLayout>
+
 </LinearLayout>


### PR DESCRIPTION
## Summary
- replace the Pending Game Invitations caption with a toolbar
- wire up the toolbar in `InvitationsActivity`
- support navigating back from the invitations screen

## Testing
- `./mobile/gradlew -p mobile assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cfab15c748330bb548bbfeb56a3c7