### PR TITLE
Replace apostrophes with HTML entity in string resources

### DIFF
--- a/mobile/app/src/main/res/values-am/strings.xml
+++ b/mobile/app/src/main/res/values-am/strings.xml
@@ -47,8 +47,8 @@
     
     <!-- Settings strings -->
     <string name="pref_title_level">የአንድሮይድ ደረጃ</string>
-    <string name="pref_title_block_invite_friend">'ጓደኛ ጋብዝ' ጥያቄዎችን ይዝጉ</string>
-    <string name="pref_summary_block_invite_friend">ሌሎች ተጫዋቾች በ'ጓደኛ ጋብዝ' በኩል ሊጋብዙዎት አይችሉም (ውድድሮች አልተጎዱም)</string>
+    <string name="pref_title_block_invite_friend">&#39;ጓደኛ ጋብዝ&#39; ጥያቄዎችን ይዝጉ</string>
+    <string name="pref_summary_block_invite_friend">ሌሎች ተጫዋቾች በ&#39;ጓደኛ ጋብዝ&#39; በኩል ሊጋብዙዎት አይችሉም (ውድድሮች አልተጎዱም)</string>
     <string name="pref_title_ads_consent">የግላዊ ማስታወቂያዎች ፈቃድ</string>
     <string name="pref_summary_ads_consent">ለግላዊ ማስታወቂያዎች ማሳያ ያለዎትን ፈቃድ ይገምግሙ ወይም ይቀይሩ</string>
     <string name="pref_title_language">ቋንቋ</string>

--- a/mobile/app/src/main/res/values-ar/strings.xml
+++ b/mobile/app/src/main/res/values-ar/strings.xml
@@ -36,8 +36,8 @@
     <string name="tournaments">البطولات</string>
     <string name="ranking">الترتيب</string>
     <string name="pref_title_level">مستوى الأندرويد</string>
-    <string name="pref_title_block_invite_friend">حظر طلبات \'ادعُ صديقاً\'</string>
-    <string name="pref_summary_block_invite_friend">لا يمكن للاعبين الآخرين دعوتك عبر \'ادعُ صديقاً\' (البطولات غير متأثرة)</string>
+    <string name="pref_title_block_invite_friend">حظر طلبات &#39;ادعُ صديقاً&#39;</string>
+    <string name="pref_summary_block_invite_friend">لا يمكن للاعبين الآخرين دعوتك عبر &#39;ادعُ صديقاً&#39; (البطولات غير متأثرة)</string>
     <string name="pref_title_ads_consent">موافقة الإعلانات المخصصة</string>
     <string name="pref_summary_ads_consent">راجع أو غيّر موافقتك لعرض الإعلانات المخصصة</string>
     <string name="pref_title_language">اللغة</string>

--- a/mobile/app/src/main/res/values-bn/strings.xml
+++ b/mobile/app/src/main/res/values-bn/strings.xml
@@ -18,8 +18,8 @@
     
     <!-- Settings preferences -->
     <string name="pref_title_level">অ্যান্ড্রয়েড স্তর</string>
-    <string name="pref_title_block_invite_friend">\'বন্ধুকে আমন্ত্রণ জানান\' অনুরোধ ব্লক করুন</string>
-    <string name="pref_summary_block_invite_friend">অন্য খেলোয়াড়রা \'বন্ধুকে আমন্ত্রণ জানান\' এর মাধ্যমে আপনাকে আমন্ত্রণ জানাতে পারবে না (টুর্নামেন্ট প্রভাবিত নয়)</string>
+    <string name="pref_title_block_invite_friend">&#39;বন্ধুকে আমন্ত্রণ জানান&#39; অনুরোধ ব্লক করুন</string>
+    <string name="pref_summary_block_invite_friend">অন্য খেলোয়াড়রা &#39;বন্ধুকে আমন্ত্রণ জানান&#39; এর মাধ্যমে আপনাকে আমন্ত্রণ জানাতে পারবে না (টুর্নামেন্ট প্রভাবিত নয়)</string>
     <string name="pref_title_ads_consent">ব্যক্তিগত বিজ্ঞাপনের সম্মতি</string>
     <string name="pref_summary_ads_consent">ব্যক্তিগত বিজ্ঞাপন প্রদর্শনের জন্য আপনার সম্মতি পর্যালোচনা বা পরিবর্তন করুন</string>
     
@@ -95,7 +95,7 @@
     <string name="load_more">আরো লোড করুন</string>
     <string name="add_friend_label">যোগ করুন</string>
     <string name="invite_blocked">%1$s আমন্ত্রণ ব্লক করেছে।</string>
-    <string name="invites_blocked_notification">অন্য খেলোয়াড়রা \'বন্ধুকে আমন্ত্রণ জানান\' ফাংশনের মাধ্যমে আপনাকে আমন্ত্রণ জানাতে পারবে না। আপনি সেটিংসে এটি পরিবর্তন করতে পারেন।</string>
+    <string name="invites_blocked_notification">অন্য খেলোয়াড়রা &#39;বন্ধুকে আমন্ত্রণ জানান&#39; ফাংশনের মাধ্যমে আপনাকে আমন্ত্রণ জানাতে পারবে না। আপনি সেটিংসে এটি পরিবর্তন করতে পারেন।</string>
     
     <!-- Invitations strings -->
     <string name="pending_game_invitations">মুলতুবি গেম আমন্ত্রণ</string>

--- a/mobile/app/src/main/res/values-de/strings.xml
+++ b/mobile/app/src/main/res/values-de/strings.xml
@@ -40,8 +40,8 @@
     
     <!-- Settings preferences -->
     <string name="pref_title_level">Android-Level</string>
-    <string name="pref_title_block_invite_friend">\'Freund einladen\'-Anfragen blockieren</string>
-    <string name="pref_summary_block_invite_friend">Andere Spieler können Sie nicht über \'Freund einladen\' einladen (Turniere nicht betroffen)</string>
+    <string name="pref_title_block_invite_friend">&#39;Freund einladen&#39;-Anfragen blockieren</string>
+    <string name="pref_summary_block_invite_friend">Andere Spieler können Sie nicht über &#39;Freund einladen&#39; einladen (Turniere nicht betroffen)</string>
     <string name="pref_title_ads_consent">Einverständnis für personalisierte Werbung</string>
     <string name="pref_summary_ads_consent">Überprüfen oder ändern Sie Ihr Einverständnis für die Anzeige personalisierter Werbung</string>
     
@@ -95,7 +95,7 @@
     <string name="load_more">Mehr laden</string>
     <string name="add_friend_label">Hinzufügen</string>
     <string name="invite_blocked">%1$s hat Einladungen blockiert.</string>
-    <string name="invites_blocked_notification">Andere Spieler können Sie nicht über die \'Freund einladen\'-Funktion einladen. Sie können dies in den Einstellungen ändern.</string>
+    <string name="invites_blocked_notification">Andere Spieler können Sie nicht über die &#39;Freund einladen&#39;-Funktion einladen. Sie können dies in den Einstellungen ändern.</string>
     
     <!-- Invitations strings -->
     <string name="pending_game_invitations">Ausstehende Spieleinladungen</string>

--- a/mobile/app/src/main/res/values-es/strings.xml
+++ b/mobile/app/src/main/res/values-es/strings.xml
@@ -40,8 +40,8 @@
     
     <!-- Settings preferences -->
     <string name="pref_title_level">Nivel de Android</string>
-    <string name="pref_title_block_invite_friend">Bloquear solicitudes de \'Invitar amigo\'</string>
-    <string name="pref_summary_block_invite_friend">Otros jugadores no pueden invitarte a través de \'Invitar amigo\' (torneos no afectados)</string>
+    <string name="pref_title_block_invite_friend">Bloquear solicitudes de &#39;Invitar amigo&#39;</string>
+    <string name="pref_summary_block_invite_friend">Otros jugadores no pueden invitarte a través de &#39;Invitar amigo&#39; (torneos no afectados)</string>
     <string name="pref_title_ads_consent">Consentimiento para anuncios personalizados</string>
     <string name="pref_summary_ads_consent">Revisar o cambiar tu consentimiento para mostrar anuncios personalizados</string>
     
@@ -95,7 +95,7 @@
     <string name="load_more">Cargar más</string>
     <string name="add_friend_label">Agregar</string>
     <string name="invite_blocked">%1$s bloqueó invitaciones.</string>
-    <string name="invites_blocked_notification">Otros jugadores no pueden invitarte a través de la función \'Invitar amigo\'. Puedes cambiarlo en Configuración.</string>
+    <string name="invites_blocked_notification">Otros jugadores no pueden invitarte a través de la función &#39;Invitar amigo&#39;. Puedes cambiarlo en Configuración.</string>
     
     <!-- Invitations strings -->
     <string name="pending_game_invitations">Invitaciones de juego pendientes</string>

--- a/mobile/app/src/main/res/values-fa/strings.xml
+++ b/mobile/app/src/main/res/values-fa/strings.xml
@@ -36,8 +36,8 @@
     <string name="tournaments">تورنمنت‌ها</string>
     <string name="ranking">رتبه‌بندی</string>
     <string name="pref_title_level">سطح اندروید</string>
-    <string name="pref_title_block_invite_friend">مسدود کردن درخواست‌های 'دعوت از دوست'</string>
-    <string name="pref_summary_block_invite_friend">بازیکنان دیگر نمی‌توانند از طریق 'دعوت از دوست' شما را دعوت کنند (بر تورنمنت‌ها تأثیر ندارد)</string>
+    <string name="pref_title_block_invite_friend">مسدود کردن درخواست‌های &#39;دعوت از دوست&#39;</string>
+    <string name="pref_summary_block_invite_friend">بازیکنان دیگر نمی‌توانند از طریق &#39;دعوت از دوست&#39; شما را دعوت کنند (بر تورنمنت‌ها تأثیر ندارد)</string>
     <string name="pref_title_ads_consent">رضایت تبلیغات شخصی‌سازی شده</string>
     <string name="pref_summary_ads_consent">رضایت خود را برای نمایش تبلیغات شخصی‌سازی شده بررسی یا تغییر دهید</string>
     <string name="pref_title_language">زبان</string>

--- a/mobile/app/src/main/res/values-fr/strings.xml
+++ b/mobile/app/src/main/res/values-fr/strings.xml
@@ -215,7 +215,7 @@
     
     <!-- Anonymous login warning -->
     <string name="anonymous_login_warning_title">Avertissement de connexion anonyme</string>
-    <string name="anonymous_login_warning_message">La connexion anonyme permet l\'accès à certaines fonctions, mais si vous perdez votre appareil, réinstallez l\'application, obtenez un nouveau téléphone ou vous déconnectez, le lien vers votre compte anonyme sera perdu et il ne sera pas possible de vous reconnecter au même compte anonyme. Voulez-vous continuer ?</string>
+    <string name="anonymous_login_warning_message">La connexion anonyme permet l&#39;accès à certaines fonctions, mais si vous perdez votre appareil, réinstallez l&#39;application, obtenez un nouveau téléphone ou vous déconnectez, le lien vers votre compte anonyme sera perdu et il ne sera pas possible de vous reconnecter au même compte anonyme. Voulez-vous continuer ?</string>
     <string name="proceed_anonymous_login">Continuer</string>
     <string name="enter_email_address">Veuillez saisir votre adresse e-mail</string>
     <string name="all_fields_required">Tous les champs sont requis</string>
@@ -283,7 +283,7 @@
     <!-- Link Account functionality -->
     <string name="link_to_registered_account">Lier au compte enregistre</string>
     <string name="link_account_title">Lier un Compte Anonyme</string>
-    <string name="link_account_description">Liez votre compte anonyme avec email, Google ou Facebook pour securiser votre compte et l\'historique des jeux.</string>
+    <string name="link_account_description">Liez votre compte anonyme avec email, Google ou Facebook pour securiser votre compte et l&#39;historique des jeux.</string>
     <string name="link_account_success">Compte lie avec succes!</string>
     <string name="link_account_failed">Echec de la liaison du compte: %1$s</string>
     <string name="link_account_in_progress">Liaison du compte...</string>
@@ -301,7 +301,7 @@
     <string name="decline_reason_offline">Je joue juste hors ligne</string>
     <string name="decline_reason_privacy">Préoccupations de confidentialité</string>
     <string name="decline_reason_complicated">Trop compliqué</string>
-    <string name="decline_reason_dont_use_providers">N\'utilise pas Google/Facebook/Email</string>
+    <string name="decline_reason_dont_use_providers">N&#39;utilise pas Google/Facebook/Email</string>
     <string name="decline_reason_other">Autre raison</string>
     
     <!-- Anonymous user prompts -->
@@ -313,9 +313,9 @@
     <!-- In-app messaging for v7/v8 users -->
     <string name="register_benefits_title">Rejoignez des tournois &amp; participez mondialement !</string>
     <string name="register_benefits_message">Inscrivez-vous pour sauvegarder votre classement et participer à des tournois avec des joueurs du monde entier.</string>
-    <string name="register_now">S\'inscrire maintenant</string>
+    <string name="register_now">S&#39;inscrire maintenant</string>
 
-    <string name="layout_initialization_error">L\'application a rencontré une erreur d\'affichage. Veuillez réessayer.</string>
+    <string name="layout_initialization_error">L&#39;application a rencontré une erreur d&#39;affichage. Veuillez réessayer.</string>
     <string name="retry">Réessayer</string>
     
     <!-- Game ready notification strings -->

--- a/mobile/app/src/main/res/values-hi/strings.xml
+++ b/mobile/app/src/main/res/values-hi/strings.xml
@@ -18,8 +18,8 @@
     
     <!-- Settings preferences -->
     <string name="pref_title_level">Android स्तर</string>
-    <string name="pref_title_block_invite_friend">\'मित्र को आमंत्रित करें\' अनुरोधों को ब्लॉक करें</string>
-    <string name="pref_summary_block_invite_friend">अन्य खिलाड़ी आपको \'मित्र को आमंत्रित करें\' के माध्यम से आमंत्रित नहीं कर सकते (टूर्नामेंट प्रभावित नहीं)</string>
+    <string name="pref_title_block_invite_friend">&#39;मित्र को आमंत्रित करें&#39; अनुरोधों को ब्लॉक करें</string>
+    <string name="pref_summary_block_invite_friend">अन्य खिलाड़ी आपको &#39;मित्र को आमंत्रित करें&#39; के माध्यम से आमंत्रित नहीं कर सकते (टूर्नामेंट प्रभावित नहीं)</string>
     <string name="pref_title_ads_consent">व्यक्तिगत विज्ञापनों की सहमति</string>
     <string name="pref_summary_ads_consent">व्यक्तिगत विज्ञापन दिखाने के लिए अपनी सहमति की समीक्षा करें या बदलें</string>
     
@@ -95,7 +95,7 @@
     <string name="load_more">और लोड करें</string>
     <string name="add_friend_label">जोड़ें</string>
     <string name="invite_blocked">%1$s ने आमंत्रण ब्लॉक कर दिए हैं।</string>
-    <string name="invites_blocked_notification">अन्य खिलाड़ी आपको \'मित्र को आमंत्रित करें\' फ़ंक्शन के माध्यम से आमंत्रित नहीं कर सकते। आप इसे सेटिंग्स में बदल सकते हैं।</string>
+    <string name="invites_blocked_notification">अन्य खिलाड़ी आपको &#39;मित्र को आमंत्रित करें&#39; फ़ंक्शन के माध्यम से आमंत्रित नहीं कर सकते। आप इसे सेटिंग्स में बदल सकते हैं।</string>
     
     <!-- Invitations strings -->
     <string name="pending_game_invitations">लंबित गेम आमंत्रण</string>

--- a/mobile/app/src/main/res/values-ne/strings.xml
+++ b/mobile/app/src/main/res/values-ne/strings.xml
@@ -18,8 +18,8 @@
     
     <!-- Settings preferences -->
     <string name="pref_title_level">एन्ड्रोइड स्तर</string>
-    <string name="pref_title_block_invite_friend">\'मित्रलाई निमन्त्रणा दिनुहोस्\' अनुरोधहरू ब्लक गर्नुहोस्</string>
-    <string name="pref_summary_block_invite_friend">अन्य खेलाडीहरूले तपाईंलाई \'मित्रलाई निमन्त्रणा दिनुहोस्\' मार्फत निमन्त्रणा दिन सक्दैनन् (प्रतियोगिताहरू प्रभावित छैनन्)</string>
+    <string name="pref_title_block_invite_friend">&#39;मित्रलाई निमन्त्रणा दिनुहोस्&#39; अनुरोधहरू ब्लक गर्नुहोस्</string>
+    <string name="pref_summary_block_invite_friend">अन्य खेलाडीहरूले तपाईंलाई &#39;मित्रलाई निमन्त्रणा दिनुहोस्&#39; मार्फत निमन्त्रणा दिन सक्दैनन् (प्रतियोगिताहरू प्रभावित छैनन्)</string>
     <string name="pref_title_ads_consent">व्यक्तिगत विज्ञापनहरूको सहमति</string>
     <string name="pref_summary_ads_consent">व्यक्तिगत विज्ञापनहरू देखाउनको लागि आफ्नो सहमति समीक्षा वा परिवर्तन गर्नुहोस्</string>
     
@@ -95,7 +95,7 @@
     <string name="load_more">थप लोड गर्नुहोस्</string>
     <string name="add_friend_label">थप्नुहोस्</string>
     <string name="invite_blocked">%1$s ले निमन्त्रणाहरू ब्लक गरेको छ।</string>
-    <string name="invites_blocked_notification">अन्य खेलाडीहरूले तपाईंलाई \'मित्रलाई निमन्त्रणा दिनुहोस्\' प्रकार्य मार्फत निमन्त्रणा दिन सक्दैनन्। तपाईं यसलाई सेटिङहरूमा परिवर्तन गर्न सक्नुहुन्छ।</string>
+    <string name="invites_blocked_notification">अन्य खेलाडीहरूले तपाईंलाई &#39;मित्रलाई निमन्त्रणा दिनुहोस्&#39; प्रकार्य मार्फत निमन्त्रणा दिन सक्दैनन्। तपाईं यसलाई सेटिङहरूमा परिवर्तन गर्न सक्नुहुन्छ।</string>
     
     <!-- Invitations strings -->
     <string name="pending_game_invitations">पेन्डिङ खेल निमन्त्रणाहरू</string>

--- a/mobile/app/src/main/res/values-ur/strings.xml
+++ b/mobile/app/src/main/res/values-ur/strings.xml
@@ -18,8 +18,8 @@
     
     <!-- Settings preferences -->
     <string name="pref_title_level">Android لیول</string>
-    <string name="pref_title_block_invite_friend">\'دوست کو دعوت دیں\' کی درخواستوں کو بلاک کریں</string>
-    <string name="pref_summary_block_invite_friend">دوسرے کھلاڑی آپ کو \'دوست کو دعوت دیں\' کے ذریعے دعوت نہیں دے سکتے (ٹورنامنٹ متاثر نہیں)</string>
+    <string name="pref_title_block_invite_friend">&#39;دوست کو دعوت دیں&#39; کی درخواستوں کو بلاک کریں</string>
+    <string name="pref_summary_block_invite_friend">دوسرے کھلاڑی آپ کو &#39;دوست کو دعوت دیں&#39; کے ذریعے دعوت نہیں دے سکتے (ٹورنامنٹ متاثر نہیں)</string>
     <string name="pref_title_ads_consent">ذاتی اشتہارات کی رضامندی</string>
     <string name="pref_summary_ads_consent">ذاتی اشتہارات دکھانے کے لیے اپنی رضامندی کا جائزہ لیں یا تبدیل کریں</string>
     
@@ -95,7 +95,7 @@
     <string name="load_more">مزید لوڈ کریں</string>
     <string name="add_friend_label">شامل کریں</string>
     <string name="invite_blocked">%1$s نے دعوتیں بلاک کر دی ہیں۔</string>
-    <string name="invites_blocked_notification">دوسرے کھلاڑی آپ کو \'دوست کو دعوت دیں\' فنکشن کے ذریعے دعوت نہیں دے سکتے۔ آپ اسے سیٹنگز میں تبدیل کر سکتے ہیں۔</string>
+    <string name="invites_blocked_notification">دوسرے کھلاڑی آپ کو &#39;دوست کو دعوت دیں&#39; فنکشن کے ذریعے دعوت نہیں دے سکتے۔ آپ اسے سیٹنگز میں تبدیل کر سکتے ہیں۔</string>
     
     <!-- Invitations strings -->
     <string name="pending_game_invitations">زیر التواء گیم دعوتیں</string>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -8,8 +8,8 @@
     <!-- Strings related to Settings -->
 
     <string name="pref_title_level">Android level</string>
-    <string name="pref_title_block_invite_friend">Block \'Invite a Friend\' requests</string>
-    <string name="pref_summary_block_invite_friend">Other players cannot invite you via \'Invite a Friend\' (tournaments not affected)</string>
+    <string name="pref_title_block_invite_friend">Block &#39;Invite a Friend&#39; requests</string>
+    <string name="pref_summary_block_invite_friend">Other players cannot invite you via &#39;Invite a Friend&#39; (tournaments not affected)</string>
     <string name="pref_title_ads_consent">Personalized ads consent</string>
     <string name="pref_summary_ads_consent">Review or change your consent for displaying personlized ads</string>
     <string name="pref_title_language">Language</string>
@@ -53,7 +53,7 @@
     <string name="settings">Settings</string>
     <string name="enter_nickname_to_invite">Enter nickname to invite:</string>
     <string name="enter_nickname_to_search">Enter nickname to search:</string>
-    <string name="friend_s_nickname">Friend\'s nickname</string>
+    <string name="friend_s_nickname">Friend&#39;s nickname</string>
     <string name="send_invitation">Send Invitation</string>
     <string name="invite_a_friend">Invite a Friend</string>
     <string name="add_a_friend">Add a Friend</string>
@@ -62,7 +62,7 @@
     <string name="no_tournaments">No tournaments have been created yet.</string>
     <string name="please_enter_a_nickname">Please enter a nickname.</string>
     <string name="user_not_found">User not found.</string>
-    <string name="you_can_t_invite_yourself">You can\'t invite yourself.</string>
+    <string name="you_can_t_invite_yourself">You can&#39;t invite yourself.</string>
     <string name="error_searching_user">Error searching user.</string>
     <string name="invitation_sent">Invitation sent!</string>
     <string name="failed_to_send_invite">Failed to send invite.</string>
@@ -74,7 +74,7 @@
     <string name="load_more">Load more</string>
     <string name="add_friend_label">Add</string>
     <string name="invite_blocked">%1$s blocked invites.</string>
-    <string name="invites_blocked_notification">Other players cannot invite you via \'Invite a Friend\' function. You can change it in Settings.</string>
+    <string name="invites_blocked_notification">Other players cannot invite you via &#39;Invite a Friend&#39; function. You can change it in Settings.</string>
     <string name="pending_game_invitations">Pending Game Invitations</string>
     <string name="pending_invites">Pending Invites</string>
     <string name="no_pending_invites">No pending invitations.</string>
@@ -299,7 +299,7 @@
     <string name="decline_reason_offline">Just playing offline</string>
     <string name="decline_reason_privacy">Privacy concerns</string>
     <string name="decline_reason_complicated">Too complicated</string>
-    <string name="decline_reason_dont_use_providers">Don\'t use Google/Facebook/Email</string>
+    <string name="decline_reason_dont_use_providers">Don&#39;t use Google/Facebook/Email</string>
     <string name="decline_reason_other">Other reason</string>
     
     <!-- Anonymous user prompts -->


### PR DESCRIPTION
## Summary
- replace apostrophes with `&#39;` in the English strings and affected localizations
- remove now-unneeded escape characters so apostrophes render via HTML entity

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cebe3c33a08330a2b447e2e354fb13