### PR TITLE
Preserve chosen language after logout

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/LanguageManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/LanguageManager.java
@@ -22,7 +22,7 @@ public class LanguageManager {
     public static final String PREFS_FILE = "app_prefs";
 
     private static final String TAG = "LanguageManager";
-    private static final String PREF_LANGUAGE_CODE = "language_code";
+    public static final String PREF_LANGUAGE_CODE = "language_code";
     
     // Language code to display name resource mapping
     private static final Map<String, Integer> LANGUAGE_NAME_RES_IDS = new HashMap<>();

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -339,7 +339,11 @@ public class MenuActivity extends BaseActivity {
                 getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE);
         String nickname = prefs.getString("nickname", null);
         if (auth.getCurrentUser() == null) {
-            prefs.edit().clear().apply();
+            String lang = prefs.getString(LanguageManager.PREF_LANGUAGE_CODE, "en");
+            SharedPreferences.Editor ed = prefs.edit();
+            ed.clear();
+            ed.putString(LanguageManager.PREF_LANGUAGE_CODE, lang);
+            ed.commit();
 
             FirebaseMessaging.getInstance().deleteToken();
             FirebaseMessaging.getInstance().setAutoInitEnabled(false);


### PR DESCRIPTION
## Summary
- expose `PREF_LANGUAGE_CODE` so it can be reused outside `LanguageManager`
- retain the stored language when clearing user data with no signed-in user

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e07ad46cc8330944d66de9181693f