### PR TITLE
Store user language on registration and terms acceptance

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
@@ -232,6 +232,9 @@ public class FirebaseAuthManager {
 
                         userData.put("method", "email");
 
+                        String langCode = LanguageManager.getCurrentLanguageCode(context);
+                        userData.put("language", langCode);
+
                         db.collection("users").document(uid).set(userData, SetOptions.merge())
                                 .addOnFailureListener(e ->
                                         Log.e("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object() {

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TermsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TermsActivity.java
@@ -12,6 +12,7 @@ import com.google.firebase.firestore.FieldValue;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.SetOptions;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class TermsActivity extends BaseActivity {
@@ -36,10 +37,10 @@ public class TermsActivity extends BaseActivity {
                 finish();
                 return;
             }
-            Map<String, Object> data = Map.of(
-                    "termsAccepted", true,
-                    "termsAcceptanceDate", FieldValue.serverTimestamp()
-            );
+            Map<String, Object> data = new HashMap<>();
+            data.put("termsAccepted", true);
+            data.put("termsAcceptanceDate", FieldValue.serverTimestamp());
+            data.put("language", langCode);
             FirebaseFirestore.getInstance()
                     .collection("users")
                     .document(uid)


### PR DESCRIPTION
## Summary
- Save current language to Firestore when creating a new account
- Record user language alongside terms acceptance

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f41192908330b9832254ed957b59