### PR TITLE
fix: white background for terms of service

### DIFF
--- a/mobile/app/src/main/res/layout/activity_terms.xml
+++ b/mobile/app/src/main/res/layout/activity_terms.xml
@@ -2,6 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:padding="20dp"
+    android:gravity="center"
+    android:background="@color/colorWhite"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 


### PR DESCRIPTION
## Summary
- match terms of service screen with regulation layout by centering contents and using a white background

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688efee899648330ae711a1dd5f19277