### PR TITLE
Ensure language changes persist after recreation

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/LanguageManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/LanguageManager.java
@@ -100,11 +100,16 @@ public class LanguageManager {
         Locale.setDefault(locale);
 
         Resources res = context.getResources();
-        Configuration config = res.getConfiguration();
+        Configuration config = new Configuration(res.getConfiguration());
         config.setLocale(locale);
+
+        // Update the resources of the current context so that any views using it
+        // immediately reflect the new locale.
         res.updateConfiguration(config, res.getDisplayMetrics());
 
-        return context;
+        // Return a context with the updated configuration. This is particularly
+        // important when attaching a base context for a newly created activity.
+        return context.createConfigurationContext(config);
     }
     
     /**


### PR DESCRIPTION
## Summary
- ensure `applyLanguage` returns a configuration-wrapped context so new activities use the selected locale

## Testing
- `./gradlew test` *(fails: build-tools;35.0.0 and platforms;android-36 not installed or licenses not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_689a3afe6ec08330ab80151a3ab09937