### PR TITLE
Use toolbar in tournament results

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentResultsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentResultsActivity.java
@@ -7,6 +7,9 @@ import android.os.Bundle;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import androidx.appcompat.widget.Toolbar;
+import java.util.Objects;
+
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -23,7 +26,6 @@ import java.util.Map;
 
 public class TournamentResultsActivity extends AppCompatActivity {
 
-    private TextView tournamentName;
     private StandingsAdapter adapter;
     private final List<StandingEntry> standings = new ArrayList<>();
 
@@ -32,7 +34,10 @@ public class TournamentResultsActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_tournament_results);
 
-        tournamentName = findViewById(R.id.tournamentName);
+        Toolbar toolbar = findViewById(R.id.results_toolbar);
+        setSupportActionBar(toolbar);
+        Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
+
         RecyclerView standingsList = findViewById(R.id.standingsList);
         standingsList.setLayoutManager(new LinearLayoutManager(this));
 
@@ -51,7 +56,8 @@ public class TournamentResultsActivity extends AppCompatActivity {
         db.collection("tournaments").document(tid).get()
                 .addOnSuccessListener(doc -> {
                     if (!doc.exists()) return;
-                    tournamentName.setText(doc.getString("name"));
+                    Objects.requireNonNull(getSupportActionBar())
+                            .setTitle(doc.getString("name"));
                 });
 
         // Step 1: fetch all participants
@@ -112,6 +118,12 @@ public class TournamentResultsActivity extends AppCompatActivity {
             e.medalCategory = category <= 3 ? category : 0;
             prevWins = e.wins;
         }
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish();
+        return true;
     }
 
     /** Internal structure for one row */

--- a/mobile/app/src/main/res/layout/activity_tournament_results.xml
+++ b/mobile/app/src/main/res/layout/activity_tournament_results.xml
@@ -1,22 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
-    android:padding="20dp"
-    android:background="@color/colorWhite"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/tournamentName"
-        android:textStyle="bold"
-        android:textColor="@color/colorGreenDark"
-        android:gravity="center"
-        android:layout_marginBottom="12dp"
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/results_toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        app:titleTextColor="@color/colorWhite" />
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/standingsList"
+    <LinearLayout
+        android:orientation="vertical"
+        android:padding="20dp"
+        android:background="@color/colorWhite"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/standingsList"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
+    </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
## Summary
- replace tournament name caption with Toolbar in results screen
- set Toolbar title to the tournament name at runtime
- add navigation up handling

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d24a8dc7c83308edbaf69870db33c