### PR TITLE
fix: remove leading newline from friends list layout

### DIFF
--- a/mobile/app/src/main/res/layout/activity_friends_list.xml
+++ b/mobile/app/src/main/res/layout/activity_friends_list.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"


### PR DESCRIPTION
## Summary
- fix Friends List layout XML by removing stray newline before declaration

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e014320308330be7868a1d594628d