### PR TITLE
Enable Facebook Sign-In in deploy script

### DIFF
--- a/gcp/cloud-build/deploy_firebase_with_auth.yaml
+++ b/gcp/cloud-build/deploy_firebase_with_auth.yaml
@@ -183,5 +183,83 @@ steps:
           exit 1
         fi
 
+  # ────────────────────────────────
+  # Step 5: Enable Facebook Sign-In
+  # ────────────────────────────────
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: enable-facebook-auth
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -ex
+
+        firebase_project_id=$(cat /workspace/SOCCER_PROJECT_ID.txt)
+        access_token=$(cat /workspace/access_token.txt)
+
+        echo "🔐 Retrieving secrets from Secret Manager (org-service-account-001)…"
+
+        gcloud secrets versions access latest \
+          --secret=facebook-app-id \
+          --project="690882718361" | tr -d '\n' > /workspace/facebook-app-id.txt
+
+        gcloud secrets versions access latest \
+          --secret=facebook-app-secret \
+          --project="690882718361" | tr -d '\n' > /workspace/facebook-app-secret.txt
+
+        if [ ! -s /workspace/facebook-app-id.txt ] || [ -z "$(cat /workspace/facebook-app-id.txt)" ]; then
+          echo "❌ Error: Failed to retrieve facebook-app-id"
+          exit 1
+        fi
+
+        if [ ! -s /workspace/facebook-app-secret.txt ] || [ -z "$(cat /workspace/facebook-app-secret.txt)" ]; then
+          echo "❌ Error: Failed to retrieve facebook-app-secret"
+          exit 1
+        fi
+
+        client_id=$(cat /workspace/facebook-app-id.txt)
+        client_secret=$(cat /workspace/facebook-app-secret.txt)
+
+        echo "🔓 Enabling Facebook Sign-In for project: $firebase_project_id"
+
+        patch_resp=$(curl -s -o /dev/null -w '%{http_code}' -X PATCH \
+          -H "Authorization: Bearer $access_token" \
+          -H "X-Goog-User-Project: $firebase_project_id" \
+          -H "Content-Type: application/json" \
+          "https://identitytoolkit.googleapis.com/admin/v2/projects/$firebase_project_id/defaultSupportedIdpConfigs/facebook.com?updateMask=enabled,clientId,clientSecret" \
+          -d '{
+                "enabled": true,
+                "clientId": "'"$client_id"'",
+                "clientSecret": "'"$client_secret"'"
+              }')
+
+        if [[ "$patch_resp" == "200" ]]; then
+          echo "✅ Facebook Sign-In provider updated."
+          exit 0
+        fi
+
+        echo "ℹ️  Trying to create Facebook provider…"
+
+        create_resp=$(curl -s -w '\n%{http_code}' -X POST \
+          -H "Authorization: Bearer $access_token" \
+          -H "X-Goog-User-Project: $firebase_project_id" \
+          -H "Content-Type: application/json" \
+          "https://identitytoolkit.googleapis.com/admin/v2/projects/$firebase_project_id/defaultSupportedIdpConfigs?idpId=facebook.com" \
+          -d '{
+                "enabled": true,
+                "clientId": "'"$client_id"'",
+                "clientSecret": "'"$client_secret"'"
+              }')
+
+        create_code=$(echo "$create_resp" | tail -n1)
+
+        if [[ "$create_code" == "200" ]]; then
+          echo "✅ Facebook Sign-In provider created."
+        else
+          echo "❌ Failed to create provider (HTTP $create_code):"
+          echo "$create_resp"
+          exit 1
+        fi
+
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## Summary
- add new Cloud Build step to configure Facebook Sign-In using secrets `facebook-app-id` and `facebook-app-secret`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8c93038288330a788a4afb6cebc12