### PR TITLE
Require Analytics account ID for Firebase Analytics setup

### DIFF
--- a/gcp/cloud-build/README-firebase-analytics.md
+++ b/gcp/cloud-build/README-firebase-analytics.md
@@ -20,8 +20,9 @@ gcloud builds submit --config gcp/cloud-build/deploy_firebase_analytics.yaml \
   --substitutions=_ANALYTICS_ACCOUNT_ID=YOUR_ACCOUNT_ID
 ```
 
-If `_ANALYTICS_ACCOUNT_ID` is omitted, the script will create a new Google
-Analytics property automatically.
+The `_ANALYTICS_ACCOUNT_ID` substitution is **required**. The Firebase
+Management API needs the ID of an existing Google Analytics account to link or
+provision a property for the Firebase project.
 
 ### `test_firebase_analytics.yaml`
 Test script that validates Firebase Analytics configuration.

--- a/gcp/cloud-build/deploy_firebase_analytics.yaml
+++ b/gcp/cloud-build/deploy_firebase_analytics.yaml
@@ -137,12 +137,18 @@ steps:
 
       echo "🚀 Enabling Firebase Analytics for project: $project..."
       analytics_account_id="${_ANALYTICS_ACCOUNT_ID}"
+
+      # The Firebase Management API requires an existing Google Analytics
+      # account to either link or create a property. Attempting to call the
+      # endpoint without an account ID results in a 400 INVALID_ARGUMENT
+      # response, so fail fast with a clear message.
       if [ -z "$analytics_account_id" ]; then
-        echo "ℹ️ _ANALYTICS_ACCOUNT_ID not provided. Creating new Analytics property."
-        data='{}'
-      else
-        data="{\"analyticsAccountId\":\"$analytics_account_id\"}"
+        echo "❌ _ANALYTICS_ACCOUNT_ID not provided. A Google Analytics account ID is required to enable Firebase Analytics."
+        echo "   Provide the account ID via the _ANALYTICS_ACCOUNT_ID substitution."
+        exit 1
       fi
+
+      data="{\"analyticsAccountId\":\"$analytics_account_id\"}"
 
       # Try to enable Analytics using Firebase Management API. This creates
       # or links a Google Analytics property and associates it with Firebase.


### PR DESCRIPTION
## Summary
- Fail fast if `_ANALYTICS_ACCOUNT_ID` is missing and instruct users to provide a Google Analytics account ID
- Update docs to clarify the Analytics account ID requirement

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd mobile && ./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b157a837d88330af1086e29f5ef921