### PR TITLE
Persist user language preference on login

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
@@ -66,6 +66,8 @@ public class FirebaseAuthManager {
                                 Map<String, Object> data = new HashMap<>();
                                 if (email != null) data.put("email", email);
                                 data.put("method", providerId);
+                                String langCode = LanguageManager.getCurrentLanguageCode(context);
+                                data.put("language", langCode);
 
                                 String nicknameToStore;
                                 if (existingNick == null || existingNick.isEmpty()) {
@@ -160,6 +162,8 @@ public class FirebaseAuthManager {
                                             Map<String, Object> data = new HashMap<>();
                                             data.put("method", "email");
                                             if (email != null) data.put("email", email);
+                                            String langCode = LanguageManager.getCurrentLanguageCode(context);
+                                            data.put("language", langCode);
                                             db.collection("users").document(uid).set(data, SetOptions.merge());
 
                                             // Preserve any previously-saved nickname instead of overwriting it


### PR DESCRIPTION
## Summary
- Update login flows to push the device's current language ISO code to each user's Firestore record
- Ensures stored preferences sync `users.language` after re-login

## Testing
- ⚠️ `./gradlew test` *(Failed: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f6d1ee2083308f4e06d20f098e9d