### PR TITLE
Gracefully handle missing Facebook SDK

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -91,43 +91,22 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
             int tokenRes = getResources().getIdentifier("facebook_client_token", "string", getPackageName());
             int appIdRes = getResources().getIdentifier("facebook_app_id", "string", getPackageName());
 
-            if (tokenRes != 0) {
-                String clientToken = getString(tokenRes);
-                if (!clientToken.isEmpty()) {
-                    FacebookSdk.setClientToken(clientToken);
-                } else {
-                    Log.w(
-                            "TAG_Soccer",
-                            getClass().getSimpleName() + ".onCreate: Facebook client token empty; proceeding without it"
-                    );
-                }
-            } else {
-                Log.w(
-                        "TAG_Soccer",
-                        getClass().getSimpleName() + ".onCreate: Facebook client token missing; proceeding without it"
-                );
-            }
+            boolean hasToken = tokenRes != 0 && !getString(tokenRes).isEmpty();
+            boolean hasAppId = appIdRes != 0 && !getString(appIdRes).isEmpty();
 
-            if (appIdRes != 0) {
-                String appId = getString(appIdRes);
-                if (!appId.isEmpty()) {
-                    FacebookSdk.setApplicationId(appId);
-                    FacebookSdk.sdkInitialize(getApplicationContext());
-                    AppEventsLogger.activateApp(this);
-                    Log.d(
-                            "TAG_Soccer",
-                            getClass().getSimpleName() + ".onCreate: Facebook SDK initialized"
-                    );
-                } else {
-                    Log.w(
-                            "TAG_Soccer",
-                            getClass().getSimpleName() + ".onCreate: Facebook app id empty; skipping initialization"
-                    );
-                }
+            if (hasToken && hasAppId) {
+                FacebookSdk.setClientToken(getString(tokenRes));
+                FacebookSdk.setApplicationId(getString(appIdRes));
+                FacebookSdk.sdkInitialize(getApplicationContext());
+                AppEventsLogger.activateApp(this);
+                Log.d(
+                        "TAG_Soccer",
+                        getClass().getSimpleName() + ".onCreate: Facebook SDK initialized"
+                );
             } else {
                 Log.w(
                         "TAG_Soccer",
-                        getClass().getSimpleName() + ".onCreate: Facebook app id missing; skipping initialization"
+                        getClass().getSimpleName() + ".onCreate: Facebook SDK not configured; skipping initialization"
                 );
             }
         } catch (Throwable t) {

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/UniversalLoginActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/UniversalLoginActivity.java
@@ -17,6 +17,7 @@ import androidx.appcompat.widget.Toolbar;
 import com.facebook.CallbackManager;
 import com.facebook.FacebookCallback;
 import com.facebook.FacebookException;
+import com.facebook.FacebookSdk;
 import com.facebook.login.LoginManager;
 import com.facebook.login.LoginResult;
 import com.google.firebase.auth.FirebaseAuth;
@@ -49,7 +50,6 @@ public class UniversalLoginActivity extends BaseActivity {
         Button btnEmail = findViewById(R.id.btnUniversalEmail);
         Button btnGoogle = findViewById(R.id.btnUniversalGoogle);
         Button btnFacebook = findViewById(R.id.btnUniversalFacebook);
-        btnFacebook.setVisibility(View.VISIBLE);
         Button btnMicrosoft = findViewById(R.id.btnUniversalMicrosoft);
 
         btnEmail.setOnClickListener(v -> {
@@ -57,8 +57,18 @@ public class UniversalLoginActivity extends BaseActivity {
         });
 
         btnGoogle.setOnClickListener(v -> handleProviderLogin("google.com"));
-        btnFacebook.setOnClickListener(v -> handleProviderLogin("facebook.com"));
         btnMicrosoft.setOnClickListener(v -> handleProviderLogin("microsoft.com"));
+
+        if (FacebookSdk.isInitialized()) {
+            btnFacebook.setVisibility(View.VISIBLE);
+            btnFacebook.setOnClickListener(v -> handleProviderLogin("facebook.com"));
+        } else {
+            Log.w(
+                    "TAG_Soccer",
+                    getClass().getSimpleName() + ".onCreate: Facebook SDK not initialized; hiding Facebook login"
+            );
+            btnFacebook.setVisibility(View.GONE);
+        }
     }
 
     @Override
@@ -146,6 +156,15 @@ public class UniversalLoginActivity extends BaseActivity {
     }
 
     private void handleFacebookLogin(FirebaseAuthManager.LoginCallback callback) {
+        if (!FacebookSdk.isInitialized()) {
+            Log.w(
+                    "TAG_Soccer",
+                    getClass().getSimpleName() + ".handleFacebookLogin: Facebook SDK not initialized"
+            );
+            callback.onLoginFailure("facebook_unavailable");
+            return;
+        }
+
         LoginManager.getInstance().logInWithReadPermissions(this, Arrays.asList("email", "public_profile"));
         LoginManager.getInstance().registerCallback(callbackManager, new FacebookCallback<LoginResult>() {
             @Override


### PR DESCRIPTION
## Summary
- Avoid initializing the Facebook SDK when configuration is incomplete
- Hide Facebook login button and guard login path if SDK isn't ready

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b2b2413c83309705af0db078ea1b