### PR TITLE
Fix nickname check on provider login

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
@@ -14,6 +14,7 @@ import androidx.annotation.Nullable;
 
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.SetOptions;
+import com.google.firebase.firestore.Source;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -47,7 +48,7 @@ public class FirebaseAuthManager {
                     String email = authResult.getUser().getEmail();
 
                     FirebaseFirestore db = FirebaseFirestore.getInstance();
-                    db.collection("users").document(uid).get()
+                    db.collection("users").document(uid).get(Source.SERVER)
                             .addOnSuccessListener(doc -> {
                                 String existingNick = doc.getString("nickname");
                                 Map<String, Object> data = new HashMap<>();


### PR DESCRIPTION
## Summary
- Force Firestore to retrieve user data from the server during provider login

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e04d0b4d08330b2340bf01de96a88