### PR TITLE
Fix backend availability propagation

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -690,6 +690,7 @@ public class MenuActivity extends AppCompatActivity {
                 );
                 runOnUiThread(() -> {
                     isBackendAvailable = true;
+                    ((SoccerApp) getApplication()).setBackendAvailable(true);
                     updateUiForAuthState();
                 });
             }
@@ -702,6 +703,7 @@ public class MenuActivity extends AppCompatActivity {
                 );
                 runOnUiThread(() -> {
                     isBackendAvailable = false;
+                    ((SoccerApp) getApplication()).setBackendAvailable(false);
                     updateUiForAuthState();
                     // Show toast notification about server unavailability
                     Toast.makeText(MenuActivity.this, 

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -346,6 +346,14 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
     public boolean isBackendAvailable() {
         return isBackendAvailable;
     }
+
+    /**
+     * Update backend availability status so other activities can query
+     * the latest value.
+     */
+    public void setBackendAvailable(boolean available) {
+        isBackendAvailable = available;
+    }
     
     /**
      * Get the backend service checker instance


### PR DESCRIPTION
## Summary
- add setter to propagate backend availability in `SoccerApp`
- update `MenuActivity` to update the global state when service check finishes

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688d179aa0808330a9f290d63dcb2d29