### PR TITLE
docs: document account deletion

### DIFF
--- a/firebase-hosting/public/privacy.html
+++ b/firebase-hosting/public/privacy.html
@@ -39,6 +39,9 @@
     <h2>Your Choices</h2>
     <p>You may update or delete your account information by contacting us. You can opt out of personalized ads through your device settings.</p>
 
+    <h2>Account Deletion</h2>
+    <p>The app includes a built-in option to permanently remove your account. Open the account screen in the application, tap <em>Remove Account</em>, and follow the prompts to confirm deletion. This process is handled within the app's <code>AccountActivity</code> and will erase your account data from our systems.</p>
+
     <h2>Children's Privacy</h2>
     <p>The Service is not directed to children under 13. We do not knowingly collect personal data from children.</p>
 

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/AccountActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/AccountActivity.java
@@ -52,6 +52,9 @@ public class AccountActivity extends AppCompatActivity {
         methodView.setText(getString(R.string.login_method_label, method));
 
         logoutBtn.setOnClickListener(v -> performLogout());
+
+        // Allow users to remove their account through the in-app option.
+        // Tapping the button opens a confirmation dialog and triggers the deletion flow.
         removeAccountBtn.setOnClickListener(v -> showRemoveAccountDialog());
     }
 
@@ -97,6 +100,11 @@ public class AccountActivity extends AppCompatActivity {
         return true;
     }
 
+    /**
+     * Displays a confirmation dialog before permanently deleting the user's account.
+     * This method is invoked when the user selects the built-in "Remove Account" option
+     * described in the privacy policy.
+     */
     private void showRemoveAccountDialog() {
         new AlertDialog.Builder(this)
                 .setTitle(R.string.remove_account_dialog_title)


### PR DESCRIPTION
## Summary
- clarify account deletion process in privacy policy
- document in-app account removal flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd mobile && ./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68944b9fe16c83309c206677c0fc342e