### PR TITLE
Add Toolbar banners to Login and Register screens

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/LoginActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/LoginActivity.java
@@ -6,7 +6,11 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
+
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+
+import java.util.Objects;
 
 public class LoginActivity extends AppCompatActivity {
 
@@ -17,6 +21,11 @@ public class LoginActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_login);
+
+        Toolbar toolbar = findViewById(R.id.login_toolbar);
+        setSupportActionBar(toolbar);
+        Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
+        getSupportActionBar().setTitle("Login");
 
         authManager = new FirebaseAuthManager(this);
 
@@ -50,5 +59,11 @@ public class LoginActivity extends AppCompatActivity {
             Intent intent = new Intent(this, RegisterAccountActivity.class);
             startActivity(intent);
         });
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish();
+        return true;
     }
 }

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegisterAccountActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegisterAccountActivity.java
@@ -6,6 +6,9 @@ import android.widget.EditText;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+
+import java.util.Objects;
 
 
 public class RegisterAccountActivity extends AppCompatActivity {
@@ -23,6 +26,11 @@ public class RegisterAccountActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_register_account);
+
+        Toolbar toolbar = findViewById(R.id.register_toolbar);
+        setSupportActionBar(toolbar);
+        Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
+        getSupportActionBar().setTitle("Register new account");
 
         authManager = new FirebaseAuthManager(this);
 
@@ -55,4 +63,10 @@ public class RegisterAccountActivity extends AppCompatActivity {
                 Toast.LENGTH_SHORT).show();
     }
 
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish();
+        return true;
     }
+
+}

--- a/mobile/app/src/main/res/layout/activity_login.xml
+++ b/mobile/app/src/main/res/layout/activity_login.xml
@@ -1,11 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/colorWhite"
-    android:gravity="center"
-    android:orientation="vertical"
-    android:padding="20dp">
+    android:orientation="vertical">
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/login_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:title="Login"
+        app:titleTextColor="@color/colorWhite" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/colorWhite"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:padding="20dp">
 
     <EditText
         android:id="@+id/editLoginEmail"
@@ -44,4 +56,5 @@
         android:text="@string/register_new_account"
         android:textColor="@color/colorGreenDark"
         android:textStyle="bold" />
+</LinearLayout>
 </LinearLayout>

--- a/mobile/app/src/main/res/layout/activity_register_account.xml
+++ b/mobile/app/src/main/res/layout/activity_register_account.xml
@@ -1,12 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/colorWhite"
-    android:gravity="center"
-    android:orientation="vertical"
-    android:padding="20dp">
+    android:orientation="vertical">
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/register_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:title="Register new account"
+        app:titleTextColor="@color/colorWhite" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/colorWhite"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:padding="20dp">
 
     <EditText
         android:id="@+id/editEmail"
@@ -48,4 +60,5 @@
         android:textAllCaps="false"
         android:text="@string/register" />
 
+</LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
## Summary
- show Toolbar in `activity_login` and `activity_register_account`
- wire up Toolbar support in `LoginActivity` and `RegisterAccountActivity`

## Testing
- `./mobile/gradlew -p mobile assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d2cdc3b148330bc018aef72fcd674