### PR TITLE
Allow authenticated users to read regulation translations

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -134,10 +134,16 @@ service cloud.firestore {
     }
 
 
-    // Regulations: read-only for authenticated users
+    // Regulations: read-only for authenticated users, including language subcollections
     match /regulations/{docId} {
       allow read: if request.auth != null;
       allow write: if false;
+
+      // Language-specific rule documents (e.g. /regulations/{id}/en/rules)
+      match /{lang}/{subDoc=**} {
+        allow read: if request.auth != null;
+        allow write: if false;
+      }
     }
 
     // App configuration settings (e.g. ads frequency)


### PR DESCRIPTION
## Summary
- allow authenticated users to read regulation translation documents and subcollections

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a0ca33209c8330bfdf14afff6061db