### PR TITLE
Refactor deprecated configuration update

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/LanguageManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/LanguageManager.java
@@ -103,10 +103,6 @@ public class LanguageManager {
         Configuration config = new Configuration(res.getConfiguration());
         config.setLocale(locale);
 
-        // Update the resources of the current context so that any views using it
-        // immediately reflect the new locale.
-        res.updateConfiguration(config, res.getDisplayMetrics());
-
         // Return a context with the updated configuration. This is particularly
         // important when attaching a base context for a newly created activity.
         return context.createConfigurationContext(config);


### PR DESCRIPTION
## Summary
- remove deprecated `updateConfiguration` call from `LanguageManager`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a567e60448330a05ef6a4515e10f1