### PR TITLE
Fix Settings toolbar caption localization

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsActivity.java
@@ -1,6 +1,7 @@
 package piotr_gorczynski.soccer2;
 
 import android.os.Bundle;
+import android.util.Log;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
@@ -16,6 +17,10 @@ public class SettingsActivity extends AppCompatActivity {
         Toolbar toolbar = findViewById(R.id.settings_toolbar);
         setSupportActionBar(toolbar);
         Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
+
+        String title = getString(R.string.settings);
+        Objects.requireNonNull(getSupportActionBar()).setTitle(title);
+        Log.d("TAG_Soccer", getClass().getSimpleName() + ".onCreate: toolbar title set to " + title);
 
         getSupportFragmentManager()
                 .beginTransaction()


### PR DESCRIPTION
## Summary
- Ensure SettingsActivity toolbar title uses current language and log the caption

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899b766e72c8330a63b400745440ffa