### PR TITLE
Localize login flows

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/LoginActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/LoginActivity.java
@@ -27,7 +27,7 @@ public class LoginActivity extends BaseActivity {
         Toolbar toolbar = findViewById(R.id.login_toolbar);
         setSupportActionBar(toolbar);
         Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
-        getSupportActionBar().setTitle("Login");
+        getSupportActionBar().setTitle(R.string.login);
 
         authManager = new FirebaseAuthManager(this);
 
@@ -41,19 +41,19 @@ public class LoginActivity extends BaseActivity {
             String email = editEmail.getText().toString().trim();
             String password = editPassword.getText().toString().trim();
             if (email.isEmpty() || password.isEmpty()) {
-                Toast.makeText(this, "Please enter both email and password", Toast.LENGTH_SHORT).show();
+                Toast.makeText(this, R.string.enter_email_and_password, Toast.LENGTH_SHORT).show();
                 return;
             }
             authManager.loginUser(email, password, new FirebaseAuthManager.LoginCallback() {
                 @Override
                 public void onLoginSuccess() {
-                    Toast.makeText(LoginActivity.this, "Login successful!", Toast.LENGTH_SHORT).show();
+                    Toast.makeText(LoginActivity.this, R.string.login_success, Toast.LENGTH_SHORT).show();
                     finish(); // Closes LoginActivity and returns to MenuActivity
                 }
 
                 @Override
                 public void onLoginFailure(String message) {
-                    Toast.makeText(LoginActivity.this, "Login failed: " + message, Toast.LENGTH_LONG).show();
+                    Toast.makeText(LoginActivity.this, getString(R.string.login_failed, message), Toast.LENGTH_LONG).show();
                 }
             });
         });
@@ -90,13 +90,13 @@ public class LoginActivity extends BaseActivity {
                 .setPositiveButton(getString(R.string.confirm), (dialog, which) -> {
                     String email = emailInput.getText().toString().trim();
                     if (email.isEmpty()) {
-                        Toast.makeText(this, "Please enter your email address", Toast.LENGTH_SHORT).show();
+                        Toast.makeText(this, R.string.enter_email_address, Toast.LENGTH_SHORT).show();
                         return;
                     }
                     Log.d("TAG_Soccer", getClass().getSimpleName() + ".showResetPasswordDialog: Attempting password reset for email: " + email);
                     requestPasswordReset(email);
                 })
-                .setNegativeButton("Cancel", null)
+                .setNegativeButton(R.string.cancel, null)
                 .show();
     }
 

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/PickNicknameActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/PickNicknameActivity.java
@@ -46,13 +46,13 @@ public class PickNicknameActivity extends BaseActivity {
             @Override public void afterTextChanged(Editable s) {
                 int len = s.length();
                 editNickname.setHint(len + " / " + NICK_MAX);
-                if (len == NICK_MAX) {
-                    if (nickToast != null) nickToast.cancel();
-                    nickToast = Toast.makeText(PickNicknameActivity.this,
-                            "Maximum 20 characters reached",
-                            Toast.LENGTH_SHORT);
-                    nickToast.show();
-                } else if (len < NICK_MAX && nickToast != null) {
+                    if (len == NICK_MAX) {
+                      if (nickToast != null) nickToast.cancel();
+                      nickToast = Toast.makeText(PickNicknameActivity.this,
+                              R.string.nickname_max_length_reached,
+                              Toast.LENGTH_SHORT);
+                      nickToast.show();
+                  } else if (len < NICK_MAX && nickToast != null) {
                     nickToast.cancel();
                     nickToast = null;
                 }
@@ -71,17 +71,17 @@ public class PickNicknameActivity extends BaseActivity {
     private void saveNickname() {
         String nickname = editNickname.getText().toString().trim();
         if (nickname.isEmpty()) {
-            Toast.makeText(this, "Nickname is required", Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, R.string.nickname_required, Toast.LENGTH_SHORT).show();
             return;
         }
         if (nickname.length() > NICK_MAX) {
-            Toast.makeText(this, "Nickname must be 20 characters or less", Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, R.string.nickname_too_long, Toast.LENGTH_SHORT).show();
             return;
         }
 
         String uid = FirebaseAuth.getInstance().getUid();
         if (uid == null) {
-            Toast.makeText(this, "Not logged in", Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, R.string.not_logged_in, Toast.LENGTH_SHORT).show();
             return;
         }
 
@@ -95,17 +95,17 @@ public class PickNicknameActivity extends BaseActivity {
                     if (!task.isSuccessful()) {
                         btnConfirm.setEnabled(true);
                         Log.e("TAG_Soccer", "Nickname check failed", task.getException());
-                        Toast.makeText(PickNicknameActivity.this,
-                                "Network error while checking nickname",
-                                Toast.LENGTH_SHORT).show();
+                          Toast.makeText(PickNicknameActivity.this,
+                                  R.string.network_error_checking_nickname,
+                                  Toast.LENGTH_SHORT).show();
                         return;
                     }
                     if (!task.getResult().isEmpty()) {
                         btnConfirm.setEnabled(true);
                         Log.e("TAG_Soccer", "Nickname already exists: " + nickname);
-                        Toast.makeText(PickNicknameActivity.this,
-                                "Nickname already taken — choose another",
-                                Toast.LENGTH_SHORT).show();
+                          Toast.makeText(PickNicknameActivity.this,
+                                  R.string.nickname_taken,
+                                  Toast.LENGTH_SHORT).show();
                         return;
                     }
 
@@ -119,9 +119,9 @@ public class PickNicknameActivity extends BaseActivity {
                                         .edit()
                                         .putString("nickname", nickname)
                                         .apply();
-                                Toast.makeText(PickNicknameActivity.this,
-                                        "Nickname saved",
-                                        Toast.LENGTH_SHORT).show();
+                                  Toast.makeText(PickNicknameActivity.this,
+                                          R.string.nickname_saved,
+                                          Toast.LENGTH_SHORT).show();
                                 if (isTaskRoot()) {
                                     startActivity(new Intent(
                                             PickNicknameActivity.this,
@@ -131,9 +131,9 @@ public class PickNicknameActivity extends BaseActivity {
                             })
                             .addOnFailureListener(e -> {
                                 btnConfirm.setEnabled(true);
-                                Toast.makeText(PickNicknameActivity.this,
-                                        "Failed to save nickname",
-                                        Toast.LENGTH_SHORT).show();
+                                  Toast.makeText(PickNicknameActivity.this,
+                                          R.string.nickname_save_failed,
+                                          Toast.LENGTH_SHORT).show();
                             });
                 });
     }

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegisterAccountActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegisterAccountActivity.java
@@ -29,7 +29,7 @@ public class RegisterAccountActivity extends BaseActivity {
         Toolbar toolbar = findViewById(R.id.register_toolbar);
         setSupportActionBar(toolbar);
         Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
-        getSupportActionBar().setTitle("Register new account");
+        getSupportActionBar().setTitle(R.string.register_new_account);
 
         authManager = new FirebaseAuthManager(this);
 
@@ -47,18 +47,18 @@ public class RegisterAccountActivity extends BaseActivity {
         String confirmPassword = editConfirmPassword.getText().toString().trim();
 
         if (email.isEmpty() || password.isEmpty() || confirmPassword.isEmpty()) {
-            Toast.makeText(this, "All fields are required", Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, R.string.all_fields_required, Toast.LENGTH_SHORT).show();
             return;
         }
 
         if (!password.equals(confirmPassword)) {
-            Toast.makeText(this, "Passwords do not match", Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, R.string.passwords_do_not_match, Toast.LENGTH_SHORT).show();
             return;
         }
 
         authManager.registerUser(email, password);
         Toast.makeText(RegisterAccountActivity.this,
-                "Registration attempt in progress...",
+                R.string.registration_in_progress,
                 Toast.LENGTH_SHORT).show();
     }
 

--- a/mobile/app/src/main/res/values-bn/strings.xml
+++ b/mobile/app/src/main/res/values-bn/strings.xml
@@ -187,4 +187,19 @@
     <string name="field_move_ellipsis_tail">চাল... ⏳ %1$s</string>
     <string name="field_waiting_for">%1$s-এর জন্য অপেক্ষা</string>
     <string name="field_to_start_tail">শুরু করার জন্য... ⏳ %1$s</string>
+    <string name="enter_email_and_password">ইমেল এবং পাসওয়ার্ড উভয়ই লিখুন</string>
+    <string name="login_success">লগইন সফল!</string>
+    <string name="login_failed">লগইন ব্যর্থ: %1$s</string>
+    <string name="enter_email_address">আপনার ইমেল ঠিকানা লিখুন দয়া করে</string>
+    <string name="all_fields_required">সমস্ত ক্ষেত্র প্রয়োজন</string>
+    <string name="passwords_do_not_match">পাসওয়ার্ড মেলে না</string>
+    <string name="registration_in_progress">অগ্রগতিতে নিবন্ধকরণের প্রচেষ্টা ...</string>
+    <string name="nickname_max_length_reached">সর্বোচ্চ 20 টি অক্ষর পৌঁছেছে</string>
+    <string name="nickname_required">ডাকনাম প্রয়োজন</string>
+    <string name="nickname_too_long">ডাকনাম অবশ্যই 20 টি অক্ষর বা তার চেয়ে কম হতে হবে</string>
+    <string name="not_logged_in">লগ ইন নেই</string>
+    <string name="network_error_checking_nickname">ডাকনাম পরীক্ষা করার সময় নেটওয়ার্ক ত্রুটি</string>
+    <string name="nickname_taken">ডাকনাম ইতিমধ্যে নেওয়া হয়েছে - অন্যটি বেছে নিন</string>
+    <string name="nickname_saved">ডাকনাম সংরক্ষণ</string>
+    <string name="nickname_save_failed">ডাকনাম সংরক্ষণ করতে ব্যর্থ</string>
 </resources>

--- a/mobile/app/src/main/res/values-de/strings.xml
+++ b/mobile/app/src/main/res/values-de/strings.xml
@@ -187,4 +187,19 @@
     <string name="field_move_ellipsis_tail">ist am Zug... ⏳ %1$s</string>
     <string name="field_waiting_for">Warte auf %1$s</string>
     <string name="field_to_start_tail">um zu starten... ⏳ %1$s</string>
+    <string name="enter_email_and_password">Bitte geben Sie sowohl E -Mail als auch Passwort ein</string>
+    <string name="login_success">Login erfolgreich!</string>
+    <string name="login_failed">Fehler bei der Anmeldung: %1$s</string>
+    <string name="enter_email_address">Bitte geben Sie Ihre E -Mail -Adresse ein</string>
+    <string name="all_fields_required">Alle Felder sind erforderlich</string>
+    <string name="passwords_do_not_match">Passwörter stimmen nicht überein</string>
+    <string name="registration_in_progress">Registrierungsversuch in Arbeit ...</string>
+    <string name="nickname_max_length_reached">Maximal 20 Zeichen erreicht</string>
+    <string name="nickname_required">Spitzname ist erforderlich</string>
+    <string name="nickname_too_long">Spitzname muss 20 Zeichen oder weniger betragen</string>
+    <string name="not_logged_in">Nicht angemeldet</string>
+    <string name="network_error_checking_nickname">Netzwerkfehler beim Überprüfen des Spitznamens</string>
+    <string name="nickname_taken">Spitzname bereits genommen - wählen Sie einen anderen</string>
+    <string name="nickname_saved">Spitzname gerettet</string>
+    <string name="nickname_save_failed">Spitzname nicht speichern</string>
 </resources>

--- a/mobile/app/src/main/res/values-es/strings.xml
+++ b/mobile/app/src/main/res/values-es/strings.xml
@@ -187,4 +187,19 @@
     <string name="field_move_ellipsis_tail">mueve... ⏳ %1$s</string>
     <string name="field_waiting_for">Esperando a %1$s</string>
     <string name="field_to_start_tail">para empezar... ⏳ %1$s</string>
+    <string name="enter_email_and_password">Ingrese tanto correo electrónico como contraseña</string>
+    <string name="login_success">¡Inicie sesión exitosa!</string>
+    <string name="login_failed">Error de inicio de sesion: %1$s</string>
+    <string name="enter_email_address">Ingrese su dirección de correo electrónico</string>
+    <string name="all_fields_required">Se requieren todos los campos</string>
+    <string name="passwords_do_not_match">Las contraseñas no coinciden</string>
+    <string name="registration_in_progress">Intento de registro en progreso ...</string>
+    <string name="nickname_max_length_reached">Máximo 20 caracteres alcanzados</string>
+    <string name="nickname_required">Se requiere un apodo</string>
+    <string name="nickname_too_long">El apodo debe ser 20 caracteres o menos</string>
+    <string name="not_logged_in">No iniciado sesión</string>
+    <string name="network_error_checking_nickname">Error de red al verificar el apodo</string>
+    <string name="nickname_taken">Apodo ya tomado - Elija otro</string>
+    <string name="nickname_saved">Apodo guardado</string>
+    <string name="nickname_save_failed">No se pudo salvar el apodo</string>
 </resources>

--- a/mobile/app/src/main/res/values-fr/strings.xml
+++ b/mobile/app/src/main/res/values-fr/strings.xml
@@ -187,4 +187,19 @@
     <string name="field_move_ellipsis_tail">joue... ⏳ %1$s</string>
     <string name="field_waiting_for">En attente de %1$s</string>
     <string name="field_to_start_tail">pour commencer... ⏳ %1$s</string>
+    <string name="enter_email_and_password">Veuillez saisir les e-mails et le mot de passe</string>
+    <string name="login_success">Connectez-vous réussi!</string>
+    <string name="login_failed">La connexion a échoué: %1$s</string>
+    <string name="enter_email_address">Veuillez saisir votre adresse e-mail</string>
+    <string name="all_fields_required">Tous les champs sont nécessaires</string>
+    <string name="passwords_do_not_match">Les mots de passe ne correspondent pas</string>
+    <string name="registration_in_progress">Tentative d'enregistrement en cours ...</string>
+    <string name="nickname_max_length_reached">Maximum 20 caractères atteints</string>
+    <string name="nickname_required">Un surnom est requis</string>
+    <string name="nickname_too_long">Le surnom doit être de 20 caractères ou moins</string>
+    <string name="not_logged_in">Pas connecté</string>
+    <string name="network_error_checking_nickname">Erreur de réseau lors de la vérification du surnom</string>
+    <string name="nickname_taken">Surnom déjà pris - choisissez un autre</string>
+    <string name="nickname_saved">Surnom enregistré</string>
+    <string name="nickname_save_failed">Échec de l'enregistrement du surnom</string>
 </resources>

--- a/mobile/app/src/main/res/values-hi/strings.xml
+++ b/mobile/app/src/main/res/values-hi/strings.xml
@@ -187,4 +187,19 @@
     <string name="field_move_ellipsis_tail">चाल... ⏳ %1$s</string>
     <string name="field_waiting_for">%1$s की प्रतीक्षा</string>
     <string name="field_to_start_tail">शुरू करने के लिए... ⏳ %1$s</string>
+    <string name="enter_email_and_password">कृपया ईमेल और पासवर्ड दोनों दर्ज करें</string>
+    <string name="login_success">लॉग इन सफल!</string>
+    <string name="login_failed">लॉगिन विफल: %1$s</string>
+    <string name="enter_email_address">कृपया अपना ईमेल एड्रेस इंटर करें</string>
+    <string name="all_fields_required">सभी फ़ील् आवश्यक हैं</string>
+    <string name="passwords_do_not_match">सांकेतिक शब्द मेल नहीं खाते</string>
+    <string name="registration_in_progress">पंजीकरण का प्रयास प्रगति में ...</string>
+    <string name="nickname_max_length_reached">अधिकतम 20 वर्ण पहुंचे</string>
+    <string name="nickname_required">उपनाम की आवश्यकता है</string>
+    <string name="nickname_too_long">उपनाम 20 अक्षर या उससे कम होना चाहिए</string>
+    <string name="not_logged_in">अंदर प्रवेश की अनुमति नहीं है</string>
+    <string name="network_error_checking_nickname">उपनाम की जाँच करते समय नेटवर्क त्रुटि</string>
+    <string name="nickname_taken">उपनाम पहले से ही लिया गया - एक और चुनें</string>
+    <string name="nickname_saved">उपनाम बचाया</string>
+    <string name="nickname_save_failed">उपनाम बचाने में विफल रहा</string>
 </resources>

--- a/mobile/app/src/main/res/values-ne/strings.xml
+++ b/mobile/app/src/main/res/values-ne/strings.xml
@@ -187,4 +187,19 @@
     <string name="field_move_ellipsis_tail">चाल... ⏳ %1$s</string>
     <string name="field_waiting_for">%1$s को प्रतीक्षा</string>
     <string name="field_to_start_tail">सुरु गर्न... ⏳ %1$s</string>
+    <string name="enter_email_and_password">कृपया दुबै ईमेल र पासवर्ड प्रविष्ट गर्नुहोस्</string>
+    <string name="login_success">लगइन सफल!</string>
+    <string name="login_failed">लगइन असफल: %1$s</string>
+    <string name="enter_email_address">कृपया तपाईंको ईमेल ठेगाना प्रविष्ट गर्नुहोस्</string>
+    <string name="all_fields_required">सबै क्षेत्रहरू आवश्यक छ</string>
+    <string name="passwords_do_not_match">पासवर्डहरू मेल खाँदैनन्</string>
+    <string name="registration_in_progress">प्रगतिमा रेजिष्ट्रेसन प्रयास ...</string>
+    <string name="nickname_max_length_reached">अधिकतम 20 वर्णहरू पुगे</string>
+    <string name="nickname_required">उपनाम आवश्यक छ</string>
+    <string name="nickname_too_long">उपनाम 20 वर्ण वा कम हुनु पर्छ</string>
+    <string name="not_logged_in">लग इन गरिएको छैन</string>
+    <string name="network_error_checking_nickname">नेटवर्क त्रुटि उपनाम जाँच गर्दा नेटवर्क त्रुटि</string>
+    <string name="nickname_taken">उपनाम पहिले नै लिइएको छ - अर्को छनौट गर्नुहोस्</string>
+    <string name="nickname_saved">उपनाम बचत भयो</string>
+    <string name="nickname_save_failed">उपनाम बचत गर्न असफल भयो</string>
 </resources>

--- a/mobile/app/src/main/res/values-pl/strings.xml
+++ b/mobile/app/src/main/res/values-pl/strings.xml
@@ -189,4 +189,19 @@
     <string name="field_move_ellipsis_tail">rusza... ⏳ %1$s</string>
     <string name="field_waiting_for">Czekanie na %1$s</string>
     <string name="field_to_start_tail">aby rozpocząć... ⏳ %1$s</string>
+    <string name="enter_email_and_password">Wprowadź zarówno e -mail, jak i hasło</string>
+    <string name="login_success">Zaloguj się sukces!</string>
+    <string name="login_failed">Logowanie nie powiodło się: %1$s</string>
+    <string name="enter_email_address">Wprowadź swój adres e -mail</string>
+    <string name="all_fields_required">Wszystkie pola są wymagane</string>
+    <string name="passwords_do_not_match">Hasła nie pasują</string>
+    <string name="registration_in_progress">Próba rejestracji w toku ...</string>
+    <string name="nickname_max_length_reached">Osiągnięte maksymalnie 20 znaków</string>
+    <string name="nickname_required">Wymagany jest pseudonim</string>
+    <string name="nickname_too_long">Pseudonim musi mieć 20 znaków lub mniej</string>
+    <string name="not_logged_in">Nie zalogowano</string>
+    <string name="network_error_checking_nickname">Błąd sieci podczas sprawdzania pseudonim</string>
+    <string name="nickname_taken">Pseudonim już zabrany - wybierz inny</string>
+    <string name="nickname_saved">Zapisany pseudonim</string>
+    <string name="nickname_save_failed">Nie udało się zapisać pseudonim</string>
 </resources>

--- a/mobile/app/src/main/res/values-ur/strings.xml
+++ b/mobile/app/src/main/res/values-ur/strings.xml
@@ -187,4 +187,19 @@
     <string name="field_move_ellipsis_tail">چلے... ⏳ %1$s</string>
     <string name="field_waiting_for">%1$s کا انتظار</string>
     <string name="field_to_start_tail">شروع کرنے کے لیے... ⏳ %1$s</string>
+    <string name="enter_email_and_password">براہ کرم ای میل اور پاس ورڈ دونوں درج کریں</string>
+    <string name="login_success">لاگ ان کامیاب!</string>
+    <string name="login_failed">لاگ ان ناکام: %1$s</string>
+    <string name="enter_email_address">براہ کرم اپنا ای میل ایڈریس درج کریں</string>
+    <string name="all_fields_required">تمام فیلڈز کی ضرورت ہے</string>
+    <string name="passwords_do_not_match">پاس ورڈ مماثل نہیں ہیں</string>
+    <string name="registration_in_progress">رجسٹریشن کی کوشش جاری ہے ...</string>
+    <string name="nickname_max_length_reached">زیادہ سے زیادہ 20 حرف پہنچ گئے</string>
+    <string name="nickname_required">عرفی نام کی ضرورت ہے</string>
+    <string name="nickname_too_long">عرفی نام 20 حروف یا اس سے کم ہونا چاہئے</string>
+    <string name="not_logged_in">لاگ ان نہیں</string>
+    <string name="network_error_checking_nickname">عرفی نام کی جانچ پڑتال کے دوران نیٹ ورک کی خرابی</string>
+    <string name="nickname_taken">پہلے سے لیا گیا عرفی نام - ایک اور کا انتخاب کریں</string>
+    <string name="nickname_saved">عرفی نام بچ گیا</string>
+    <string name="nickname_save_failed">عرفیت کو بچانے میں ناکام</string>
 </resources>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -182,4 +182,19 @@
     <string name="field_move_ellipsis_tail">move... ⏳ %1$s</string>
     <string name="field_waiting_for">Waiting for %1$s</string>
     <string name="field_to_start_tail">to start... ⏳ %1$s</string>
+    <string name="enter_email_and_password">Please enter both email and password</string>
+    <string name="login_success">Login successful!</string>
+    <string name="login_failed">Login failed: %1$s</string>
+    <string name="enter_email_address">Please enter your email address</string>
+    <string name="all_fields_required">All fields are required</string>
+    <string name="passwords_do_not_match">Passwords do not match</string>
+    <string name="registration_in_progress">Registration attempt in progress...</string>
+    <string name="nickname_max_length_reached">Maximum 20 characters reached</string>
+    <string name="nickname_required">Nickname is required</string>
+    <string name="nickname_too_long">Nickname must be 20 characters or less</string>
+    <string name="not_logged_in">Not logged in</string>
+    <string name="network_error_checking_nickname">Network error while checking nickname</string>
+    <string name="nickname_taken">Nickname already taken — choose another</string>
+    <string name="nickname_saved">Nickname saved</string>
+    <string name="nickname_save_failed">Failed to save nickname</string>
 </resources>


### PR DESCRIPTION
## Summary
- Replace hardcoded login and registration strings with resource IDs
- Add translations for supported locales
- Show toasts via string resources

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e1d0ef7788330b2cdc6daf986cf9e