### PR TITLE
Fix Facebook SDK initialization

### DIFF
--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
             android:value="@string/facebook_app_id" />
         <provider
             android:name="com.facebook.FacebookContentProvider"
-            android:authorities="com.facebook.app.FacebookContentProvider123456789"
+            android:authorities="com.facebook.app.FacebookContentProvider1232966491486195"
             android:exported="true" />
         <activity
             android:name="com.facebook.FacebookActivity"

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -22,6 +22,7 @@ import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 
 import com.facebook.FacebookSdk;
+import com.facebook.appevents.AppEventsLogger;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
@@ -87,6 +88,8 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
         super.onCreate();
 
         FacebookSdk.sdkInitialize(getApplicationContext());
+        AppEventsLogger.activateApp(this);
+        Log.d("TAG_Soccer", getClass().getSimpleName() + ".onCreate: Facebook SDK initialized");
 
         String code = LanguageManager.getCurrentLanguageCode(this);
         AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(code));


### PR DESCRIPTION
## Summary
- Correct Facebook content provider authority to match the real app ID
- Initialize AppEventsLogger and log when Facebook SDK is ready

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a996f486dc8330b4a7d11cce7f7b1a