### PR TITLE
Enable Facebook login option

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/UniversalLoginActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/UniversalLoginActivity.java
@@ -6,6 +6,7 @@ import android.widget.Button;
 import android.widget.Toast;
 import android.content.SharedPreferences;
 import android.util.Log;
+import android.view.View;
 import java.util.Objects;
 
 import androidx.annotation.Nullable;
@@ -38,6 +39,7 @@ public class UniversalLoginActivity extends BaseActivity {
         Button btnEmail = findViewById(R.id.btnUniversalEmail);
         Button btnGoogle = findViewById(R.id.btnUniversalGoogle);
         Button btnFacebook = findViewById(R.id.btnUniversalFacebook);
+        btnFacebook.setVisibility(View.VISIBLE);
         Button btnMicrosoft = findViewById(R.id.btnUniversalMicrosoft);
 
         btnEmail.setOnClickListener(v -> {

--- a/mobile/app/src/main/res/layout/activity_universal_login.xml
+++ b/mobile/app/src/main/res/layout/activity_universal_login.xml
@@ -58,8 +58,7 @@
         android:drawablePadding="8dp"
         android:text="@string/login_facebook"
         android:textAllCaps="false"
-        android:textColor="@color/colorWhite"
-        android:visibility="gone" />
+        android:textColor="@color/colorWhite" />
 
     <Button
         android:id="@+id/btnUniversalMicrosoft"


### PR DESCRIPTION
## Summary
- Show Facebook login button in universal login screen
- Explicitly mark Facebook login button visible in activity

## Testing
- `./gradlew test` (fails: SDK location not found)

------
https://chatgpt.com/codex/tasks/task_e_68a8cf17978c8330b6daaf55c51e8f2f