### PR TITLE
Add toolbar to tournaments screen

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentsActivity.java
@@ -9,6 +9,7 @@ import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -30,8 +31,10 @@ public class TournamentsActivity extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_tournaments);
-
-
+        Toolbar toolbar = findViewById(R.id.tournaments_toolbar);
+        setSupportActionBar(toolbar);
+        Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
+        getSupportActionBar().setTitle(R.string.tournaments);
 
         // ── RecyclerView ─────────────────────────────────────────────
         RecyclerView registeringList = findViewById(R.id.registeringList);
@@ -186,6 +189,12 @@ public class TournamentsActivity extends AppCompatActivity {
                         Toast.makeText(this, e.getMessage(), Toast.LENGTH_LONG).show();
                     }
                 });
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish();
+        return true;
     }
 
 }

--- a/mobile/app/src/main/res/layout/activity_tournaments.xml
+++ b/mobile/app/src/main/res/layout/activity_tournaments.xml
@@ -1,8 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/tournaments_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:title="@string/tournaments"
+        app:titleTextColor="@color/colorWhite" />
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
@@ -11,7 +20,6 @@
 
         <LinearLayout
             android:orientation="vertical"
-            android:gravity="center"
             android:background="@color/colorWhite"
             android:padding="20dp"
             android:paddingBottom="40dp"


### PR DESCRIPTION
## Summary
- add toolbar to TournamentsActivity layout
- set support action bar in TournamentsActivity
- align content top by removing centering
- handle back navigation

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d00093b6483309a49effd3c3b38a0