### PR TITLE
Allow Facebook SDK init without client token

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -89,10 +89,29 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
 
         try {
             int tokenRes = getResources().getIdentifier("facebook_client_token", "string", getPackageName());
+            int appIdRes = getResources().getIdentifier("facebook_app_id", "string", getPackageName());
+
             if (tokenRes != 0) {
                 String clientToken = getString(tokenRes);
                 if (!clientToken.isEmpty()) {
                     FacebookSdk.setClientToken(clientToken);
+                } else {
+                    Log.w(
+                            "TAG_Soccer",
+                            getClass().getSimpleName() + ".onCreate: Facebook client token empty; proceeding without it"
+                    );
+                }
+            } else {
+                Log.w(
+                        "TAG_Soccer",
+                        getClass().getSimpleName() + ".onCreate: Facebook client token missing; proceeding without it"
+                );
+            }
+
+            if (appIdRes != 0) {
+                String appId = getString(appIdRes);
+                if (!appId.isEmpty()) {
+                    FacebookSdk.setApplicationId(appId);
                     FacebookSdk.sdkInitialize(getApplicationContext());
                     AppEventsLogger.activateApp(this);
                     Log.d(
@@ -102,13 +121,13 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
                 } else {
                     Log.w(
                             "TAG_Soccer",
-                            getClass().getSimpleName() + ".onCreate: Facebook client token empty; skipping initialization"
+                            getClass().getSimpleName() + ".onCreate: Facebook app id empty; skipping initialization"
                     );
                 }
             } else {
                 Log.w(
                         "TAG_Soccer",
-                        getClass().getSimpleName() + ".onCreate: Facebook client token missing; skipping initialization"
+                        getClass().getSimpleName() + ".onCreate: Facebook app id missing; skipping initialization"
                 );
             }
         } catch (Throwable t) {


### PR DESCRIPTION
## Summary
- initialize Facebook SDK even when no `facebook_client_token` is provided

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9af2f44b883309da9ab43febf17ad