### PR TITLE
Initialize Facebook SDK on app startup

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -21,6 +21,7 @@ import androidx.work.WorkManager;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 
+import com.facebook.FacebookSdk;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
@@ -84,6 +85,8 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
     @Override
     public void onCreate() {
         super.onCreate();
+
+        FacebookSdk.sdkInitialize(getApplicationContext());
 
         String code = LanguageManager.getCurrentLanguageCode(this);
         AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(code));


### PR DESCRIPTION
## Summary
- import Facebook SDK in SoccerApp
- call FacebookSdk.sdkInitialize in onCreate to prepare Facebook login

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8dd2b686c8330adfe5bc60dac75b8