### PR TITLE
Add toolbar to tournament lobby screen

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentLobbyActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentLobbyActivity.java
@@ -5,6 +5,7 @@ import static java.util.Objects.*;
 import android.os.Bundle;
 import android.util.Log;
 import android.widget.TextView;
+import androidx.appcompat.widget.Toolbar;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -27,7 +28,7 @@ public class TournamentLobbyActivity extends AppCompatActivity {
 
     private MatchAdapter mAdapter;
     private ListenerRegistration matchListener;
-    private TextView tournamentName;
+    private TextView tournamentBanner;
 
     /* one common handler so we don’t repeat the diff logic */
     EventListener<QuerySnapshot> makeHandler(String label) {
@@ -85,7 +86,11 @@ public class TournamentLobbyActivity extends AppCompatActivity {
                 + ": Method start");
         setContentView(R.layout.activity_tournament_lobby);
 
-        tournamentName = findViewById(R.id.tournamentName);
+        Toolbar toolbar = findViewById(R.id.tournament_lobby_toolbar);
+        setSupportActionBar(toolbar);
+        Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
+
+        tournamentBanner = findViewById(R.id.tournamentBanner);
 
         String tid   = getIntent().getStringExtra("tournamentId");
         String nameExtra = getIntent().getStringExtra("tournamentName");
@@ -93,12 +98,12 @@ public class TournamentLobbyActivity extends AppCompatActivity {
         FirebaseFirestore db = FirebaseFirestore.getInstance();
 
         if (nameExtra != null) {
-            tournamentName.setText(nameExtra);
+            getSupportActionBar().setTitle(nameExtra);
         } else if (tid != null) {
             db.collection("tournaments").document(tid).get()
                     .addOnSuccessListener(doc -> {
                         String n = doc.getString("name");
-                        if (n != null) tournamentName.setText(n);
+                        if (n != null) getSupportActionBar().setTitle(n);
                     });
         }
 
@@ -154,6 +159,12 @@ public class TournamentLobbyActivity extends AppCompatActivity {
     @Override protected void onDestroy() {
         if (matchListener != null) matchListener.remove();
         super.onDestroy();
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish();
+        return true;
     }
 }
 

--- a/mobile/app/src/main/res/layout/activity_tournament_lobby.xml
+++ b/mobile/app/src/main/res/layout/activity_tournament_lobby.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:gravity="center"
     android:background="@color/colorWhite"
@@ -7,9 +8,16 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/tournament_lobby_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        app:titleTextColor="@color/colorWhite" />
+
     <!-- banner -->
     <TextView
-        android:id="@+id/tournamentName"
+        android:id="@+id/tournamentBanner"
         android:text="@string/lobby_started"
         android:textColor="@color/colorGreenDark"
         android:textStyle="bold"


### PR DESCRIPTION
## Summary
- swap tournament lobby caption for a Toolbar
- show tournament name on the toolbar title
- keep banner text below the toolbar
- support navigate up in TournamentLobbyActivity

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d2476697883309974b5ce16e63f39