### PR TITLE
Ensure toolbar back arrows are white

### DIFF
--- a/mobile/app/src/main/res/layout/activity_account.xml
+++ b/mobile/app/src/main/res/layout/activity_account.xml
@@ -10,6 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         android:title="@string/account_information"
         app:titleTextColor="@color/colorWhite" />
 

--- a/mobile/app/src/main/res/layout/activity_add_friend.xml
+++ b/mobile/app/src/main/res/layout/activity_add_friend.xml
@@ -10,6 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         android:title="@string/add_a_friend"
         app:titleTextColor="@color/colorWhite" />
 

--- a/mobile/app/src/main/res/layout/activity_friends_list.xml
+++ b/mobile/app/src/main/res/layout/activity_friends_list.xml
@@ -10,6 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         android:title="@string/invite_a_friend"
         app:titleTextColor="@color/colorWhite" />
 

--- a/mobile/app/src/main/res/layout/activity_invitations.xml
+++ b/mobile/app/src/main/res/layout/activity_invitations.xml
@@ -10,6 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         android:title="@string/pending_game_invitations"
         app:titleTextColor="@color/colorWhite" />
 

--- a/mobile/app/src/main/res/layout/activity_login.xml
+++ b/mobile/app/src/main/res/layout/activity_login.xml
@@ -8,6 +8,7 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         android:title="Login"
         app:titleTextColor="@color/colorWhite" />
 

--- a/mobile/app/src/main/res/layout/activity_menu.xml
+++ b/mobile/app/src/main/res/layout/activity_menu.xml
@@ -12,6 +12,7 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         android:title="@string/app_name"
         app:titleTextColor="@android:color/white" />
     <LinearLayout

--- a/mobile/app/src/main/res/layout/activity_register_account.xml
+++ b/mobile/app/src/main/res/layout/activity_register_account.xml
@@ -9,6 +9,7 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         android:title="Register new account"
         app:titleTextColor="@color/colorWhite" />
 

--- a/mobile/app/src/main/res/layout/activity_settings.xml
+++ b/mobile/app/src/main/res/layout/activity_settings.xml
@@ -10,6 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         android:popupTheme="@style/ThemeOverlay.AppCompat.Light"
         android:title="@string/settings"
         app:titleTextColor="@android:color/white" />

--- a/mobile/app/src/main/res/layout/activity_tournament_lobby.xml
+++ b/mobile/app/src/main/res/layout/activity_tournament_lobby.xml
@@ -12,6 +12,7 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         app:titleTextColor="@color/colorWhite" />
 
 

--- a/mobile/app/src/main/res/layout/activity_tournament_results.xml
+++ b/mobile/app/src/main/res/layout/activity_tournament_results.xml
@@ -10,6 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         app:titleTextColor="@color/colorWhite" />
 
     <LinearLayout

--- a/mobile/app/src/main/res/layout/activity_tournaments.xml
+++ b/mobile/app/src/main/res/layout/activity_tournaments.xml
@@ -10,6 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         android:title="@string/tournaments"
         app:titleTextColor="@color/colorWhite" />
 

--- a/mobile/app/src/main/res/layout/activity_universal_login.xml
+++ b/mobile/app/src/main/res/layout/activity_universal_login.xml
@@ -10,6 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         android:title="@string/account_information"
         app:titleTextColor="@color/colorWhite" />
 


### PR DESCRIPTION
## Summary
- Apply `ThemeOverlay.AppCompat.Dark.ActionBar` to all Toolbar layouts so back arrow icons display in white

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e0ad1bb088330ae914583f06322a3