### PR TITLE
fix: terminate Firestore before clearing persistence

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -180,7 +180,9 @@ public class MenuActivity extends AppCompatActivity {
             prefs.edit().clear().apply();
             FirebaseMessaging.getInstance().deleteToken();
             FirebaseMessaging.getInstance().setAutoInitEnabled(false);
-            FirebaseFirestore.getInstance().clearPersistence();
+            FirebaseFirestore.getInstance()
+                    .terminate()
+                    .addOnSuccessListener(unused -> FirebaseFirestore.getInstance().clearPersistence());
             return;
         }
 
@@ -333,7 +335,9 @@ public class MenuActivity extends AppCompatActivity {
             FirebaseMessaging.getInstance().deleteToken();
             FirebaseMessaging.getInstance().setAutoInitEnabled(false);
 
-            FirebaseFirestore.getInstance().clearPersistence();
+            FirebaseFirestore.getInstance()
+                    .terminate()
+                    .addOnSuccessListener(unused -> FirebaseFirestore.getInstance().clearPersistence());
             nickname = null;
         } else {
             String uid = auth.getUid();

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -102,32 +102,50 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
         FirebaseFirestore db = FirebaseFirestore.getInstance();
 
         // 1️⃣  Wipe the local cache & cached rules once per cold start
-        db.clearPersistence().addOnCompleteListener(t -> {
-            if (!t.isSuccessful()) {
-                Log.w("TAG_Soccer", getClass().getSimpleName() + ".onCreate: clearPersistence failed", t.getException());
+        db.terminate().addOnCompleteListener(termTask -> {
+            Task<Void> clearTask;
+            if (termTask.isSuccessful()) {
+                clearTask = db.clearPersistence();
+            } else {
+                Log.w(
+                        "TAG_Soccer",
+                        getClass().getSimpleName() + ".onCreate: terminate failed",
+                        termTask.getException()
+                );
+                clearTask = Tasks.forResult(null);
             }
 
-            // 2️⃣  Now it’s safe to register listeners or use Firestore
-            ProcessLifecycleOwner.get()
-                    .getLifecycle()
-                    .addObserver(this);
+            clearTask.addOnCompleteListener(t -> {
+                if (!t.isSuccessful()) {
+                    Log.w(
+                            "TAG_Soccer",
+                            getClass().getSimpleName() + ".onCreate: clearPersistence failed",
+                            t.getException()
+                    );
+                }
 
-            FirebaseAuth auth = FirebaseAuth.getInstance();
-            auth.addAuthStateListener(a -> {
-                if (a.getCurrentUser() != null) {
-                    startPresence(a.getCurrentUser().getUid());
+                // 2️⃣  Now it’s safe to register listeners or use Firestore
+                ProcessLifecycleOwner.get()
+                        .getLifecycle()
+                        .addObserver(this);
+
+                FirebaseAuth auth = FirebaseAuth.getInstance();
+                auth.addAuthStateListener(a -> {
+                    if (a.getCurrentUser() != null) {
+                        startPresence(a.getCurrentUser().getUid());
+                        enableFcmAutoInit();
+                    } else {
+                        stopPresence();
+                        disableFcmAutoInit();
+                    }
+                });
+
+                // handle “already signed-in” on cold start
+                if (auth.getCurrentUser() != null) {
+                    startPresence(auth.getCurrentUser().getUid());
                     enableFcmAutoInit();
-                } else {
-                    stopPresence();
-                    disableFcmAutoInit();
                 }
             });
-
-            // handle “already signed-in” on cold start
-            if (auth.getCurrentUser() != null) {
-                startPresence(auth.getCurrentUser().getUid());
-                enableFcmAutoInit();
-            }
         });
 
         MobileAds.initialize(this, initializationStatus -> {});


### PR DESCRIPTION
## Summary
- terminate Firestore before calling clearPersistence in `SoccerApp`
- ensure Firestore is terminated before clearing persistence in `MenuActivity`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899be17ddac8330a431123fa99741ad