### PR TITLE
style: adjust toolbar icon color

### DIFF
--- a/mobile/app/src/main/res/layout/activity_ranking.xml
+++ b/mobile/app/src/main/res/layout/activity_ranking.xml
@@ -11,6 +11,7 @@
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
         android:title="@string/ranking"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         app:titleTextColor="@color/colorWhite" />
 
     <LinearLayout


### PR DESCRIPTION
## Summary
- ensure ranking toolbar uses dark overlay so back arrow is white

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e05613204833094657373165f2939