### PR TITLE
Fix settings toolbar title localization

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SettingsActivity.java
@@ -17,11 +17,13 @@ public class SettingsActivity extends BaseActivity {
         setSupportActionBar(toolbar);
         Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
 
-        toolbar.setTitle(R.string.title_activity_settings);
+        Objects.requireNonNull(getSupportActionBar()).setTitle(R.string.title_activity_settings);
         Log.d(
                 "TAG_Soccer",
                 getClass().getSimpleName() +
-                        ".onCreate: toolbar title set to \"" + toolbar.getTitle() + "\""
+                        ".onCreate: toolbar title set to \"" +
+                        Objects.requireNonNull(getSupportActionBar()).getTitle() +
+                        "\""
         );
 
         getSupportFragmentManager()

--- a/mobile/app/src/main/res/layout/activity_settings.xml
+++ b/mobile/app/src/main/res/layout/activity_settings.xml
@@ -12,7 +12,7 @@
         android:background="?attr/colorPrimary"
         android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         android:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-        android:title="@string/settings"
+        android:title="@string/title_activity_settings"
         app:titleTextColor="@android:color/white" />
 
     <FrameLayout


### PR DESCRIPTION
## Summary
- Ensure SettingsActivity sets toolbar title via support action bar
- Use localized title resource in settings toolbar layout

## Testing
- ⚠️ `./gradlew test` *(failed: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f0635c988330907049b0f71a0d57