### PR TITLE
Add terms of service acceptance flow

### DIFF
--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -104,6 +104,10 @@
                 android:value=".MenuActivity"/>
         </activity>
 
+        <activity
+            android:name=".TermsActivity"
+            android:exported="false" />
+
         <service
             android:name=".notifications.MyFirebaseMessagingService"
             android:exported="false">

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -135,6 +135,25 @@ public class MenuActivity extends AppCompatActivity {
                 });
     }
 
+    private void ensureTermsAccepted(@NonNull String uid) {
+        FirebaseFirestore.getInstance()
+                .collection("users")
+                .document(uid)
+                .get()
+                .addOnSuccessListener(doc -> {
+                    if (FirebaseAuth.getInstance().getCurrentUser() == null) return;
+                    Boolean accepted = doc.getBoolean("termsAccepted");
+                    if (accepted == null || !accepted) {
+                        startActivity(new Intent(this, TermsActivity.class));
+                    }
+                })
+                .addOnFailureListener(e -> Log.e(
+                        "TAG_Soccer",
+                        getClass().getSimpleName() + ".ensureTermsAccepted: failed",
+                        e
+                ));
+    }
+
     /* ───────────── misc tasks that must always run on launch ───────────── */
     private void runHousekeeping() {
         String uid = FirebaseAuth.getInstance().getUid();
@@ -301,6 +320,7 @@ public class MenuActivity extends AppCompatActivity {
         } else {
             String uid = auth.getUid();
             if (uid != null) {
+                ensureTermsAccepted(uid);
                 Runnable pickNick = () -> {
                     if (FirebaseAuth.getInstance().getCurrentUser() != null) {
                         startActivity(new Intent(this, PickNicknameActivity.class));

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TermsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TermsActivity.java
@@ -1,0 +1,53 @@
+package piotr_gorczynski.soccer2;
+
+import android.os.Bundle;
+import android.widget.Button;
+import android.webkit.WebView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.firestore.FieldValue;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.SetOptions;
+
+import java.util.Map;
+
+public class TermsActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_terms);
+
+        WebView webView = findViewById(R.id.termsWebView);
+        webView.loadUrl("https://piotr-gorczynski.com/terms.html");
+
+        Button acceptBtn = findViewById(R.id.acceptTerms);
+        Button declineBtn = findViewById(R.id.declineTerms);
+
+        acceptBtn.setOnClickListener(v -> {
+            String uid = FirebaseAuth.getInstance().getUid();
+            if (uid == null) {
+                FirebaseAuth.getInstance().signOut();
+                finish();
+                return;
+            }
+            Map<String, Object> data = Map.of(
+                    "termsAccepted", true,
+                    "termsAcceptanceDate", FieldValue.serverTimestamp()
+            );
+            FirebaseFirestore.getInstance()
+                    .collection("users")
+                    .document(uid)
+                    .set(data, SetOptions.merge())
+                    .addOnSuccessListener(r -> finish())
+                    .addOnFailureListener(e -> Toast.makeText(this, e.getMessage(), Toast.LENGTH_LONG).show());
+        });
+
+        declineBtn.setOnClickListener(v -> {
+            FirebaseAuth.getInstance().signOut();
+            finish();
+        });
+    }
+}

--- a/mobile/app/src/main/res/layout/activity_terms.xml
+++ b/mobile/app/src/main/res/layout/activity_terms.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="20dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <WebView
+        android:id="@+id/termsWebView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <LinearLayout
+        android:orientation="horizontal"
+        android:gravity="end"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp">
+
+        <Button
+            android:id="@+id/declineTerms"
+            android:text="@string/decline"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <Button
+            android:id="@+id/acceptTerms"
+            android:text="@string/accept"
+            android:layout_marginStart="16dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add TermsActivity to display and handle Terms of Service acceptance
- check for acceptance on resume and prompt if missing
- register terms activity and layout

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e807fad28833090472bb9a15426f5