### PR TITLE
Request ads consent after login

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -286,10 +286,14 @@ public class MenuActivity extends AppCompatActivity {
 
         // Ensure the FCM token is stored after login
         ((SoccerApp) getApplication()).syncFcmTokenIfNeeded();
-        
+
+        FirebaseAuth auth = FirebaseAuth.getInstance();
+        if (auth.getCurrentUser() != null && !hasAdsConsent()) {
+            ((SoccerApp) getApplication()).requestConsent(this);
+        }
+
         SharedPreferences prefs = getSharedPreferences(getPackageName() + "_preferences", MODE_PRIVATE);
         String nickname = prefs.getString("nickname", null);
-        FirebaseAuth auth = FirebaseAuth.getInstance();
         if (auth.getCurrentUser() == null) {
             prefs.edit().clear().apply();
 
@@ -382,7 +386,6 @@ public class MenuActivity extends AppCompatActivity {
 
         // Initialize backend service checker
         SoccerApp app = (SoccerApp) getApplication();
-        app.requestConsent(this);
         serviceChecker = app.getServiceChecker();
         
         // Get initial backend availability state from the app


### PR DESCRIPTION
## Summary
- Request ads consent on activity resume only when a user is logged in and no consent is recorded
- Remove automatic consent request on activity creation to avoid prompting before authentication

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e7967ebec8330b16cf8adf50c8c57