### PR TITLE
Add offline status indicator in menu toolbar

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -628,6 +628,11 @@ public class MenuActivity extends AppCompatActivity {
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.tournaments_menu, menu);
         this.optionsMenu = menu;
+        // Hide offline indicator by default or based on current state
+        MenuItem offlineItem = menu.findItem(R.id.action_offline);
+        if (offlineItem != null) {
+            offlineItem.setVisible(!isBackendAvailable);
+        }
         checkAndUpdateBlockedInviteWarning(); // Check blocked invite status
         return true;
     }
@@ -648,6 +653,10 @@ public class MenuActivity extends AppCompatActivity {
         } else if (id == R.id.action_invite_blocked_warning) {
             // Show toast explaining the warning
             Toast.makeText(this, R.string.invites_blocked_notification, Toast.LENGTH_LONG).show();
+            return true;
+        } else if (id == R.id.action_offline) {
+            // Clicking the offline icon shows the same toast as when the check fails
+            Toast.makeText(this, R.string.server_unavailable_message, Toast.LENGTH_LONG).show();
             return true;
         }
         return super.onOptionsItemSelected(item);
@@ -691,6 +700,12 @@ public class MenuActivity extends AppCompatActivity {
                 runOnUiThread(() -> {
                     isBackendAvailable = true;
                     updateUiForAuthState();
+                    if (optionsMenu != null) {
+                        MenuItem offlineItem = optionsMenu.findItem(R.id.action_offline);
+                        if (offlineItem != null) {
+                            offlineItem.setVisible(false);
+                        }
+                    }
                 });
             }
 
@@ -703,9 +718,15 @@ public class MenuActivity extends AppCompatActivity {
                 runOnUiThread(() -> {
                     isBackendAvailable = false;
                     updateUiForAuthState();
+                    if (optionsMenu != null) {
+                        MenuItem offlineItem = optionsMenu.findItem(R.id.action_offline);
+                        if (offlineItem != null) {
+                            offlineItem.setVisible(true);
+                        }
+                    }
                     // Show toast notification about server unavailability
-                    Toast.makeText(MenuActivity.this, 
-                            "We are sorry, but the Soccer server is not available at the moment...", 
+                    Toast.makeText(MenuActivity.this,
+                            R.string.server_unavailable_message,
                             Toast.LENGTH_LONG).show();
                 });
             }

--- a/mobile/app/src/main/res/menu/tournaments_menu.xml
+++ b/mobile/app/src/main/res/menu/tournaments_menu.xml
@@ -8,6 +8,12 @@
         android:visible="false"
         app:showAsAction="always" />
     <item
+        android:id="@+id/action_offline"
+        android:title="@string/server_unavailable"
+        android:icon="@android:drawable/presence_offline"
+        android:visible="false"
+        app:showAsAction="always" />
+    <item
         android:id="@+id/action_account"
         android:title="@string/account"
         android:icon="@android:drawable/ic_menu_myplaces"

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -110,6 +110,7 @@
     <string name="regulation_load_error">Failed to load regulation.</string>
     <string name="regulation_auth_required">Please log in to view the regulation.</string>
     <string name="server_unavailable">Server Unavailable</string>
+    <string name="server_unavailable_message">We are sorry, but the Soccer server is not available at the moment...</string>
 
     <!-- Account strings -->
     <string name="account">Account</string>


### PR DESCRIPTION
## Summary
- add toolbar menu item for showing backend offline status
- display toast on icon click
- toggle icon visibility when backend availability changes
- add new string resource for offline toast

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d166774d08330bb78efe94eb57506