### PR TITLE
fix: copy all tournament rules for seeding

### DIFF
--- a/gcp/cloud-build/seed_regulations.yaml
+++ b/gcp/cloud-build/seed_regulations.yaml
@@ -55,7 +55,7 @@ steps:
         cp /workspace/soccer/firebase/functions/seed-regulations/package.json /workspace/firebase/functions/seed-regulations/
         cp /workspace/soccer/firebase/functions/seed-regulations/index.js /workspace/firebase/functions/seed-regulations/
         mkdir -p /workspace/firebase/seed
-        cp /workspace/soccer/firebase/seed/tournament_rules.json /workspace/firebase/seed/
+        cp /workspace/soccer/firebase/seed/tournament_rules_*.json /workspace/firebase/seed/
 
   # Step 4: Install dependencies
   - name: 'node:18-slim'


### PR DESCRIPTION
## Summary
- copy all tournament_rules_*.json files into seeding workspace during Cloud Build

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f61b16f308330bac9ff3f56f314f4