### PR TITLE
chore: require root for sync scripts

### DIFF
--- a/tools/sync-dev-to-test.ps1
+++ b/tools/sync-dev-to-test.ps1
@@ -1,2 +1,7 @@
+if (-not (Test-Path (Join-Path (Get-Location) '.gitmodules'))) {
+    Write-Error "Run this script from the repository root (Soccer) with 'tools\\sync-dev-to-test.ps1'."
+    exit 1
+}
+
 . "$PSScriptRoot/sync-branches.ps1"
 Sync-Branches -Source 'dev' -Target 'test'

--- a/tools/sync-test-to-prod.ps1
+++ b/tools/sync-test-to-prod.ps1
@@ -1,2 +1,7 @@
+if (-not (Test-Path (Join-Path (Get-Location) '.gitmodules'))) {
+    Write-Error "Run this script from the repository root (Soccer) with 'tools\\sync-test-to-prod.ps1'."
+    exit 1
+}
+
 . "$PSScriptRoot/sync-branches.ps1"
 Sync-Branches -Source 'test' -Target 'prod'


### PR DESCRIPTION
## Summary
- abort `sync-dev-to-test.ps1` and `sync-test-to-prod.ps1` if not run from repository root

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pwsh ./tools/sync-dev-to-test.ps1` *(fails: command not found: pwsh)*


------
https://chatgpt.com/codex/tasks/task_e_68aec3682b408330bf65ad42e2d26f4b