### PR TITLE
Handle initialization errors for Facebook SDK

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -87,9 +87,17 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
     public void onCreate() {
         super.onCreate();
 
-        FacebookSdk.sdkInitialize(getApplicationContext());
-        AppEventsLogger.activateApp(this);
-        Log.d("TAG_Soccer", getClass().getSimpleName() + ".onCreate: Facebook SDK initialized");
+        try {
+            FacebookSdk.sdkInitialize(getApplicationContext());
+            AppEventsLogger.activateApp(this);
+            Log.d("TAG_Soccer", getClass().getSimpleName() + ".onCreate: Facebook SDK initialized");
+        } catch (Exception e) {
+            Log.w(
+                    "TAG_Soccer",
+                    getClass().getSimpleName() + ".onCreate: Facebook SDK init failed",
+                    e
+            );
+        }
 
         String code = LanguageManager.getCurrentLanguageCode(this);
         AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(code));


### PR DESCRIPTION
## Summary
- safeguard SoccerApp startup by wrapping Facebook SDK initialization in try/catch to avoid app crash and log failure

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a99cb239a88330a3c633c155056477