### PR TITLE
Remove deprecated Firebase Analytics API

### DIFF
--- a/gcp/cloud-build/README-firebase-analytics.md
+++ b/gcp/cloud-build/README-firebase-analytics.md
@@ -9,7 +9,7 @@ Cloud Build script that enables Firebase Analytics for the project.
 
 **Features:**
 - Checks if Firebase Analytics is already enabled before attempting to enable it
-- Enables required APIs (`firebase.googleapis.com`, `firebaseanalytics.googleapis.com`)
+- Enables required API (`firebase.googleapis.com`)
 - Creates Google Analytics property and links it to Firebase
 - Provides comprehensive error handling for various scenarios
 - Verifies successful enablement
@@ -23,10 +23,10 @@ gcloud builds submit --config gcp/cloud-build/deploy_firebase_analytics.yaml
 Test script that validates Firebase Analytics configuration.
 
 **Features:**
-- Checks project accessibility
-- Validates required APIs are enabled
-- Tests Analytics configuration endpoints
-- Provides diagnostic information
+ - Checks project accessibility
+ - Validates required API is enabled
+ - Tests Analytics configuration endpoints
+ - Provides diagnostic information
 
 **Usage:**
 ```bash

--- a/gcp/cloud-build/deploy_firebase_analytics.yaml
+++ b/gcp/cloud-build/deploy_firebase_analytics.yaml
@@ -55,11 +55,10 @@ steps:
         fi
       }
 
-      # Enable Firebase APIs required for Analytics
+      # Enable Firebase API required for Analytics
       enable_api "firebase.googleapis.com"
-      enable_api "firebaseanalytics.googleapis.com"
 
-      echo "🎉 All required Firebase Analytics APIs are enabled."
+      echo "🎉 Firebase API for Analytics enabled."
 
 # 2. Generate access token for Firebase Management API calls
 - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'

--- a/gcp/cloud-build/test_firebase_analytics.yaml
+++ b/gcp/cloud-build/test_firebase_analytics.yaml
@@ -100,15 +100,14 @@ steps:
           fi
         }
 
-        # Check required APIs
+        # Check required API
         api_status=0
         check_api "firebase.googleapis.com" || api_status=1
-        check_api "firebaseanalytics.googleapis.com" || api_status=1
 
         if [ $api_status -eq 0 ]; then
-          echo "✅ All required APIs for Firebase Analytics are enabled."
+          echo "✅ Firebase API for Analytics is enabled."
         else
-          echo "⚠️ Some required APIs are missing. Run deploy_firebase_analytics.yaml first."
+          echo "⚠️ Firebase API is missing. Run deploy_firebase_analytics.yaml first."
         fi
 
   # Step 5: Test Analytics configuration endpoint


### PR DESCRIPTION
## Summary
- stop enabling non-existent firebaseanalytics.googleapis.com service
- update tests to check only firebase.googleapis.com
- document single required Firebase API for analytics setup

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b0a7e51adc8330be3e4e411eaa27a3