### PR TITLE
fix: remove deprecated freshness flag

### DIFF
--- a/gcp/cloud-build/test_delete_unverified_users.yaml
+++ b/gcp/cloud-build/test_delete_unverified_users.yaml
@@ -64,12 +64,15 @@ steps:
         sleep 30
 
         echo "Reading logs for function 'deleteUnverifiedUsers' from the last 5 minutes..."
-        # Show the last few lines of logs
+        # Calculate the start time 5 minutes ago in RFC3339 format
+        start_time=$(date -u -d '5 minutes ago' '+%Y-%m-%dT%H:%M:%SZ')
+
+        # Show the last few lines of logs from the calculated start time
         gcloud functions logs read deleteUnverifiedUsers \
           --region=us-central1 \
           --project="$project_id" \
           --limit=20 \
-          --freshness=5m \
+          --start-time="$start_time" \
           > /workspace/log_output.txt || true
 
         echo "===== LOG OUTPUT ====="


### PR DESCRIPTION
## Summary
- replace deprecated gcloud `--freshness` flag with RFC3339 `--start-time`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab7b84f1b88330a45258c0ce752f4e