### PR TITLE
Fix account screen title

### DIFF
--- a/mobile/app/src/main/res/layout/activity_account.xml
+++ b/mobile/app/src/main/res/layout/activity_account.xml
@@ -10,7 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
-        android:title="@string/account"
+        android:title="@string/account_information"
         app:titleTextColor="@color/colorWhite" />
 
     <LinearLayout

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -114,6 +114,7 @@
 
     <!-- Account strings -->
     <string name="account">Account</string>
+    <string name="account_information">Account information</string>
     <string name="nickname_label">Nickname: %1$s</string>
     <string name="email_label">Email: %1$s</string>
 


### PR DESCRIPTION
## Summary
- localize toolbar title for the account screen
- reference the new string in the layout

## Testing
- `npm test` *(fails: Missing script)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d280445b0833081897533a1fa4ccf