### PR TITLE
Fix nickname activity race

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -115,7 +115,11 @@ public class MenuActivity extends AppCompatActivity {
                         updateUiForAuthState();
                         checkAndUpdateBlockedInviteWarning();
                     } else {
-                        onMissing.run();
+                        if (uid.equals(FirebaseAuth.getInstance().getUid())) {
+                            onMissing.run();
+                        } else {
+                            Log.d("TAG_Soccer", getClass().getSimpleName() + ".fetchNicknameFromFirestore: user changed, skipping nickname prompt");
+                        }
                     }
                 })
                 .addOnFailureListener(e -> {
@@ -297,7 +301,11 @@ public class MenuActivity extends AppCompatActivity {
         } else {
             String uid = auth.getUid();
             if (uid != null) {
-                Runnable pickNick = () -> startActivity(new Intent(this, PickNicknameActivity.class));
+                Runnable pickNick = () -> {
+                    if (FirebaseAuth.getInstance().getCurrentUser() != null) {
+                        startActivity(new Intent(this, PickNicknameActivity.class));
+                    }
+                };
                 if (nickname == null || nickname.isEmpty()) {
                     fetchNicknameFromFirestore(uid, prefs, pickNick);
                     return;


### PR DESCRIPTION
## Summary
- only prompt for nickname if the same user is still logged in
- avoid launching PickNicknameActivity after logout

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d324b9ca4833092781e4e704e7508