### PR TITLE
Localize tournament status captions

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentAdapter.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentAdapter.java
@@ -11,6 +11,8 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
+import android.text.format.DateUtils;
+
 import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
@@ -110,8 +112,10 @@ public class TournamentAdapter
         if (isEndedMode) {
             // === Ended mode ===
             String endedWhen = endDL != null
-                    ? "Ended " + englishRelative(endDL.toDate().getTime())
-                    : "Ended";
+                    ? h.itemView.getContext().getString(
+                            R.string.tournament_ended,
+                            relativeTime(endDL.toDate().getTime()))
+                    : h.itemView.getContext().getString(R.string.tournament_ended_short);
             h.endsIn.setText(endedWhen);
 
             h.joinBtn.setEnabled(true);
@@ -127,8 +131,10 @@ public class TournamentAdapter
             // ① label: “Registration ends in …”
             long mLeft = Objects.requireNonNull(regDL).toDate().getTime() - System.currentTimeMillis();
             String endsText = (mLeft <= 0)
-                    ? "Registration closed. Tournament will start within 1 hour"
-                    : "Registration ends "+englishRelative(regDL.toDate().getTime());
+                    ? h.itemView.getContext().getString(R.string.registration_closed)
+                    : h.itemView.getContext().getString(
+                            R.string.registration_ends,
+                            relativeTime(regDL.toDate().getTime()));
             h.endsIn.setText(endsText);
 
             // ② buttons: Join & Leave
@@ -184,9 +190,10 @@ public class TournamentAdapter
                         + ": mLeft (ms): " + mLeft);
             }
             String endsText = (mLeft <= 0)
-                    ? "Tournament ends now..."
-                    : "Tournament running. Ends " + englishRelative(
-                    endDL.toDate().getTime());
+                    ? h.itemView.getContext().getString(R.string.tournament_ends_now)
+                    : h.itemView.getContext().getString(
+                            R.string.tournament_running_ends,
+                            relativeTime(endDL.toDate().getTime()));
 
             h.endsIn.setText(endsText);
             h.notRegistered.setVisibility(View.GONE);
@@ -233,35 +240,12 @@ public class TournamentAdapter
     @Override
     public int getItemCount() { return data.size(); }
 
-    /** Absolute, English-only relative time. Works for past & future moments. */
-    public static String englishRelative(long targetTimeMillis) {
-
-        final long NOW  = System.currentTimeMillis();
-        long diff       = targetTimeMillis - NOW;      // + => future, – => past
-
-        final long MIN  = 60_000L;
-        final long HOUR = 60 * MIN;
-        final long DAY  = 24 * HOUR;
-
-        // ── “just now / in a moment” ───────────────────────────────
-        if (Math.abs(diff) < MIN) {
-            return diff >= 0 ? "in a moment" : "just now";
-        }
-
-        // ── FUTURE (“in …”) ────────────────────────────────────────
-        if (diff > 0) {
-            if (diff < HOUR)  { long m = diff / MIN;  return "in " + m + " min" + (m == 1 ? "" : "s"); }
-            if (diff < DAY)   { long h = diff / HOUR; return "in " + h + " h"; }
-            if (diff < 2*DAY) { return "tomorrow"; }
-            long d = diff / DAY;                       return "in " + d + " days";
-        }
-
-        // ── PAST (“… ago”) ─────────────────────────────────────────
-        diff = -diff;                                 // make positive
-        if (diff < HOUR)  { long m = diff / MIN;  return m + " min" + (m == 1 ? "" : "s") + " ago"; }
-        if (diff < DAY)   { long h = diff / HOUR; return h + " h ago"; }
-        if (diff < 2*DAY) { return "yesterday"; }
-        long d = diff / DAY;                          return d + " days ago";
+    private static String relativeTime(long targetTimeMillis) {
+        return DateUtils.getRelativeTimeSpanString(
+                targetTimeMillis,
+                System.currentTimeMillis(),
+                DateUtils.MINUTE_IN_MILLIS,
+                DateUtils.FORMAT_ABBREV_RELATIVE
+        ).toString();
     }
-
 }

--- a/mobile/app/src/main/res/values-bn/strings.xml
+++ b/mobile/app/src/main/res/values-bn/strings.xml
@@ -105,6 +105,12 @@
     <string name="running">চলমান…</string>
     <string name="registering">নিবন্ধন করা হচ্ছে…</string>
     <string name="view_results">ফলাফল দেখুন</string>
+    <string name="tournament_running_ends">টুর্নামেন্ট চলছে। %1$s শেষ হবে</string>
+    <string name="registration_ends">নিবন্ধন %1$s শেষ হবে</string>
+    <string name="registration_closed">নিবন্ধন বন্ধ। টুর্নামেন্ট ১ ঘন্টার মধ্যে শুরু হবে</string>
+    <string name="tournament_ends_now">টুর্নামেন্ট এখন শেষ হচ্ছে...</string>
+    <string name="tournament_ended">%1$s আগে শেষ হয়েছে</string>
+    <string name="tournament_ended_short">শেষ হয়েছে</string>
     <string name="logout">লগ আউট</string>
     <string name="logged_out">আপনি লগ আউট হয়েছেন</string>
     

--- a/mobile/app/src/main/res/values-de/strings.xml
+++ b/mobile/app/src/main/res/values-de/strings.xml
@@ -105,6 +105,12 @@
     <string name="running">Läuft…</string>
     <string name="registering">Registrierung…</string>
     <string name="view_results">Ergebnisse anzeigen</string>
+    <string name="tournament_running_ends">Turnier läuft. Endet %1$s</string>
+    <string name="registration_ends">Registrierung endet %1$s</string>
+    <string name="registration_closed">Registrierung geschlossen. Turnier beginnt innerhalb einer Stunde</string>
+    <string name="tournament_ends_now">Turnier endet jetzt...</string>
+    <string name="tournament_ended">Beendet %1$s</string>
+    <string name="tournament_ended_short">Beendet</string>
     <string name="logout">Abmelden</string>
     <string name="logged_out">Sie wurden abgemeldet</string>
     

--- a/mobile/app/src/main/res/values-es/strings.xml
+++ b/mobile/app/src/main/res/values-es/strings.xml
@@ -105,6 +105,12 @@
     <string name="running">En curso…</string>
     <string name="registering">Registrándose…</string>
     <string name="view_results">Ver resultados</string>
+    <string name="tournament_running_ends">Torneo en curso. Termina %1$s</string>
+    <string name="registration_ends">La inscripción termina %1$s</string>
+    <string name="registration_closed">Inscripción cerrada. El torneo comenzará en 1 hora</string>
+    <string name="tournament_ends_now">El torneo termina ahora...</string>
+    <string name="tournament_ended">Terminado %1$s</string>
+    <string name="tournament_ended_short">Terminado</string>
     <string name="logout">Cerrar sesión</string>
     <string name="logged_out">Has cerrado sesión</string>
     

--- a/mobile/app/src/main/res/values-fr/strings.xml
+++ b/mobile/app/src/main/res/values-fr/strings.xml
@@ -105,6 +105,12 @@
     <string name="running">En cours…</string>
     <string name="registering">Inscription…</string>
     <string name="view_results">Voir les résultats</string>
+    <string name="tournament_running_ends">Tournoi en cours. Se termine %1$s</string>
+    <string name="registration_ends">Les inscriptions se terminent %1$s</string>
+    <string name="registration_closed">Inscriptions closes. Le tournoi commencera dans une heure</string>
+    <string name="tournament_ends_now">Le tournoi se termine maintenant...</string>
+    <string name="tournament_ended">Terminé %1$s</string>
+    <string name="tournament_ended_short">Terminé</string>
     <string name="logout">Se déconnecter</string>
     <string name="logged_out">Vous avez été déconnecté</string>
     

--- a/mobile/app/src/main/res/values-hi/strings.xml
+++ b/mobile/app/src/main/res/values-hi/strings.xml
@@ -105,6 +105,12 @@
     <string name="running">चल रहा…</string>
     <string name="registering">पंजीकरण कर रहे हैं…</string>
     <string name="view_results">परिणाम देखें</string>
+    <string name="tournament_running_ends">टूर्नामेंट जारी है। %1$s समाप्त होगा</string>
+    <string name="registration_ends">पंजीकरण %1$s समाप्त होगा</string>
+    <string name="registration_closed">पंजीकरण बंद। टूर्नामेंट 1 घंटे के भीतर शुरू होगा</string>
+    <string name="tournament_ends_now">टूर्नामेंट अभी समाप्त हो रहा है...</string>
+    <string name="tournament_ended">%1$s समाप्त हुआ</string>
+    <string name="tournament_ended_short">समाप्त</string>
     <string name="logout">लॉग आउट</string>
     <string name="logged_out">आप लॉग आउट हो गए हैं</string>
     

--- a/mobile/app/src/main/res/values-ne/strings.xml
+++ b/mobile/app/src/main/res/values-ne/strings.xml
@@ -105,6 +105,12 @@
     <string name="running">चलिरहेको…</string>
     <string name="registering">दर्ता गर्दै…</string>
     <string name="view_results">परिणामहरू हेर्नुहोस्</string>
+    <string name="tournament_running_ends">टूर्नामेन्ट चलिरहेको छ। %1$s समाप्त हुन्छ</string>
+    <string name="registration_ends">दर्ता %1$s समाप्त हुन्छ</string>
+    <string name="registration_closed">दर्ता बन्द। टूर्नामेन्ट १ घण्टाभित्र सुरु हुनेछ</string>
+    <string name="tournament_ends_now">टूर्नामेन्ट अहिले समाप्त हुँदैछ...</string>
+    <string name="tournament_ended">%1$s समाप्त भयो</string>
+    <string name="tournament_ended_short">समाप्त भयो</string>
     <string name="logout">लग आउट</string>
     <string name="logged_out">तपाईं लग आउट हुनुभयो</string>
     

--- a/mobile/app/src/main/res/values-pl/strings.xml
+++ b/mobile/app/src/main/res/values-pl/strings.xml
@@ -105,6 +105,12 @@
     <string name="running">W trakcie…</string>
     <string name="registering">Rejestrowanie…</string>
     <string name="view_results">Zobacz wyniki</string>
+    <string name="tournament_running_ends">Turniej trwa. Zakończy się %1$s</string>
+    <string name="registration_ends">Rejestracja kończy się %1$s</string>
+    <string name="registration_closed">Rejestracja zakończona. Turniej rozpocznie się w ciągu 1 godziny</string>
+    <string name="tournament_ends_now">Turniej kończy się teraz...</string>
+    <string name="tournament_ended">Zakończono %1$s</string>
+    <string name="tournament_ended_short">Zakończono</string>
     <string name="logout">Wyloguj się</string>
     <string name="logged_out">Zostałeś wylogowany</string>
     

--- a/mobile/app/src/main/res/values-ur/strings.xml
+++ b/mobile/app/src/main/res/values-ur/strings.xml
@@ -105,6 +105,12 @@
     <string name="running">جاری…</string>
     <string name="registering">رجسٹر کر رہے ہیں…</string>
     <string name="view_results">نتائج دیکھیں</string>
+    <string name="tournament_running_ends">ٹورنامنٹ جاری ہے۔ %1$s ختم ہوگا</string>
+    <string name="registration_ends">رجسٹریشن %1$s ختم ہوگی</string>
+    <string name="registration_closed">رجسٹریشن بند ہے۔ ٹورنامنٹ 1 گھنٹے کے اندر شروع ہوگا</string>
+    <string name="tournament_ends_now">ٹورنامنٹ ابھی ختم ہو رہا ہے...</string>
+    <string name="tournament_ended">%1$s ختم ہوا</string>
+    <string name="tournament_ended_short">ختم ہوا</string>
     <string name="logout">لاگ آؤٹ</string>
     <string name="logged_out">آپ لاگ آؤٹ ہو گئے ہیں</string>
     

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -94,6 +94,12 @@
     <string name="running">Running…</string>
     <string name="registering">Registering…</string>
     <string name="view_results">View Results</string>
+    <string name="tournament_running_ends">Tournament running. Ends %1$s</string>
+    <string name="registration_ends">Registration ends %1$s</string>
+    <string name="registration_closed">Registration closed. Tournament will start within 1 hour</string>
+    <string name="tournament_ends_now">Tournament ends now...</string>
+    <string name="tournament_ended">Ended %1$s</string>
+    <string name="tournament_ended_short">Ended</string>
     <string name="logout">Log out</string>
     <string name="logged_out">You’ve been logged out</string>
     <plurals name="wins_format">


### PR DESCRIPTION
## Summary
- externalize tournament status captions and wire them to Android string resources
- translate new captions for English, Polish, German, French, Spanish, Urdu, Bengali, Nepali and Hindi

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a363a9ee4833088064867d982d2c1