### PR TITLE
feat: add remove account cloud function

### DIFF
--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -11,7 +11,7 @@
     {
       "source": "functions/clock-timeout",
       "codebase": "clock-timeout"
-    },    
+    },
     {
       "source": "functions/send-invite-notification",
       "codebase": "send-invite-notification"
@@ -81,6 +81,10 @@
     {
       "source": "functions/seed-service-status",
       "codebase": "seed-service-status"
+    },
+    {
+      "source": "functions/remove-account",
+      "codebase": "remove-account"
     }
   ],
   "firestore": {

--- a/firebase/functions/remove-account/index.js
+++ b/firebase/functions/remove-account/index.js
@@ -1,0 +1,37 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+admin.initializeApp();
+
+const db = admin.firestore();
+
+exports.removeAccount = functions
+  .region('us-central1')
+  .https.onCall(async (data, context) => {
+    const uid = context.auth?.uid;
+    if (!uid) {
+      throw new functions.https.HttpsError('unauthenticated', 'Login required');
+    }
+
+    try {
+      await admin.auth().deleteUser(uid);
+    } catch (err) {
+      console.error('removeAccount: auth deletion failed', err);
+      throw new functions.https.HttpsError('internal', 'auth-deletion-failed');
+    }
+
+    const updates = {
+      email: admin.firestore.FieldValue.delete(),
+      nickname: '(Account removed)',
+      nicknameLowercase: '(account removed)',
+      accountDeleted: true,
+    };
+
+    try {
+      await db.collection('users').doc(uid).update(updates);
+    } catch (err) {
+      console.error('removeAccount: firestore update failed', err);
+      throw new functions.https.HttpsError('internal', 'firestore-update-failed');
+    }
+
+    return { uid };
+  });

--- a/firebase/functions/remove-account/package.json
+++ b/firebase/functions/remove-account/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "remove-account",
+  "description": "Callable function to delete a user account and update Firestore user document.",
+  "version": "1.0.0",
+  "main": "index.js",
+  "engines": {
+    "node": "18"
+  },
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.5.0"
+  }
+}

--- a/gcp/cloud-build/deploy_remove_account.yaml
+++ b/gcp/cloud-build/deploy_remove_account.yaml
@@ -1,0 +1,109 @@
+substitutions:
+  _ENVIRONMENT: 'dev'
+  _FOLDER_NAME: 'soccer'
+
+steps:
+  # Step 1: Get Firebase project ID
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'get-project-id'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -e
+        echo "🔎 Finding project for ${_FOLDER_NAME}-${_ENVIRONMENT}..."
+        gcloud projects list \
+          --filter="name~^${_FOLDER_NAME}-${_ENVIRONMENT}" \
+          --format="value(projectId)" \
+          | head -n 1 > /workspace/FIREBASE_PROJECT_ID.txt
+
+        if [ ! -s /workspace/FIREBASE_PROJECT_ID.txt ]; then
+          echo "❌ Project ID not found!"
+          exit 1
+        fi
+
+  # Step 2: Install Firebase CLI
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'install-firebase-cli'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -e
+        echo "⬇️ Installing Firebase CLI..."
+        curl -sL https://firebase.tools | bash
+        mkdir -p /workspace/firebase
+        cp /usr/local/bin/firebase /workspace/firebase/
+        chmod +x /workspace/firebase/firebase
+        echo "✅ Firebase CLI installed."
+
+  # Step 3: Clone source code
+  - name: 'gcr.io/cloud-builders/git'
+    id: 'pull-files'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -ex
+        echo "📦 Cloning from the ${_ENVIRONMENT} branch..."
+        git clone -b ${_ENVIRONMENT} --single-branch https://github.com/piotr-gorczynski/Soccer.git /workspace/soccer
+
+        echo "📁 Copying Firestore config & remove-account function..."
+        cp /workspace/soccer/firebase/firebase.json /workspace/firebase/firebase.json
+        cp /workspace/soccer/firebase/firestore.rules /workspace/firebase/firestore.rules
+
+        mkdir -p /workspace/firebase/functions/remove-account
+        cp /workspace/soccer/firebase/functions/remove-account/package.json /workspace/firebase/functions/remove-account/
+        cp /workspace/soccer/firebase/functions/remove-account/index.js /workspace/firebase/functions/remove-account/
+
+  # Step 4: Install dependencies
+  - name: 'node:18-slim'
+    id: 'install-deps-remove-account'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -ex
+        cd /workspace/firebase/functions/remove-account
+        npm install
+        echo "📦 Dependencies installed."
+
+  # Step 5: Deploy function
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'deploy-remove-account'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -e
+        cd /workspace/firebase
+        project_id=$(cat /workspace/FIREBASE_PROJECT_ID.txt)
+
+        ./firebase deploy \
+          --only functions:remove-account \
+          --project="$project_id" \
+          --force
+
+        echo "✅ Function 'removeAccount' deployed successfully."
+
+  # Step 6: Add IAM policy binding to allow allUsers to invoke
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'bind-invoker-role'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -e
+        project_id=$(cat /workspace/FIREBASE_PROJECT_ID.txt)
+
+        echo "🔐 Granting invoker role to allUsers for 'removeAccount'..."
+        gcloud functions add-iam-policy-binding removeAccount \
+          --region=us-central1 \
+          --project="$project_id" \
+          --member="allUsers" \
+          --role="roles/cloudfunctions.invoker"
+
+        echo "✅ IAM policy binding applied."
+
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## Summary
- add callable `removeAccount` function to remove a user and update their Firestore doc
- register `remove-account` in Firebase config
- add Cloud Build script to deploy `remove-account` function

## Testing
- `npm test` (fails: Missing script "test")
- `cd firebase/functions/remove-account && npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6893c83cf8c48330a2bdfdd56ec7cfa8