### PR TITLE
Fix verification email error string resolution

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
@@ -258,7 +258,7 @@ public class FirebaseAuthManager {
                                                 : "Unknown error";
                                         new AlertDialog.Builder(context)
                                                 .setTitle(R.string.email_verification_failed)
-                                                .setMessage(getString(R.string.could_not_send_verification_email, error))
+                                                .setMessage(context.getString(R.string.could_not_send_verification_email, error))
                                                 .setPositiveButton(R.string.ok, null)
                                                 .show();
                                     }


### PR DESCRIPTION
## Summary
- Use `context.getString` when composing verification email failure message in `FirebaseAuthManager`.

## Testing
- `./gradlew -Penv=dev test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c51363b883308bd848b589ecc3ff