### PR TITLE
Fix consent status type

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/ConsentUtils.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/ConsentUtils.java
@@ -74,7 +74,7 @@ public class ConsentUtils {
     public static boolean hasUmpConsent(Context ctx) {
         try {
             ConsentInformation consentInfo = UserMessagingPlatform.getConsentInformation(ctx);
-            ConsentInformation.ConsentStatus status = consentInfo.getConsentStatus();
+            @ConsentInformation.ConsentStatus int status = consentInfo.getConsentStatus();
             
             Log.d("TAG_Soccer", "UMP consent status: " + status);
             


### PR DESCRIPTION
## Summary
- use `@ConsentInformation.ConsentStatus int` to store consent status from UMP

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a5f27fec8330a6561262bf9eb05d