### PR TITLE
Use consistent TAG_Soccer for logging

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/GameActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/GameActivity.java
@@ -131,7 +131,7 @@ public class GameActivity extends BaseActivity {
         @Override
         public void uncaughtException(Thread thread, Throwable throwable) {
             // 🔹 Your custom logic here (e.g., logging to file)
-            Log.e("ExceptionHandler", "Uncaught exception", throwable);
+            Log.e("TAG_Soccer", "Uncaught exception", throwable);
 
             // 🔹 Call the original handler (important!)
             if (existingHandler != null) {

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/LanguageManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/LanguageManager.java
@@ -14,7 +14,8 @@ import java.util.Map;
 
 public class LanguageManager {
     
-    private static final String TAG = "LanguageManager";
+    // Use the same tag throughout the app for consistent Logcat filtering
+    private static final String TAG = "TAG_Soccer";
     private static final String PREF_LANGUAGE_CODE = "language_code";
     
     // Language code to display name resource mapping

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TermsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TermsActivity.java
@@ -23,7 +23,7 @@ public class TermsActivity extends BaseActivity {
         WebView webView = findViewById(R.id.termsWebView);
         String langCode = LanguageManager.getCurrentLanguageCode(this);
         String url = "https://piotr-gorczynski.com/terms-" + langCode + ".html";
-        Log.d("TermsActivity", "Loading terms from URL: " + url);
+        Log.d("TAG_Soccer", "Loading terms from URL: " + url);
         webView.loadUrl(url);
 
         Button acceptBtn = findViewById(R.id.acceptTerms);


### PR DESCRIPTION
## Summary
- Standardize all Android log statements on the `TAG_Soccer` tag
- Replace remaining custom tags in TermsActivity, GameActivity, and LanguageManager

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b7fcbe0d08330a72204572bc0aa2a