### PR TITLE
chore: skip Facebook SDK init when client token missing

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -88,14 +88,34 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
         super.onCreate();
 
         try {
-            FacebookSdk.sdkInitialize(getApplicationContext());
-            AppEventsLogger.activateApp(this);
-            Log.d("TAG_Soccer", getClass().getSimpleName() + ".onCreate: Facebook SDK initialized");
-        } catch (Exception e) {
+            int tokenRes = getResources().getIdentifier("facebook_client_token", "string", getPackageName());
+            if (tokenRes != 0) {
+                String clientToken = getString(tokenRes);
+                if (!clientToken.isEmpty()) {
+                    FacebookSdk.setClientToken(clientToken);
+                    FacebookSdk.sdkInitialize(getApplicationContext());
+                    AppEventsLogger.activateApp(this);
+                    Log.d(
+                            "TAG_Soccer",
+                            getClass().getSimpleName() + ".onCreate: Facebook SDK initialized"
+                    );
+                } else {
+                    Log.w(
+                            "TAG_Soccer",
+                            getClass().getSimpleName() + ".onCreate: Facebook client token empty; skipping initialization"
+                    );
+                }
+            } else {
+                Log.w(
+                        "TAG_Soccer",
+                        getClass().getSimpleName() + ".onCreate: Facebook client token missing; skipping initialization"
+                );
+            }
+        } catch (Throwable t) {
             Log.w(
                     "TAG_Soccer",
                     getClass().getSimpleName() + ".onCreate: Facebook SDK init failed",
-                    e
+                    t
             );
         }
 


### PR DESCRIPTION
## Summary
- avoid initializing Facebook SDK when client token is absent
- log missing token and catch all errors to keep app running

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9acadb4048330bb24b560f9f69794