### PR TITLE
Fix nickname prompt on email login

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
@@ -130,8 +130,11 @@ public class FirebaseAuthManager {
 
                             if (isVerified) {
                                 FirebaseFirestore db = FirebaseFirestore.getInstance();
+                                // Always fetch the latest data directly from the server so that
+                                // a stale or missing cache entry doesn't cause us to miss an
+                                // existing nickname and prompt the user unnecessarily.
                                 db.collection("users").document(uid)
-                                        .get()
+                                        .get(Source.SERVER)
                                         .addOnSuccessListener(doc -> {
                                             String nickname = doc.getString("nickname");
                                             // Always record the login method as email when using this path


### PR DESCRIPTION
## Summary
- Ensure email login fetches user profile from Firestore server instead of cache

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688efde19358833083872c35110b8755