### PR TITLE
Fix nickname reset after logout

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -256,6 +256,13 @@ public class MenuActivity extends AppCompatActivity {
         FirebaseMessaging.getInstance().setAutoInitEnabled(false);
 
         Toast.makeText(this, R.string.logged_out, Toast.LENGTH_SHORT).show();
+
+        // Update nickname label after logging out
+        TextView nicknameLabel = findViewById(R.id.nicknameLabel);
+        if (nicknameLabel != null) {
+            nicknameLabel.setText(getString(R.string.welcome_to_soccer));
+        }
+
         updateUiForAuthState();
     }
 


### PR DESCRIPTION
## Summary
- update MenuActivity to reset nickname label when logging out

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d29a964988330a727adcdfd795dae