### PR TITLE
Disable multiple registration clicks

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegulationActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RegulationActivity.java
@@ -24,6 +24,7 @@ public class RegulationActivity extends BaseActivity {
     private String tournamentId;
     private String regulationId;
     private AnalyticsManager analyticsManager;
+    private Button acceptBtn;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -32,7 +33,7 @@ public class RegulationActivity extends BaseActivity {
 
         TextView nameTv = findViewById(R.id.regulationName);
         TextView bodyTv = findViewById(R.id.regulationBody);
-        Button acceptBtn = findViewById(R.id.acceptRegulation);
+        acceptBtn = findViewById(R.id.acceptRegulation);
         Button declineBtn = findViewById(R.id.declineRegulation);
 
         tournamentId = getIntent().getStringExtra("tournamentId");
@@ -132,11 +133,15 @@ public class RegulationActivity extends BaseActivity {
                 Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
                 ": starting acceptAndJoin");
 
+        acceptBtn.setEnabled(false);
+        Toast.makeText(this, R.string.registration_in_progress, Toast.LENGTH_SHORT).show();
+
         if (TextUtils.isEmpty(tournamentId)) {
             Log.e("TAG_Soccer", getClass().getSimpleName() + "." +
                     Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
                     ": empty tournamentId");
             Toast.makeText(this, getString(R.string.tournament_not_found), Toast.LENGTH_LONG).show();
+            acceptBtn.setEnabled(true);
             return;
         }
         FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
@@ -145,6 +150,7 @@ public class RegulationActivity extends BaseActivity {
                     Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
                     ": user not logged-in");
             Toast.makeText(this, getString(R.string.must_be_logged_in), Toast.LENGTH_LONG).show();
+            acceptBtn.setEnabled(true);
             return;
         }
 
@@ -197,7 +203,14 @@ public class RegulationActivity extends BaseActivity {
                                 Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
                                 ": joinTournament failed", e);
                         Toast.makeText(this, e.getMessage(), Toast.LENGTH_LONG).show();
+                        acceptBtn.setEnabled(true);
                     });
+        }).addOnFailureListener(e -> {
+            Log.e("TAG_Soccer", getClass().getSimpleName() + "." +
+                    Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
+                    ": token refresh failed", e);
+            Toast.makeText(this, e.getMessage(), Toast.LENGTH_LONG).show();
+            acceptBtn.setEnabled(true);
         });
     }
 }


### PR DESCRIPTION
## Summary
- prevent multiple tournament registration submissions by disabling Accept button and displaying a "registration in progress" message
- re-enable the button when registration fails

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b01f0e0d90833084c2f781dac43c81