### PR TITLE
Handle optional Analytics account ID in deployment script

### DIFF
--- a/gcp/cloud-build/README-firebase-analytics.md
+++ b/gcp/cloud-build/README-firebase-analytics.md
@@ -10,7 +10,7 @@ Cloud Build script that enables Firebase Analytics for the project.
 **Features:**
 - Checks if Firebase Analytics is already enabled before attempting to enable it
 - Enables required API (`firebase.googleapis.com`)
-- Creates Google Analytics property under your Analytics account and links it to Firebase
+- Creates or links a Google Analytics property for the Firebase project
 - Provides comprehensive error handling for various scenarios
 - Verifies successful enablement
 
@@ -19,6 +19,9 @@ Cloud Build script that enables Firebase Analytics for the project.
 gcloud builds submit --config gcp/cloud-build/deploy_firebase_analytics.yaml \
   --substitutions=_ANALYTICS_ACCOUNT_ID=YOUR_ACCOUNT_ID
 ```
+
+If `_ANALYTICS_ACCOUNT_ID` is omitted, the script will create a new Google
+Analytics property automatically.
 
 ### `test_firebase_analytics.yaml`
 Test script that validates Firebase Analytics configuration.

--- a/gcp/cloud-build/deploy_firebase_analytics.yaml
+++ b/gcp/cloud-build/deploy_firebase_analytics.yaml
@@ -136,21 +136,21 @@ steps:
       fi
 
       echo "🚀 Enabling Firebase Analytics for project: $project..."
-
       analytics_account_id="${_ANALYTICS_ACCOUNT_ID}"
       if [ -z "$analytics_account_id" ]; then
-        echo "❌ _ANALYTICS_ACCOUNT_ID must be provided."
-        exit 1
+        echo "ℹ️ _ANALYTICS_ACCOUNT_ID not provided. Creating new Analytics property."
+        data='{}'
+      else
+        data="{\"analyticsAccountId\":\"$analytics_account_id\"}"
       fi
 
       # Try to enable Analytics using Firebase Management API. This creates
-      # a Google Analytics property under the specified account and links it
-      # to Firebase.
+      # or links a Google Analytics property and associates it with Firebase.
       response=$(curl -s -w '\n%{http_code}' -X POST \
         -H "Authorization: Bearer $access_token" \
         -H "Content-Type: application/json" \
         "https://firebase.googleapis.com/v1beta1/projects/$project:addGoogleAnalytics" \
-        -d "{\"analyticsAccountId\":\"$analytics_account_id\"}")
+        -d "$data")
 
       http_code=$(echo "$response" | tail -n1)
       body=$(echo "$response" | head -n-1)


### PR DESCRIPTION
## Summary
- Allow `deploy_firebase_analytics.yaml` to proceed without `_ANALYTICS_ACCOUNT_ID`, creating a new Analytics property when not supplied
- Document that `_ANALYTICS_ACCOUNT_ID` is optional in the Firebase Analytics deployment guide

## Testing
- ⚠️ `npm test` (missing script)
- ⚠️ `yamllint gcp/cloud-build/deploy_firebase_analytics.yaml` (style warnings)
- ✅ `python - <<'PY'
import yaml, sys
with open('gcp/cloud-build/deploy_firebase_analytics.yaml') as f:
    yaml.safe_load(f)
print('YAML parsed successfully')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b145590500833083d02b6741a80010