### PR TITLE
docs: add prod debug SHA1 note

### DIFF
--- a/gcp/cloud-build/final-instructions.yaml
+++ b/gcp/cloud-build/final-instructions.yaml
@@ -54,6 +54,8 @@ steps:
         echo "Store the downloaded key in Secrets."
         echo ""
         echo "Add mobile SHA fingerprints to Firebase."
+        echo "For PROD add debug SHA1 temporarily while testing production before launch"
+        
         echo "Firebase console → Project Settings → General → Scroll to Android apps"
         echo "──────────────────────────────────────────────────────────"
         echo ""


### PR DESCRIPTION
## Summary
- remind devs to temporarily add debug SHA1 when testing production

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688e031e7d548330bd3ac2204de62a23