### PR TITLE
Add terms of service page and link

### DIFF
--- a/firebase-hosting/public/index.html
+++ b/firebase-hosting/public/index.html
@@ -87,7 +87,8 @@
       </a>
     </div>
     
-    <a href="privacy.html" class="privacy-link">Privacy Policy</a>
+    <div><a href="privacy.html" class="privacy-link">Privacy Policy</a></div>
+    <div><a href="terms.html" class="privacy-link">Terms of Service</a></div>
   </div>
 </body>
 </html>

--- a/firebase-hosting/public/terms.html
+++ b/firebase-hosting/public/terms.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Terms of Service</title>
+  <style>
+    body { background:#ECEFF1; color:rgba(0,0,0,0.87); font-family:Roboto,Helvetica,Arial,sans-serif; margin:0; padding:0; }
+    #content { background:white; max-width:680px; margin:40px auto; padding:32px 24px; border-radius:3px; }
+    h1 { font-size:24px; font-weight:300; margin-top:0; }
+    h2 { font-size:18px; font-weight:bold; margin-bottom:8px; }
+    p { line-height:140%; margin:16px 0; font-size:14px; }
+    ul { margin:16px 0; padding-left:20px; font-size:14px; }
+  </style>
+</head>
+<body>
+  <div id="content">
+    <h1>Terms of Service</h1>
+    <p>Last Updated: 2025-07-30</p>
+
+    <h2>General</h2>
+    <p>This game is provided for general use and entertainment. By using the service you agree to these terms.</p>
+
+    <h2>Age Requirement</h2>
+    <p>Because the game displays advertisements, it is intended for users who are at least 13 years old.</p>
+
+    <h2>Privacy</h2>
+    <p>Details about how we handle data are described in our <a href="https://piotr-gorczynski.com/privacy.html">Privacy Policy</a>.</p>
+
+    <h2>Nickname Rules</h2>
+    <p>You must choose a nickname that will be visible to other players. If you do not want to reveal personal information, do not include it in your nickname. Nicknames must not:</p>
+    <ul>
+      <li>contain personal data such as real names, email addresses or contact details;</li>
+      <li>be vulgar, obscene or contain profanity;</li>
+      <li>promote hate or discrimination, including homophobia, racism or sexism;</li>
+      <li>harass, threaten or defame other people;</li>
+      <li>impersonate others or infringe on trademarks or copyrights;</li>
+      <li>advertise products or services, include spam or malicious content.</li>
+    </ul>
+
+    <h2>Disclaimer</h2>
+    <p>The service is provided "as is" without warranties of any kind. The developer is not responsible for any damages or losses resulting from the use of the game.</p>
+
+    <h2>Changes</h2>
+    <p>These terms may be updated from time to time. Continued use of the service constitutes acceptance of the revised terms.</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add Terms of Service page outlining app usage, age restrictions, nickname rules, and liability disclaimer.
- Link Terms of Service from the landing page.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e76f49e5083309ced2e6bae6fe9e3