### PR TITLE
docs: clarify nickname privacy guidance

### DIFF
--- a/firebase-hosting/public/terms.html
+++ b/firebase-hosting/public/terms.html
@@ -28,7 +28,9 @@
     <p>Details about how we handle data are described in our <a href="https://piotr-gorczynski.com/privacy.html">Privacy Policy</a>.</p>
 
     <h2>Nickname Rules</h2>
-    <p>You must choose a nickname that will be visible to other players. If you do not want to reveal personal information, do not include it in your nickname. Nicknames must not:</p>
+    <p>Users may select a nickname for use within the application. We strongly recommend that users do <strong>not</strong> use their full real name (i.e., first and last name) or any personally identifiable information as a nickname, in order to protect their privacy.</p>
+    <p>By creating a nickname, users agree not to impersonate other individuals, use offensive language, or violate the rights of others. We reserve the right to remove or restrict nicknames that we determine, in our sole discretion, to be inappropriate or in violation of these terms.</p>
+    <p>Nicknames must not:</p>
     <ul>
       <li>contain personal data such as real names, email addresses or contact details;</li>
       <li>be vulgar, obscene or contain profanity;</li>


### PR DESCRIPTION
## Summary
- advise users against using full real names or PII in nicknames
- clarify we may remove nicknames that violate the terms

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_688f09dad2f08330a84927b4c8857245