### PR TITLE
Preserve language preference for logged-out users

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -177,7 +177,11 @@ public class MenuActivity extends BaseActivity {
                             }.getClass().getEnclosingMethod()).getName()
                             + ": ⚠️ No logged-in user; clearing stored credentials"
             );
-            prefs.edit().clear().apply();
+            String languageCode = LanguageManager.getCurrentLanguageCode(this);
+            SharedPreferences.Editor ed = prefs.edit();
+            ed.clear();
+            ed.putString("language_code", languageCode);
+            ed.apply();
             FirebaseMessaging.getInstance().deleteToken();
             FirebaseMessaging.getInstance().setAutoInitEnabled(false);
             FirebaseFirestore.getInstance()


### PR DESCRIPTION
## Summary
- Keep selected language when no user is logged in by preserving `language_code` preference

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a664efc6c8330a679fc8527c996c8