### PR TITLE
fix: require analytics account id for analytics deployment

### DIFF
--- a/gcp/cloud-build/README-firebase-analytics.md
+++ b/gcp/cloud-build/README-firebase-analytics.md
@@ -10,13 +10,14 @@ Cloud Build script that enables Firebase Analytics for the project.
 **Features:**
 - Checks if Firebase Analytics is already enabled before attempting to enable it
 - Enables required API (`firebase.googleapis.com`)
-- Creates Google Analytics property and links it to Firebase
+- Creates Google Analytics property under your Analytics account and links it to Firebase
 - Provides comprehensive error handling for various scenarios
 - Verifies successful enablement
 
 **Usage:**
 ```bash
-gcloud builds submit --config gcp/cloud-build/deploy_firebase_analytics.yaml
+gcloud builds submit --config gcp/cloud-build/deploy_firebase_analytics.yaml \
+  --substitutions=_ANALYTICS_ACCOUNT_ID=YOUR_ACCOUNT_ID
 ```
 
 ### `test_firebase_analytics.yaml`

--- a/gcp/cloud-build/deploy_firebase_analytics.yaml
+++ b/gcp/cloud-build/deploy_firebase_analytics.yaml
@@ -2,6 +2,7 @@
 substitutions:
   _ENVIRONMENT: 'dev'
   _FOLDER_NAME: 'soccer'
+  _ANALYTICS_ACCOUNT_ID: ''
 
 steps:
 # 0. Resolve Firebase project ID & number
@@ -136,15 +137,20 @@ steps:
 
       echo "🚀 Enabling Firebase Analytics for project: $project..."
 
-      # Try to enable Analytics using Firebase Management API
-      # This creates a Google Analytics property and links it to Firebase.
-      # Sending an empty payload allows Firebase to create and link a
-      # property automatically without conflicting fields.
+      analytics_account_id="${_ANALYTICS_ACCOUNT_ID}"
+      if [ -z "$analytics_account_id" ]; then
+        echo "❌ _ANALYTICS_ACCOUNT_ID must be provided."
+        exit 1
+      fi
+
+      # Try to enable Analytics using Firebase Management API. This creates
+      # a Google Analytics property under the specified account and links it
+      # to Firebase.
       response=$(curl -s -w '\n%{http_code}' -X POST \
         -H "Authorization: Bearer $access_token" \
         -H "Content-Type: application/json" \
         "https://firebase.googleapis.com/v1beta1/projects/$project:addGoogleAnalytics" \
-        -d '{}')
+        -d "{\"analyticsAccountId\":\"$analytics_account_id\"}")
 
       http_code=$(echo "$response" | tail -n1)
       body=$(echo "$response" | head -n-1)


### PR DESCRIPTION
## Summary
- ensure deploy_firebase_analytics requires a Google Analytics account id when enabling analytics
- document required substitution in firebase analytics README

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b131bc6fe08330b93a478e8843668e