### PR TITLE
Fix language preference reverting to English in settings

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/LanguageManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/LanguageManager.java
@@ -68,7 +68,9 @@ public class LanguageManager {
     public static void setLanguage(Context context, String languageCode) {
         // Save to SharedPreferences
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        prefs.edit().putString(PREF_LANGUAGE_CODE, languageCode).apply();
+        // Use commit() so that subsequent reads from other SharedPreferences instances
+        // (e.g. in MenuActivity.runHousekeeping) immediately observe the updated value.
+        prefs.edit().putString(PREF_LANGUAGE_CODE, languageCode).commit();
         
         // Save to Firestore if user is logged in
         String uid = FirebaseAuth.getInstance().getUid();


### PR DESCRIPTION
## Summary
- Persist selected language synchronously to ensure later reads get the updated value

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b767a065c8330bbcb4b5fb9e0a8a8