### PR TITLE
fix: avoid lang variable redefinition

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -339,10 +339,10 @@ public class MenuActivity extends BaseActivity {
                 getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE);
         String nickname = prefs.getString("nickname", null);
         if (auth.getCurrentUser() == null) {
-            String lang = prefs.getString(LanguageManager.PREF_LANGUAGE_CODE, "en");
+            String savedLang = prefs.getString(LanguageManager.PREF_LANGUAGE_CODE, "en");
             SharedPreferences.Editor ed = prefs.edit();
             ed.clear();
-            ed.putString(LanguageManager.PREF_LANGUAGE_CODE, lang);
+            ed.putString(LanguageManager.PREF_LANGUAGE_CODE, savedLang);
             ed.commit();
 
             FirebaseMessaging.getInstance().deleteToken();


### PR DESCRIPTION
## Summary
- prevent duplicate `lang` variable declaration in `MenuActivity.onResume`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e19b92128833090620ff1d9ee200a