### PR TITLE
Display registration reminder on locked feature buttons

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -434,13 +434,8 @@ public class MenuActivity extends BaseActivity {
         }
 
         // Backend is available - proceed with normal auth-based logic
-        // 1) Enable or disable the three feature buttons based on login status
-        inviteBtn.setEnabled(loggedIn);
-        pendingBtn.setEnabled(loggedIn);
-        tournamentsBtn.setEnabled(loggedIn);
-        rankingBtn.setEnabled(loggedIn);
-
-        // Optional: visual cue (dim when disabled due to not being logged in)
+        // Dim buttons when the user is not logged in, but keep them clickable so we can
+        // show a toast informing them to register.
         float alpha = loggedIn ? 1f : 0.4f;
         inviteBtn.setAlpha(alpha);
         pendingBtn.setAlpha(alpha);
@@ -752,6 +747,10 @@ public class MenuActivity extends BaseActivity {
     }
 
     public void OpenInviteFriend(View view) {
+        if (FirebaseAuth.getInstance().getCurrentUser() == null) {
+            Toast.makeText(this, R.string.register_to_use_function, Toast.LENGTH_SHORT).show();
+            return;
+        }
         if (!hasAdsConsent()) {
             showConsentRequiredDialog();
             return;
@@ -761,6 +760,10 @@ public class MenuActivity extends BaseActivity {
     }
 
     public void OpenInvites(View view) {
+        if (FirebaseAuth.getInstance().getCurrentUser() == null) {
+            Toast.makeText(this, R.string.register_to_use_function, Toast.LENGTH_SHORT).show();
+            return;
+        }
         if (!hasAdsConsent()) {
             showConsentRequiredDialog();
             return;
@@ -770,6 +773,10 @@ public class MenuActivity extends BaseActivity {
     }
 
     public void OpenTournaments(View view) {
+        if (FirebaseAuth.getInstance().getCurrentUser() == null) {
+            Toast.makeText(this, R.string.register_to_use_function, Toast.LENGTH_SHORT).show();
+            return;
+        }
         if (!hasAdsConsent()) {
             showConsentRequiredDialog();
             return;
@@ -779,6 +786,10 @@ public class MenuActivity extends BaseActivity {
     }
 
     public void OpenRanking(View view) {
+        if (FirebaseAuth.getInstance().getCurrentUser() == null) {
+            Toast.makeText(this, R.string.register_to_use_function, Toast.LENGTH_SHORT).show();
+            return;
+        }
         if (!hasAdsConsent()) {
             showConsentRequiredDialog();
             return;

--- a/mobile/app/src/main/res/values-bn/strings.xml
+++ b/mobile/app/src/main/res/values-bn/strings.xml
@@ -198,6 +198,7 @@
     <string name="nickname_required">ডাকনাম প্রয়োজন</string>
     <string name="nickname_too_long">ডাকনাম অবশ্যই 20 টি অক্ষর বা তার চেয়ে কম হতে হবে</string>
     <string name="not_logged_in">লগ ইন নেই</string>
+    <string name="register_to_use_function">এই ফাংশনটি ব্যবহার করতে দয়া করে নিজেকে নিবন্ধন করুন।</string>
     <string name="network_error_checking_nickname">ডাকনাম পরীক্ষা করার সময় নেটওয়ার্ক ত্রুটি</string>
     <string name="nickname_taken">ডাকনাম ইতিমধ্যে নেওয়া হয়েছে - অন্যটি বেছে নিন</string>
     <string name="nickname_saved">ডাকনাম সংরক্ষণ</string>

--- a/mobile/app/src/main/res/values-de/strings.xml
+++ b/mobile/app/src/main/res/values-de/strings.xml
@@ -198,6 +198,7 @@
     <string name="nickname_required">Spitzname ist erforderlich</string>
     <string name="nickname_too_long">Spitzname muss 20 Zeichen oder weniger betragen</string>
     <string name="not_logged_in">Nicht angemeldet</string>
+    <string name="register_to_use_function">Bitte registriere dich, um diese Funktion zu verwenden.</string>
     <string name="network_error_checking_nickname">Netzwerkfehler beim Überprüfen des Spitznamens</string>
     <string name="nickname_taken">Spitzname bereits genommen - wählen Sie einen anderen</string>
     <string name="nickname_saved">Spitzname gerettet</string>

--- a/mobile/app/src/main/res/values-es/strings.xml
+++ b/mobile/app/src/main/res/values-es/strings.xml
@@ -198,6 +198,7 @@
     <string name="nickname_required">Se requiere un apodo</string>
     <string name="nickname_too_long">El apodo debe ser 20 caracteres o menos</string>
     <string name="not_logged_in">No iniciado sesión</string>
+    <string name="register_to_use_function">Por favor regístrate para usar esta función.</string>
     <string name="network_error_checking_nickname">Error de red al verificar el apodo</string>
     <string name="nickname_taken">Apodo ya tomado - Elija otro</string>
     <string name="nickname_saved">Apodo guardado</string>

--- a/mobile/app/src/main/res/values-fr/strings.xml
+++ b/mobile/app/src/main/res/values-fr/strings.xml
@@ -201,6 +201,7 @@
     <string name="nickname_required">Un pseudonyme est requis</string>
     <string name="nickname_too_long">Le pseudonyme doit comporter 20 caractères ou moins</string>
     <string name="not_logged_in">Non connecté</string>
+    <string name="register_to_use_function">Veuillez vous inscrire pour utiliser cette fonction.</string>
     <string name="network_error_checking_nickname">Erreur réseau lors de la vérification du pseudonyme</string>
     <string name="nickname_taken">Pseudonyme déjà pris — choisissez-en un autre</string>
     <string name="nickname_saved">Pseudonyme enregistré</string>

--- a/mobile/app/src/main/res/values-hi/strings.xml
+++ b/mobile/app/src/main/res/values-hi/strings.xml
@@ -198,6 +198,7 @@
     <string name="nickname_required">उपनाम की आवश्यकता है</string>
     <string name="nickname_too_long">उपनाम 20 अक्षर या उससे कम होना चाहिए</string>
     <string name="not_logged_in">अंदर प्रवेश की अनुमति नहीं है</string>
+    <string name="register_to_use_function">कृपया इस फ़ंक्शन का उपयोग करने के लिए स्वयं को पंजीकृत करें।</string>
     <string name="network_error_checking_nickname">उपनाम की जाँच करते समय नेटवर्क त्रुटि</string>
     <string name="nickname_taken">उपनाम पहले से ही लिया गया - एक और चुनें</string>
     <string name="nickname_saved">उपनाम बचाया</string>

--- a/mobile/app/src/main/res/values-ne/strings.xml
+++ b/mobile/app/src/main/res/values-ne/strings.xml
@@ -198,6 +198,7 @@
     <string name="nickname_required">उपनाम आवश्यक छ</string>
     <string name="nickname_too_long">उपनाम 20 वर्ण वा कम हुनु पर्छ</string>
     <string name="not_logged_in">लग इन गरिएको छैन</string>
+    <string name="register_to_use_function">कृपया यो सुविधा प्रयोग गर्न आफूलाई दर्ता गर्नुहोस्।</string>
     <string name="network_error_checking_nickname">नेटवर्क त्रुटि उपनाम जाँच गर्दा नेटवर्क त्रुटि</string>
     <string name="nickname_taken">उपनाम पहिले नै लिइएको छ - अर्को छनौट गर्नुहोस्</string>
     <string name="nickname_saved">उपनाम बचत भयो</string>

--- a/mobile/app/src/main/res/values-pl/strings.xml
+++ b/mobile/app/src/main/res/values-pl/strings.xml
@@ -199,6 +199,7 @@
     <string name="nickname_required">Wymagany jest pseudonim</string>
     <string name="nickname_too_long">Pseudonim musi mieć 20 znaków lub mniej</string>
     <string name="not_logged_in">Nie zalogowano</string>
+    <string name="register_to_use_function">Zarejestruj się, aby korzystać z tej funkcji.</string>
     <string name="network_error_checking_nickname">Błąd sieci podczas sprawdzania pseudonim</string>
     <string name="nickname_taken">Pseudonim już zabrany - wybierz inny</string>
     <string name="nickname_saved">Zapisany pseudonim</string>

--- a/mobile/app/src/main/res/values-ur/strings.xml
+++ b/mobile/app/src/main/res/values-ur/strings.xml
@@ -198,6 +198,7 @@
     <string name="nickname_required">عرفی نام کی ضرورت ہے</string>
     <string name="nickname_too_long">عرفی نام 20 حروف یا اس سے کم ہونا چاہئے</string>
     <string name="not_logged_in">لاگ ان نہیں</string>
+    <string name="register_to_use_function">براہ کرم اس فنکشن کو استعمال کرنے کے لیے خود کو رجسٹر کریں۔</string>
     <string name="network_error_checking_nickname">عرفی نام کی جانچ پڑتال کے دوران نیٹ ورک کی خرابی</string>
     <string name="nickname_taken">پہلے سے لیا گیا عرفی نام - ایک اور کا انتخاب کریں</string>
     <string name="nickname_saved">عرفی نام بچ گیا</string>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -192,6 +192,7 @@
     <string name="nickname_required">Nickname is required</string>
     <string name="nickname_too_long">Nickname must be 20 characters or less</string>
     <string name="not_logged_in">Not logged in</string>
+    <string name="register_to_use_function">Please register yourself to use this function</string>
     <string name="network_error_checking_nickname">Network error while checking nickname</string>
     <string name="nickname_taken">Nickname already taken — choose another</string>
     <string name="nickname_saved">Nickname saved</string>


### PR DESCRIPTION
## Summary
- Dim feature buttons when not logged in but keep them clickable
- Show localized toast prompting registration when Invite Friend, Pending Invites, Tournaments or Ranking buttons are tapped without an account
- Add translation for the reminder across all supported languages

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f572b5f883308990a2bc02169291