### PR TITLE
Replace deprecated Android and Facebook APIs

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/AccountActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/AccountActivity.java
@@ -10,6 +10,8 @@ import android.widget.Toast;
 import android.view.View;
 import android.content.Intent;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
 
@@ -310,15 +312,15 @@ public class AccountActivity extends BaseActivity {
         finish();
     }
 
-    @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-        
-        if (requestCode == LINK_ACCOUNT_REQUEST_CODE && resultCode == RESULT_OK) {
-            // Account linking was successful, refresh the UI with updated data
-            refreshAccountData();
-        }
-    }
+    private final ActivityResultLauncher<Intent> linkAccountLauncher =
+            registerForActivityResult(
+                    new ActivityResultContracts.StartActivityForResult(),
+                    result -> {
+                        if (result.getResultCode() == RESULT_OK) {
+                            // Account linking was successful, refresh the UI with updated data
+                            refreshAccountData();
+                        }
+                    });
 
     /**
      * Refreshes the account data from SharedPreferences and updates the UI.
@@ -404,14 +406,12 @@ public class AccountActivity extends BaseActivity {
         methodView.setText(getString(R.string.login_method_label, method));
     }
 
-    private static final int LINK_ACCOUNT_REQUEST_CODE = 1001;
-
     /**
      * Starts the link account activity to allow anonymous users to link their account
      * with email, Google, or Facebook credentials.
      */
     private void startLinkAccountActivity() {
         Intent intent = new Intent(this, LinkAccountActivity.class);
-        startActivityForResult(intent, LINK_ACCOUNT_REQUEST_CODE);
+        linkAccountLauncher.launch(intent);
     }
 }

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -118,7 +118,7 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
             if (hasToken && hasAppId) {
                 FacebookSdk.setClientToken(clientToken);
                 FacebookSdk.setApplicationId(getString(appIdRes));
-                FacebookSdk.sdkInitialize(getApplicationContext());
+                FacebookSdk.fullyInitialize();
                 AppEventsLogger.activateApp(this);
                 Log.d(
                         "TAG_Soccer",


### PR DESCRIPTION
## Summary
- Replace deprecated startActivityForResult pattern in AccountActivity with ActivityResultLauncher
- Use FacebookSdk.fullyInitialize instead of deprecated sdkInitialize call

## Testing
- `./gradlew test` *(fails: Could not find com.google.firebase:firebase-crashlytics-gradle:3.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b01a249008833093bddca151027fa5