### PR TITLE
Log localized settings toolbar title

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsActivity.java
@@ -17,14 +17,11 @@ public class SettingsActivity extends BaseActivity {
         setSupportActionBar(toolbar);
         Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
 
-        toolbar.setTitle(R.string.settings_title);
+        toolbar.setTitle(R.string.title_activity_settings);
         Log.d(
                 "TAG_Soccer",
-                getClass().getSimpleName() + ".onCreate: toolbar title set to " + getString(R.string.settings_title)
-        );
-        Log.d(
-                "TAG_Soccer",
-                getClass().getSimpleName() + ".onCreate: toolbar caption=\"" + toolbar.getTitle() + "\""
+                getClass().getSimpleName() +
+                        ".onCreate: toolbar title set to \"" + toolbar.getTitle() + "\""
         );
 
         getSupportFragmentManager()

--- a/mobile/app/src/main/res/values-fr/strings.xml
+++ b/mobile/app/src/main/res/values-fr/strings.xml
@@ -61,7 +61,6 @@
 
     <!-- Common / settings -->
     <string name="settings">Paramètres</string>
-    <string name="settings_title">Paramètres</string>
     <string name="cancel">Annuler</string>
     <string name="confirm">Confirmer</string>
     <string name="close">Fermer</string>

--- a/mobile/app/src/main/res/values-pl/strings.xml
+++ b/mobile/app/src/main/res/values-pl/strings.xml
@@ -176,7 +176,6 @@
     
     <!-- Common strings -->
     <string name="settings">Ustawienia</string>
-    <string name="settings_title">Ustawienia</string>
     <string name="cancel">Anuluj</string>
     <string name="confirm">Potwierdź</string>
 

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -51,7 +51,6 @@
     <string name="reset_password_failed">Failed to send password reset email. Please try again.</string>
     <string name="nickname">Nickname</string>
     <string name="settings">Settings</string>
-    <string name="settings_title">Settings</string>
     <string name="enter_nickname_to_invite">Enter nickname to invite:</string>
     <string name="enter_nickname_to_search">Enter nickname to search:</string>
     <string name="friend_s_nickname">Friend\'s nickname</string>


### PR DESCRIPTION
## Summary
- log the toolbar caption using the actual title set on SettingsActivity
- reuse existing `title_activity_settings` string and drop redundant `settings_title` entries

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e6f9ba408330b7fd5a8929fbd15b