### PR TITLE
Show account deleted message for friend invites

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FriendsListActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FriendsListActivity.java
@@ -106,6 +106,7 @@ public class FriendsListActivity extends AppCompatActivity {
                                     case "sender_busy" -> R.string.invite_already_sent;
                                     /* target has its own outgoing invite and is waiting */
                                     case "target_busy" -> R.string.target_player_busy;
+                                    case "User account no longer available" -> R.string.account_no_longer_available;
                                     default -> R.string.failed_to_send_invite;
                                 };
                             }

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -63,6 +63,7 @@
     <string name="error_searching_user">Error searching user.</string>
     <string name="invitation_sent">Invitation sent!</string>
     <string name="failed_to_send_invite">Failed to send invite.</string>
+    <string name="account_no_longer_available">User account no longer available.</string>
     <string name="failed_to_add_friend">Failed to add friend.</string>
     <string name="failed_to_add_friend_reason">Failed to add friend: %1$s</string>
     <string name="failed_to_load_nickname">Failed to load nickname.</string>


### PR DESCRIPTION
## Summary
- Display a dedicated toast when the target account has been deleted instead of a generic invite failure
- Add `account_no_longer_available` string resource for the new message

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893babf19148330af46d90a19ed6952