### PR TITLE
Add debug logging for language selection and UI labels

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/LanguageSelectionActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/LanguageSelectionActivity.java
@@ -4,6 +4,7 @@ import android.app.AlertDialog;
 import android.content.Intent;
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
+import android.util.Log;
 
 public class LanguageSelectionActivity extends AppCompatActivity {
 
@@ -33,10 +34,19 @@ public class LanguageSelectionActivity extends AppCompatActivity {
             String[] nonLocalizedLanguages = LanguageManager.getAvailableLanguages();
             String selectedLanguage = nonLocalizedLanguages[which];
             String languageCode = LanguageManager.getLanguageCode(selectedLanguage);
-            
+
+            Log.d(
+                    "TAG_Soccer",
+                    getClass().getSimpleName()
+                            + ".showLanguageSelectionDialog: selectedLanguage="
+                            + selectedLanguage
+                            + ", code="
+                            + languageCode
+            );
+
             // Set the language
             LanguageManager.setLanguage(this, languageCode);
-            
+
             dialog.dismiss();
             proceedToMainActivity();
         });

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -100,7 +100,15 @@ public class MenuActivity extends AppCompatActivity {
                         if (local == null || !local.equals(remoteNick)) {
                             ed.putString("nickname", remoteNick);
                             TextView nicknameLabel = findViewById(R.id.nicknameLabel);
-                            nicknameLabel.setText(getString(R.string.hello_nickname, remoteNick));
+                            String labelText = getString(R.string.hello_nickname, remoteNick);
+                            nicknameLabel.setText(labelText);
+                            Log.d(
+                                    "TAG_Soccer",
+                                    getClass().getSimpleName()
+                                            + ".fetchNicknameFromFirestore: nicknameLabel=\""
+                                            + labelText
+                                            + "\""
+                            );
                         }
                         String localEmail = prefs.getString("email", null);
                         if (remoteEmail != null && (localEmail == null || !localEmail.equals(remoteEmail))) {
@@ -286,6 +294,13 @@ public class MenuActivity extends AppCompatActivity {
         TextView nicknameLabel = findViewById(R.id.nicknameLabel);
         if (nicknameLabel != null) {
             nicknameLabel.setText(getString(R.string.welcome_to_soccer));
+            Log.d(
+                    "TAG_Soccer",
+                    getClass().getSimpleName()
+                            + ".logoutUser: nicknameLabel=\""
+                            + nicknameLabel.getText()
+                            + "\""
+            );
         }
 
         updateUiForAuthState();
@@ -340,13 +355,29 @@ public class MenuActivity extends AppCompatActivity {
         }
 
         TextView nicknameLabel = findViewById(R.id.nicknameLabel);
+        String labelText;
         if (nickname != null && !nickname.isEmpty()) {
-            Log.d("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object() {
-            }.getClass().getEnclosingMethod()).getName() + ": Nickname: " + nickname);
-            nicknameLabel.setText(getString(R.string.hello_nickname, nickname));
+            Log.d(
+                    "TAG_Soccer",
+                    getClass().getSimpleName()
+                            + "."
+                            + Objects.requireNonNull(new Object() {
+                    }.getClass().getEnclosingMethod()).getName()
+                            + ": Nickname: "
+                            + nickname
+            );
+            labelText = getString(R.string.hello_nickname, nickname);
         } else {
-            nicknameLabel.setText(getString(R.string.welcome_to_soccer));
+            labelText = getString(R.string.welcome_to_soccer);
         }
+        nicknameLabel.setText(labelText);
+        Log.d(
+                "TAG_Soccer",
+                getClass().getSimpleName()
+                        + ".onResume: nicknameLabel=\""
+                        + labelText
+                        + "\""
+        );
         updateUiForAuthState();
         checkAndUpdateBlockedInviteWarning(); // Also check on resume
 

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
@@ -236,6 +236,13 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         String currentLanguage = LanguageManager.getCurrentLanguageName(requireContext());
         String summary = getString(R.string.current_language, currentLanguage);
         preference.setSummary(summary);
+        Log.d(
+                "TAG_Soccer",
+                getClass().getSimpleName()
+                        + ".updateLanguagePreferenceSummary: summary=\""
+                        + summary
+                        + "\""
+        );
     }
 
     private void showLanguageSelectionDialog() {


### PR DESCRIPTION
## Summary
- Log selected language and code in `LanguageSelectionActivity`
- Report current language label in `SettingsFragment`
- Trace `nicknameLabel` text updates throughout `MenuActivity`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68998d31ed948330ae25d0c09a11d381