### PR TITLE
Defer ad consent prompt until after terms acceptance

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -145,6 +145,8 @@ public class MenuActivity extends AppCompatActivity {
                     Boolean accepted = doc.getBoolean("termsAccepted");
                     if (accepted == null || !accepted) {
                         startActivity(new Intent(this, TermsActivity.class));
+                    } else if (!hasAdsConsent()) {
+                        ((SoccerApp) getApplication()).requestConsent(this);
                     }
                 })
                 .addOnFailureListener(e -> Log.e(
@@ -307,9 +309,6 @@ public class MenuActivity extends AppCompatActivity {
         ((SoccerApp) getApplication()).syncFcmTokenIfNeeded();
 
         FirebaseAuth auth = FirebaseAuth.getInstance();
-        if (auth.getCurrentUser() != null && !hasAdsConsent()) {
-            ((SoccerApp) getApplication()).requestConsent(this);
-        }
 
         SharedPreferences prefs = getSharedPreferences(getPackageName() + "_preferences", MODE_PRIVATE);
         String nickname = prefs.getString("nickname", null);


### PR DESCRIPTION
## Summary
- Move ad consent prompt into `ensureTermsAccepted` so it only shows after terms accepted
- Remove premature ad consent request from `MenuActivity.onResume`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688efe8bfc348330a178bd3b35a4fb3d