### PR TITLE
Resolve variable shadowing in AccountActivity logout handler

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/AccountActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/AccountActivity.java
@@ -104,10 +104,10 @@ public class AccountActivity extends BaseActivity {
         methodView.setText(getString(R.string.login_method_label, method));
 
         logoutBtn.setOnClickListener(v -> {
-            String method = getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE)
+            String currentMethod = getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE)
                     .getString("method", "-");
-            
-            if ("anonymous".equals(method)) {
+
+            if ("anonymous".equals(currentMethod)) {
                 showAnonymousLogoutWarning();
             } else {
                 performLogout();


### PR DESCRIPTION
## Summary
- Rename inner variable in logout click listener to avoid shadowing and compilation error

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc737424c833094510fe7c631f51c