### PR TITLE
Fix language summary to respect current locale

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/LanguageManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/LanguageManager.java
@@ -17,18 +17,18 @@ public class LanguageManager {
     private static final String TAG = "LanguageManager";
     private static final String PREF_LANGUAGE_CODE = "language_code";
     
-    // Language code to display name mapping
-    private static final Map<String, String> LANGUAGE_NAMES = new HashMap<>();
+    // Language code to display name resource mapping
+    private static final Map<String, Integer> LANGUAGE_NAME_RES_IDS = new HashMap<>();
     static {
-        LANGUAGE_NAMES.put("en", "English");
-        LANGUAGE_NAMES.put("pl", "Polish");
-        LANGUAGE_NAMES.put("de", "German");
-        LANGUAGE_NAMES.put("fr", "French");
-        LANGUAGE_NAMES.put("es", "Spanish");
-        LANGUAGE_NAMES.put("ur", "Urdu");
-        LANGUAGE_NAMES.put("bn", "Bengali");
-        LANGUAGE_NAMES.put("ne", "Nepali");
-        LANGUAGE_NAMES.put("hi", "Hindi");
+        LANGUAGE_NAME_RES_IDS.put("en", R.string.language_english);
+        LANGUAGE_NAME_RES_IDS.put("pl", R.string.language_polish);
+        LANGUAGE_NAME_RES_IDS.put("de", R.string.language_german);
+        LANGUAGE_NAME_RES_IDS.put("fr", R.string.language_french);
+        LANGUAGE_NAME_RES_IDS.put("es", R.string.language_spanish);
+        LANGUAGE_NAME_RES_IDS.put("ur", R.string.language_urdu);
+        LANGUAGE_NAME_RES_IDS.put("bn", R.string.language_bengali);
+        LANGUAGE_NAME_RES_IDS.put("ne", R.string.language_nepali);
+        LANGUAGE_NAME_RES_IDS.put("hi", R.string.language_hindi);
     }
     
     // Language display name to code mapping
@@ -58,7 +58,8 @@ public class LanguageManager {
      */
     public static String getCurrentLanguageName(Context context) {
         String code = getCurrentLanguageCode(context);
-        return LANGUAGE_NAMES.getOrDefault(code, "English");
+        Integer resId = LANGUAGE_NAME_RES_IDS.get(code);
+        return context.getString(resId != null ? resId : R.string.language_english);
     }
     
     /**
@@ -161,7 +162,7 @@ public class LanguageManager {
                 .addOnSuccessListener(doc -> {
                     if (doc.exists() && doc.contains("language")) {
                         String languageCode = doc.getString("language");
-                        if (languageCode != null && LANGUAGE_NAMES.containsKey(languageCode)) {
+                        if (languageCode != null && LANGUAGE_NAME_RES_IDS.containsKey(languageCode)) {
                             // Update local preferences if different
                             String currentCode = getCurrentLanguageCode(context);
                             if (!currentCode.equals(languageCode)) {

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
@@ -247,13 +247,14 @@ public class SettingsFragment extends PreferenceFragmentCompat {
 
     private void showLanguageSelectionDialog() {
         String[] languages = LanguageManager.getAvailableLanguages(requireContext());
-        String currentLanguage = LanguageManager.getCurrentLanguageName(requireContext());
-        
+        String currentLanguageCode = LanguageManager.getCurrentLanguageCode(requireContext());
+
         // Find current selection index using non-localized names for consistent mapping
         String[] nonLocalizedLanguages = LanguageManager.getAvailableLanguages();
         int currentIndex = 0;
         for (int i = 0; i < nonLocalizedLanguages.length; i++) {
-            if (nonLocalizedLanguages[i].equals(currentLanguage)) {
+            String code = LanguageManager.getLanguageCode(nonLocalizedLanguages[i]);
+            if (code.equals(currentLanguageCode)) {
                 currentIndex = i;
                 break;
             }


### PR DESCRIPTION
## Summary
- Localize language names by mapping language codes to string resources
- Use language codes when determining current selection in settings dialog

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a30a11aa8833088001206e2e28947