### PR TITLE
Centralize language preferences and apply locale immediately

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/AccountActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/AccountActivity.java
@@ -38,12 +38,11 @@ public class AccountActivity extends BaseActivity {
         Button logoutBtn = findViewById(R.id.btnLogout);
         Button removeAccountBtn = findViewById(R.id.btnRemoveAccount);
 
-        String prefsName = getPackageName() + "_preferences";
-        String nickname = getSharedPreferences(prefsName, MODE_PRIVATE)
+        String nickname = getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE)
                 .getString("nickname", "-");
-        String email = getSharedPreferences(prefsName, MODE_PRIVATE)
+        String email = getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE)
                 .getString("email", "-");
-        String method = getSharedPreferences(prefsName, MODE_PRIVATE)
+        String method = getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE)
                 .getString("method", "-");
 
         nickView.setText(getString(R.string.nickname_label, nickname));
@@ -72,8 +71,7 @@ public class AccountActivity extends BaseActivity {
     }
 
     private void finishLogoutUi() {
-        String prefsName = getPackageName() + "_preferences";
-        getSharedPreferences(prefsName, MODE_PRIVATE)
+        getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE)
                 .edit()
                 .remove("fcmToken") // ensure FCM token is wiped
                 .clear()
@@ -188,8 +186,7 @@ public class AccountActivity extends BaseActivity {
         FirebaseAuth.getInstance().signOut();
 
         // Clear local preferences
-        String prefsName = getPackageName() + "_preferences";
-        getSharedPreferences(prefsName, MODE_PRIVATE)
+        getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE)
                 .edit()
                 .clear()
                 .apply();

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/BackendServiceChecker.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/BackendServiceChecker.java
@@ -196,8 +196,8 @@ public class BackendServiceChecker {
             return projectId;
         }
 
-        SharedPreferences prefs = context.getSharedPreferences(
-                context.getPackageName() + "_preferences", Context.MODE_PRIVATE);
+        SharedPreferences prefs =
+                context.getSharedPreferences(LanguageManager.PREFS_FILE, Context.MODE_PRIVATE);
 
         String storedId = prefs.getString("backend_project_id", null);
         if (storedId != null && !storedId.isEmpty()) {
@@ -229,8 +229,8 @@ public class BackendServiceChecker {
      * This could be enhanced to read from secure storage
      */
     private String getSecretKey() {
-        SharedPreferences prefs = context.getSharedPreferences(
-                context.getPackageName() + "_preferences", Context.MODE_PRIVATE);
+        SharedPreferences prefs =
+                context.getSharedPreferences(LanguageManager.PREFS_FILE, Context.MODE_PRIVATE);
 
         String raw = prefs.getString("backend_secret_key", null);
         if (raw != null) {
@@ -277,8 +277,8 @@ public class BackendServiceChecker {
      * Set the secret key for authentication
      */
     public void setSecretKey(String secretKey) {
-        SharedPreferences prefs = context.getSharedPreferences(
-                context.getPackageName() + "_preferences", Context.MODE_PRIVATE);
+        SharedPreferences prefs =
+                context.getSharedPreferences(LanguageManager.PREFS_FILE, Context.MODE_PRIVATE);
         String trimmed = secretKey != null ? secretKey.trim() : null;
         prefs.edit().putString("backend_secret_key", trimmed).apply();
         if (trimmed != null && !trimmed.equals(secretKey)) {

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
@@ -126,7 +126,7 @@ public class FirebaseAuthManager {
     }
 
     private void storeUserData(String uid, String email, String nickname, String method) {
-        context.getSharedPreferences(context.getPackageName() + "_preferences", Context.MODE_PRIVATE)
+        context.getSharedPreferences(LanguageManager.PREFS_FILE, Context.MODE_PRIVATE)
                 .edit()
                 .putString("uid", uid)
                 .putString("email", email)
@@ -164,7 +164,7 @@ public class FirebaseAuthManager {
 
                                             // Preserve any previously-saved nickname instead of overwriting it
                                             SharedPreferences p = context.getSharedPreferences(
-                                                    context.getPackageName() + "_preferences",
+                                                    LanguageManager.PREFS_FILE,
                                                     Context.MODE_PRIVATE);
                                             String currentNick = p.getString("nickname", "");
 

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/GameActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/GameActivity.java
@@ -387,7 +387,7 @@ public class GameActivity extends BaseActivity {
 
 
         SharedPreferences sharedPreferences =
-                getSharedPreferences(getPackageName() + "_preferences", Context.MODE_PRIVATE);
+                getSharedPreferences(LanguageManager.PREFS_FILE, Context.MODE_PRIVATE);
 
         if (sharedPreferences.contains("android_level")) {
             androidLevel = Integer.parseInt(sharedPreferences.getString("android_level", "1"));

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
@@ -131,7 +131,8 @@ public class InvitationsActivity extends BaseActivity {
                                 Toast.makeText(this, "Invite accepted! Starting game…",
                                         Toast.LENGTH_SHORT).show();
 
-                                SharedPreferences prefs = getSharedPreferences(getPackageName() + "_preferences", MODE_PRIVATE);
+                                SharedPreferences prefs =
+                                        getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE);
                                 String nickname = prefs.getString("nickname", "Player");
 
                                 // Start game with matchPath, GameType 3, and local player nickname

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/LanguageManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/LanguageManager.java
@@ -5,16 +5,23 @@ import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.util.Log;
+
+import androidx.appcompat.app.AppCompatDelegate;
+import androidx.core.os.LocaleListCompat;
+
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.firestore.FirebaseFirestore;
-import java.util.Locale;
+
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 public class LanguageManager {
-    
-    // Use the same tag throughout the app for consistent Logcat filtering
-    private static final String TAG = "TAG_Soccer";
+
+    /** Preferences file name used across the entire app. */
+    public static final String PREFS_FILE = "app_prefs";
+
+    private static final String TAG = "LanguageManager";
     private static final String PREF_LANGUAGE_CODE = "language_code";
     
     // Language code to display name resource mapping
@@ -49,8 +56,8 @@ public class LanguageManager {
      * Get the currently selected language code from preferences
      */
     public static String getCurrentLanguageCode(Context context) {
-        SharedPreferences prefs = context.getSharedPreferences(
-                context.getPackageName() + "_preferences", Context.MODE_PRIVATE);
+        SharedPreferences prefs =
+                context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE);
         return prefs.getString(PREF_LANGUAGE_CODE, "en"); // Default to English
     }
     
@@ -68,11 +75,10 @@ public class LanguageManager {
      */
     public static void setLanguage(Context context, String languageCode) {
         // Save to SharedPreferences
-        SharedPreferences prefs = context.getSharedPreferences(
-                context.getPackageName() + "_preferences", Context.MODE_PRIVATE);
-        // Use commit() so that subsequent reads from other SharedPreferences instances
-        // (e.g. in MenuActivity.runHousekeeping) immediately observe the updated value.
-        prefs.edit().putString(PREF_LANGUAGE_CODE, languageCode).commit();
+        context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
+                .edit()
+                .putString(PREF_LANGUAGE_CODE, languageCode)
+                .commit();
         
         // Save to Firestore if user is logged in
         String uid = FirebaseAuth.getInstance().getUid();
@@ -87,13 +93,11 @@ public class LanguageManager {
                             Log.e(TAG, "Failed to update language preference in Firestore", e));
         }
 
-        // Apply the language change to both the current and application contexts so
-        // that all running activities receive the updated configuration immediately.
-        Context appContext = context.getApplicationContext();
-        applyLanguage(appContext, languageCode);
-        if (appContext != context) {
-            applyLanguage(context, languageCode);
-        }
+        // Apply the locale immediately for already-running contexts
+        AppCompatDelegate.setApplicationLocales(
+                LocaleListCompat.forLanguageTags(languageCode));
+        applyLanguage(context, languageCode);
+        Log.d(TAG, "setLanguage: applied=" + languageCode);
     }
     
     /**
@@ -150,9 +154,8 @@ public class LanguageManager {
      * Check if language preference has been set
      */
     public static boolean isLanguageSet(Context context) {
-        SharedPreferences prefs = context.getSharedPreferences(
-                context.getPackageName() + "_preferences", Context.MODE_PRIVATE);
-        return prefs.contains(PREF_LANGUAGE_CODE);
+        return context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
+                .contains(PREF_LANGUAGE_CODE);
     }
     
     /**
@@ -179,9 +182,12 @@ public class LanguageManager {
                             // Only apply the Firestore value if the language hasn't been
                             // changed locally since the request was initiated.
                             if (currentCode.equals(initialCode) && !currentCode.equals(languageCode)) {
-                                SharedPreferences prefs = context.getSharedPreferences(
-                                        context.getPackageName() + "_preferences", Context.MODE_PRIVATE);
-                                prefs.edit().putString(PREF_LANGUAGE_CODE, languageCode).apply();
+                                context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
+                                        .edit()
+                                        .putString(PREF_LANGUAGE_CODE, languageCode)
+                                        .apply();
+                                AppCompatDelegate.setApplicationLocales(
+                                        LocaleListCompat.forLanguageTags(languageCode));
                                 applyLanguage(context, languageCode);
                             }
                         }

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -178,13 +178,7 @@ public class MenuActivity extends BaseActivity {
                             }.getClass().getEnclosingMethod()).getName()
                             + ": ⚠️ No logged-in user; clearing stored credentials"
             );
-            String languageCode = LanguageManager.getCurrentLanguageCode(this);
-            SharedPreferences.Editor ed = prefs.edit();
-            ed.clear();
-            ed.putString("language_code", languageCode);
-            // Use commit() so subsequent reads in newly created Activities
-            // observe the updated language immediately.
-            ed.commit();
+            prefs.edit().clear().commit();
             FirebaseMessaging.getInstance().deleteToken();
             FirebaseMessaging.getInstance().setAutoInitEnabled(false);
             FirebaseFirestore.getInstance()
@@ -280,8 +274,7 @@ public class MenuActivity extends BaseActivity {
 
         FirebaseAuth.getInstance().signOut();
 
-        String prefsName = getPackageName() + "_preferences";
-        getSharedPreferences(prefsName, MODE_PRIVATE)
+        getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE)
                 .edit()
                 .remove(PREF_FCM_TOKEN)
                 .clear()
@@ -342,7 +335,8 @@ public class MenuActivity extends BaseActivity {
 
         FirebaseAuth auth = FirebaseAuth.getInstance();
 
-        SharedPreferences prefs = getSharedPreferences(getPackageName() + "_preferences", MODE_PRIVATE);
+        SharedPreferences prefs =
+                getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE);
         String nickname = prefs.getString("nickname", null);
         if (auth.getCurrentUser() == null) {
             prefs.edit().clear().apply();
@@ -451,7 +445,8 @@ public class MenuActivity extends BaseActivity {
     }
 
     private void checkForActiveMatch() {
-        SharedPreferences prefs = getSharedPreferences(getPackageName() + "_preferences", MODE_PRIVATE);
+        SharedPreferences prefs =
+                getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE);
         String uid = FirebaseAuth.getInstance().getUid();
         Log.d("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object() {
         }.getClass().getEnclosingMethod()).getName() + ": Auth UID at match-lookup = " + uid);
@@ -574,7 +569,8 @@ public class MenuActivity extends BaseActivity {
     }
 
     private void showAdThenRun(Runnable action) {
-        SharedPreferences prefs = getSharedPreferences(getPackageName() + "_preferences", MODE_PRIVATE);
+        SharedPreferences prefs =
+                getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE);
 
         FirebaseFirestore.getInstance()
                 .collection("settings")

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/PickNicknameActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/PickNicknameActivity.java
@@ -115,7 +115,7 @@ public class PickNicknameActivity extends BaseActivity {
                     db.collection("users").document(uid)
                             .set(data, SetOptions.merge())
                             .addOnSuccessListener(v -> {
-                                getSharedPreferences(getPackageName() + "_preferences", MODE_PRIVATE)
+                                getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE)
                                         .edit()
                                         .putString("nickname", nickname)
                                         .apply();

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsActivity.java
@@ -17,9 +17,11 @@ public class SettingsActivity extends BaseActivity {
         setSupportActionBar(toolbar);
         Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
 
-        String title = getString(R.string.settings);
-        Objects.requireNonNull(getSupportActionBar()).setTitle(title);
-        Log.d("TAG_Soccer", getClass().getSimpleName() + ".onCreate: toolbar title set to " + title);
+        toolbar.setTitle(R.string.settings_title);
+        Log.d(
+                "TAG_Soccer",
+                getClass().getSimpleName() + ".onCreate: toolbar title set to " + getString(R.string.settings_title)
+        );
 
         getSupportFragmentManager()
                 .beginTransaction()

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsFragment.java
@@ -233,8 +233,39 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     }
 
     private void updateLanguagePreferenceSummary(Preference preference) {
-        String currentLanguage = LanguageManager.getCurrentLanguageName(requireContext());
-        String summary = getString(R.string.current_language, currentLanguage);
+        String code = LanguageManager.getCurrentLanguageCode(requireContext());
+        String label;
+        switch (code) {
+            case "pl":
+                label = getString(R.string.language_polish);
+                break;
+            case "de":
+                label = getString(R.string.language_german);
+                break;
+            case "fr":
+                label = getString(R.string.language_french);
+                break;
+            case "es":
+                label = getString(R.string.language_spanish);
+                break;
+            case "ur":
+                label = getString(R.string.language_urdu);
+                break;
+            case "bn":
+                label = getString(R.string.language_bengali);
+                break;
+            case "ne":
+                label = getString(R.string.language_nepali);
+                break;
+            case "hi":
+                label = getString(R.string.language_hindi);
+                break;
+            default:
+                label = getString(R.string.language_english);
+                break;
+        }
+
+        String summary = getString(R.string.current_language, label);
         preference.setSummary(summary);
         Log.d(
                 "TAG_Soccer",

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -38,6 +38,8 @@ import com.google.android.ump.UserMessagingPlatform;
 import com.google.android.ump.ConsentForm;
 import com.google.android.ump.FormError;
 import androidx.preference.PreferenceManager;
+import androidx.appcompat.app.AppCompatDelegate;
+import androidx.core.os.LocaleListCompat;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -83,6 +85,8 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
     public void onCreate() {
         super.onCreate();
 
+        String code = LanguageManager.getCurrentLanguageCode(this);
+        AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(code));
         // Ensure the app uses the saved language before any UI is shown
         checkLanguagePreference();
 
@@ -156,8 +160,8 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
 
         FirebaseMessaging.getInstance().getToken()
                 .addOnSuccessListener(newToken -> {
-                    SharedPreferences prefs = getSharedPreferences(
-                            getPackageName() + "_preferences", MODE_PRIVATE);
+                    SharedPreferences prefs =
+                            getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE);
                     String saved = prefs.getString("fcmToken", null);
                     if (saved != null && saved.equals(newToken)) return;
 
@@ -400,7 +404,8 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
      * Configure default project ID if not already set
      */
     private void configureDefaultProjectId() {
-        SharedPreferences prefs = getSharedPreferences(getPackageName() + "_preferences", MODE_PRIVATE);
+        SharedPreferences prefs =
+                getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE);
 
         // Always attempt to read the project ID from google-services.json
         String firebaseProjectId = null;

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/UniversalLoginActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/UniversalLoginActivity.java
@@ -31,7 +31,8 @@ public class UniversalLoginActivity extends BaseActivity {
 
         authManager = new FirebaseAuthManager(this);
 
-        SharedPreferences prefs = getSharedPreferences(getPackageName() + "_preferences", MODE_PRIVATE);
+        SharedPreferences prefs =
+                getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE);
         storedNickname = prefs.getString("nickname", null);
 
         Button btnEmail = findViewById(R.id.btnUniversalEmail);
@@ -77,10 +78,8 @@ public class UniversalLoginActivity extends BaseActivity {
                                 ": onLoginSuccess"
                 );
 
-                SharedPreferences prefs = getSharedPreferences(
-                        getPackageName() + "_preferences",
-                        MODE_PRIVATE
-                );
+                SharedPreferences prefs =
+                        getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE);
 
                 String uid = Objects.requireNonNull(FirebaseAuth.getInstance().getCurrentUser()).getUid();
 

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/WaitingActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/WaitingActivity.java
@@ -172,7 +172,8 @@ public class WaitingActivity extends BaseActivity {
     private void launchGame(String matchPath) {
         gameActivityLaunched = true;
 
-        SharedPreferences prefs = getSharedPreferences(getPackageName() + "_preferences", MODE_PRIVATE);
+        SharedPreferences prefs =
+                getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE);
         String nickname = prefs.getString("nickname", "Player");
 
         startActivity(new Intent(this, GameActivity.class)
@@ -201,7 +202,7 @@ public class WaitingActivity extends BaseActivity {
         Log.d("TAG_Soccer",
                 getClass().getSimpleName() + ".onDestroy: ❎ clearing activeInviteId");
         /* remove the marker so we don’t restore an invite that’s finished */
-        getSharedPreferences(getPackageName() + "_preferences", MODE_PRIVATE)
+        getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE)
                 .edit()
                 .remove("activeInviteId")
                 .apply();

--- a/mobile/app/src/main/res/values-pl/strings.xml
+++ b/mobile/app/src/main/res/values-pl/strings.xml
@@ -176,6 +176,7 @@
     
     <!-- Common strings -->
     <string name="settings">Ustawienia</string>
+    <string name="settings_title">Ustawienia</string>
     <string name="cancel">Anuluj</string>
     <string name="confirm">Potwierdź</string>
 

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="reset_password_failed">Failed to send password reset email. Please try again.</string>
     <string name="nickname">Nickname</string>
     <string name="settings">Settings</string>
+    <string name="settings_title">Settings</string>
     <string name="enter_nickname_to_invite">Enter nickname to invite:</string>
     <string name="enter_nickname_to_search">Enter nickname to search:</string>
     <string name="friend_s_nickname">Friend\'s nickname</string>


### PR DESCRIPTION
## Summary
- consolidate language preference handling in `LanguageManager` with a single `app_prefs` store
- apply locale immediately via `AppCompatDelegate` and ensure startup initialization in `SoccerApp`
- update settings UI strings and fragment summary to use localized resources

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b890aa70083309bd0bfb3afe79246