### PR TITLE
feat: integrate admob ad unit

### DIFF
--- a/mobile/app/build.gradle
+++ b/mobile/app/build.gradle
@@ -75,7 +75,7 @@ android {
         }
         _prod {
             dimension "environment"
-            buildConfigField "String", "AD_UNIT_ID", '"ca-app-pub-9113152787055223~3266191463"'
+            buildConfigField "String", "AD_UNIT_ID", '"ca-app-pub-9113152787055223/9306362927"'
         }
     }
     packagingOptions {


### PR DESCRIPTION
## Summary
- use provided AdMob interstitial unit ID for production build

## Testing
- `./gradlew -Penv=dev assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e003a70788330abe4941400b5af5f