### PR TITLE
Localize Field draw strings

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -38,6 +38,7 @@ public class Field {
     private final String sPlayer0;
     private final String sPlayer1;
     private final int gameType;
+    private final Context context;
     final ArrayList<MoveTo> possibleMoves;//= new ArrayList<MoveTo>();
     final ArrayList<MoveTo> Moves;//= new ArrayList<MoveTo>();
     private boolean isFlipped=false;
@@ -58,6 +59,7 @@ public class Field {
                 + ", localPlayerIndex=" + localPlayerIndex);
 
         this.gameType = argGameType;  // ✅ Save GameType for later use
+        this.context = current;
 
         switch (argGameType) {
             case 1 -> {
@@ -369,14 +371,14 @@ public class Field {
 
         if (isLocalTurn) {
             if (gameType != 3) {
-                textBottom = "Your move!";
+                textBottom = context.getString(R.string.field_your_move);
             } else {
 
                 textBottom = fitNameInBanner(localName,
-                        " move ... ⏳ " + localTime,
+                        " " + context.getString(R.string.field_move_tail, localTime),
                         pHintText, bannerWidthPx);
                 textTop = fitNameInBanner(opponentName,
-                        " ⏳ " + oponentTime,
+                        " " + context.getString(R.string.field_hourglass_tail, oponentTime),
                         pHintText, bannerWidthPx);
 
                 pHintText.getTextBounds(textTop, 0, textTop.length(), rText);
@@ -396,24 +398,24 @@ public class Field {
 
         } else {
             if (gameType == 1) {
-                textTop = "Your move...";  // could be improved, but likely shared screen
+                textTop = context.getString(R.string.field_your_move_ellipsis);  // could be improved, but likely shared screen
             } else if (gameType == 2) {
-                textTop = "Thinking...";
+                textTop = context.getString(R.string.field_thinking);
             } else  {
                 // Multiplayer: determine which name is the opponent
 
 
                 if (turnStartTime != null) {
                     textTop = fitNameInBanner(opponentName,
-                            " move... ⏳ " + oponentTime,
+                            " " + context.getString(R.string.field_move_ellipsis_tail, oponentTime),
                             pHintText, bannerWidthPx);
                 } else {
-                    textTop = fitNameInBanner("Waiting for " + opponentName,
-                            " to start... ⏳ " + oponentTime,
+                    textTop = fitNameInBanner(context.getString(R.string.field_waiting_for, opponentName),
+                            " " + context.getString(R.string.field_to_start_tail, oponentTime),
                             pHintText, bannerWidthPx);
                 }
                 textBottom = fitNameInBanner(localName,
-                        " ⏳ " + localTime,
+                        " " + context.getString(R.string.field_hourglass_tail, localTime),
                         pHintText, bannerWidthPx);
 
                 pHintText.getTextBounds(textBottom, 0, textBottom.length(), rText);

--- a/mobile/app/src/main/res/values-bn/strings.xml
+++ b/mobile/app/src/main/res/values-bn/strings.xml
@@ -175,6 +175,16 @@
     
     <!-- Common strings -->
     <string name="settings">সেটিংস</string>
-    <string name="cancel">বাতিল করুন</string>
-    <string name="confirm">নিশ্চিত করুন</string>
+   <string name="cancel">বাতিল করুন</string>
+   <string name="confirm">নিশ্চিত করুন</string>
+
+    <!-- Field draw strings -->
+    <string name="field_your_move">আপনার চাল!</string>
+    <string name="field_move_tail">চাল ... ⏳ %1$s</string>
+    <string name="field_hourglass_tail">⏳ %1$s</string>
+    <string name="field_your_move_ellipsis">আপনার চাল...</string>
+    <string name="field_thinking">ভাবছে...</string>
+    <string name="field_move_ellipsis_tail">চাল... ⏳ %1$s</string>
+    <string name="field_waiting_for">%1$s-এর জন্য অপেক্ষা</string>
+    <string name="field_to_start_tail">শুরু করার জন্য... ⏳ %1$s</string>
 </resources>

--- a/mobile/app/src/main/res/values-de/strings.xml
+++ b/mobile/app/src/main/res/values-de/strings.xml
@@ -177,4 +177,14 @@
     <string name="settings">Einstellungen</string>
     <string name="cancel">Abbrechen</string>
     <string name="confirm">Bestätigen</string>
+
+    <!-- Field draw strings -->
+    <string name="field_your_move">Du bist dran!</string>
+    <string name="field_move_tail">ist am Zug ... ⏳ %1$s</string>
+    <string name="field_hourglass_tail">⏳ %1$s</string>
+    <string name="field_your_move_ellipsis">Du bist dran...</string>
+    <string name="field_thinking">Denkt nach...</string>
+    <string name="field_move_ellipsis_tail">ist am Zug... ⏳ %1$s</string>
+    <string name="field_waiting_for">Warte auf %1$s</string>
+    <string name="field_to_start_tail">um zu starten... ⏳ %1$s</string>
 </resources>

--- a/mobile/app/src/main/res/values-es/strings.xml
+++ b/mobile/app/src/main/res/values-es/strings.xml
@@ -177,4 +177,14 @@
     <string name="settings">Configuración</string>
     <string name="cancel">Cancelar</string>
     <string name="confirm">Confirmar</string>
+
+    <!-- Field draw strings -->
+    <string name="field_your_move">¡Tu turno!</string>
+    <string name="field_move_tail">mueve ... ⏳ %1$s</string>
+    <string name="field_hourglass_tail">⏳ %1$s</string>
+    <string name="field_your_move_ellipsis">Tu turno...</string>
+    <string name="field_thinking">Pensando...</string>
+    <string name="field_move_ellipsis_tail">mueve... ⏳ %1$s</string>
+    <string name="field_waiting_for">Esperando a %1$s</string>
+    <string name="field_to_start_tail">para empezar... ⏳ %1$s</string>
 </resources>

--- a/mobile/app/src/main/res/values-fr/strings.xml
+++ b/mobile/app/src/main/res/values-fr/strings.xml
@@ -177,4 +177,14 @@
     <string name="settings">Paramètres</string>
     <string name="cancel">Annuler</string>
     <string name="confirm">Confirmer</string>
+
+    <!-- Field draw strings -->
+    <string name="field_your_move">À vous de jouer !</string>
+    <string name="field_move_tail">joue ... ⏳ %1$s</string>
+    <string name="field_hourglass_tail">⏳ %1$s</string>
+    <string name="field_your_move_ellipsis">À vous de jouer...</string>
+    <string name="field_thinking">Réflexion...</string>
+    <string name="field_move_ellipsis_tail">joue... ⏳ %1$s</string>
+    <string name="field_waiting_for">En attente de %1$s</string>
+    <string name="field_to_start_tail">pour commencer... ⏳ %1$s</string>
 </resources>

--- a/mobile/app/src/main/res/values-hi/strings.xml
+++ b/mobile/app/src/main/res/values-hi/strings.xml
@@ -177,4 +177,14 @@
     <string name="settings">सेटिंग्स</string>
     <string name="cancel">रद्द करें</string>
     <string name="confirm">पुष्टि करें</string>
+
+    <!-- Field draw strings -->
+    <string name="field_your_move">आपकी चाल!</string>
+    <string name="field_move_tail">चाल ... ⏳ %1$s</string>
+    <string name="field_hourglass_tail">⏳ %1$s</string>
+    <string name="field_your_move_ellipsis">आपकी चाल...</string>
+    <string name="field_thinking">सोच रहा है...</string>
+    <string name="field_move_ellipsis_tail">चाल... ⏳ %1$s</string>
+    <string name="field_waiting_for">%1$s की प्रतीक्षा</string>
+    <string name="field_to_start_tail">शुरू करने के लिए... ⏳ %1$s</string>
 </resources>

--- a/mobile/app/src/main/res/values-ne/strings.xml
+++ b/mobile/app/src/main/res/values-ne/strings.xml
@@ -177,4 +177,14 @@
     <string name="settings">सेटिङहरू</string>
     <string name="cancel">रद्द गर्नुहोस्</string>
     <string name="confirm">पुष्टि गर्नुहोस्</string>
+
+    <!-- Field draw strings -->
+    <string name="field_your_move">तपाईंको चाल!</string>
+    <string name="field_move_tail">चाल ... ⏳ %1$s</string>
+    <string name="field_hourglass_tail">⏳ %1$s</string>
+    <string name="field_your_move_ellipsis">तपाईंको चाल...</string>
+    <string name="field_thinking">सोच्दै...</string>
+    <string name="field_move_ellipsis_tail">चाल... ⏳ %1$s</string>
+    <string name="field_waiting_for">%1$s को प्रतीक्षा</string>
+    <string name="field_to_start_tail">सुरु गर्न... ⏳ %1$s</string>
 </resources>

--- a/mobile/app/src/main/res/values-pl/strings.xml
+++ b/mobile/app/src/main/res/values-pl/strings.xml
@@ -178,4 +178,14 @@
     <string name="settings">Ustawienia</string>
     <string name="cancel">Anuluj</string>
     <string name="confirm">Potwierdź</string>
+
+    <!-- Field draw strings -->
+    <string name="field_your_move">Twój ruch!</string>
+    <string name="field_move_tail">rusza ... ⏳ %1$s</string>
+    <string name="field_hourglass_tail">⏳ %1$s</string>
+    <string name="field_your_move_ellipsis">Twój ruch...</string>
+    <string name="field_thinking">Myśli...</string>
+    <string name="field_move_ellipsis_tail">rusza... ⏳ %1$s</string>
+    <string name="field_waiting_for">Czekanie na %1$s</string>
+    <string name="field_to_start_tail">aby rozpocząć... ⏳ %1$s</string>
 </resources>

--- a/mobile/app/src/main/res/values-ur/strings.xml
+++ b/mobile/app/src/main/res/values-ur/strings.xml
@@ -177,4 +177,14 @@
     <string name="settings">سیٹنگز</string>
     <string name="cancel">منسوخ کریں</string>
     <string name="confirm">تصدیق کریں</string>
+
+    <!-- Field draw strings -->
+    <string name="field_your_move">آپ کی باری!</string>
+    <string name="field_move_tail">چلے ... ⏳ %1$s</string>
+    <string name="field_hourglass_tail">⏳ %1$s</string>
+    <string name="field_your_move_ellipsis">آپ کی باری...</string>
+    <string name="field_thinking">سوچ رہا ہے...</string>
+    <string name="field_move_ellipsis_tail">چلے... ⏳ %1$s</string>
+    <string name="field_waiting_for">%1$s کا انتظار</string>
+    <string name="field_to_start_tail">شروع کرنے کے لیے... ⏳ %1$s</string>
 </resources>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -171,4 +171,14 @@
     <string name="language_bengali">Bengali</string>
     <string name="language_nepali">Nepali</string>
     <string name="language_hindi">Hindi</string>
+
+    <!-- Field draw strings -->
+    <string name="field_your_move">Your move!</string>
+    <string name="field_move_tail">move ... ⏳ %1$s</string>
+    <string name="field_hourglass_tail">⏳ %1$s</string>
+    <string name="field_your_move_ellipsis">Your move...</string>
+    <string name="field_thinking">Thinking...</string>
+    <string name="field_move_ellipsis_tail">move... ⏳ %1$s</string>
+    <string name="field_waiting_for">Waiting for %1$s</string>
+    <string name="field_to_start_tail">to start... ⏳ %1$s</string>
 </resources>


### PR DESCRIPTION
## Summary
- Pull user-facing text from `Field.draw` into string resources
- Translate new strings across supported locales
- Store context in `Field` for resource access

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a5ad6f9f083308a0de4b75e56e229