### PR TITLE
Log actual toolbar caption in SettingsActivity

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsActivity.java
@@ -22,6 +22,10 @@ public class SettingsActivity extends BaseActivity {
                 "TAG_Soccer",
                 getClass().getSimpleName() + ".onCreate: toolbar title set to " + getString(R.string.settings_title)
         );
+        Log.d(
+                "TAG_Soccer",
+                getClass().getSimpleName() + ".onCreate: toolbar caption=\"" + toolbar.getTitle() + "\""
+        );
 
         getSupportFragmentManager()
                 .beginTransaction()


### PR DESCRIPTION
## Summary
- Log the toolbar's current caption after setting the Settings title to aid debugging of language inconsistencies.

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e489b0048330ac3d3ee5c12b4e73