### PR TITLE
Fix universal login toolbar title

### DIFF
--- a/mobile/app/src/main/res/layout/activity_universal_login.xml
+++ b/mobile/app/src/main/res/layout/activity_universal_login.xml
@@ -10,7 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
-        android:title="@string/login"
+        android:title="@string/account_information"
         app:titleTextColor="@color/colorWhite" />
 
     <LinearLayout


### PR DESCRIPTION
## Summary
- Show "Account information" on the universal login toolbar instead of the previous title

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e05c6effc8330bade125c30f360e2