### PR TITLE
Fix duplicate friend resource strings

### DIFF
--- a/mobile/app/src/main/res/values-am/strings.xml
+++ b/mobile/app/src/main/res/values-am/strings.xml
@@ -320,10 +320,7 @@
     <string name="presence_offline">ከመስመር ውጭ</string>
     <string name="error_checking_friend_status">የጓደኛ ሁኔታን በማረጋገጥ ላይ ስህተት</string>
     <string name="friend_added">ጓደኛ በተሳካ ሁኔታ ታክሏል</string>
-    <string name="failed_to_add_friend">ጓደኛን ማከል አልተሳካም</string>
-    <string name="failed_to_send_invite">ግብዣ መላክ አልተሳካም</string>
     <string name="active_invitation_exists">ንቁ ግብዣ አስቀድሞ አለ</string>
     <string name="user_blocked_invites">ተጠቃሚ ግብዣዎችን አግዷል</string>
     <string name="cannot_invite_this_user">ይህን ተጠቃሚ ግብዣ ልላክ አልችልም</string>
-    <string name="user_not_found">ተጠቃሚ አልተገኘም</string>
 </resources>

--- a/mobile/app/src/main/res/values-ar/strings.xml
+++ b/mobile/app/src/main/res/values-ar/strings.xml
@@ -301,10 +301,7 @@
     <string name="presence_offline">غير متصل</string>
     <string name="error_checking_friend_status">خطأ في التحقق من حالة الصديق</string>
     <string name="friend_added">تمت إضافة الصديق بنجاح</string>
-    <string name="failed_to_add_friend">فشل في إضافة الصديق</string>
-    <string name="failed_to_send_invite">فشل في إرسال الدعوة</string>
     <string name="active_invitation_exists">الدعوة النشطة موجودة بالفعل</string>
     <string name="user_blocked_invites">المستخدم قد حظر الدعوات</string>
     <string name="cannot_invite_this_user">لا يمكن دعوة هذا المستخدم</string>
-    <string name="user_not_found">المستخدم غير موجود</string>
 </resources>

--- a/mobile/app/src/main/res/values-bn/strings.xml
+++ b/mobile/app/src/main/res/values-bn/strings.xml
@@ -347,12 +347,9 @@
     <string name="presence_offline">অফলাইন</string>
     <string name="error_checking_friend_status">বন্ধুর অবস্থা পরীক্ষা করতে ত্রুটি</string>
     <string name="friend_added">সফলভাবে বন্ধু যোগ হয়েছে</string>
-    <string name="failed_to_add_friend">বন্ধু যোগ করতে ব্যর্থ</string>
-    <string name="failed_to_send_invite">আমন্ত্রণ পাঠাতে ব্যর্থ</string>
     <string name="active_invitation_exists">সক্রিয় আমন্ত্রণ ইতিমধ্যে বিদ্যমান</string>
     <string name="user_blocked_invites">ব্যবহারকারী আমন্ত্রণ ব্লক করেছেন</string>
     <string name="cannot_invite_this_user">এই ব্যবহারকারীকে আমন্ত্রণ জানানো যাবে না</string>
-    <string name="user_not_found">ব্যবহারকারী পাওয়া যায়নি</string>
     
     <!-- Preference level values -->
     <string-array name="pref_level_values">

--- a/mobile/app/src/main/res/values-de/strings.xml
+++ b/mobile/app/src/main/res/values-de/strings.xml
@@ -348,12 +348,9 @@
     <string name="presence_offline">Offline</string>
     <string name="error_checking_friend_status">Fehler beim Überprüfen des Freundstatus</string>
     <string name="friend_added">Freund erfolgreich hinzugefügt</string>
-    <string name="failed_to_add_friend">Freund konnte nicht hinzugefügt werden</string>
-    <string name="failed_to_send_invite">Einladung konnte nicht gesendet werden</string>
     <string name="active_invitation_exists">Aktive Einladung existiert bereits</string>
     <string name="user_blocked_invites">Benutzer hat Einladungen blockiert</string>
     <string name="cannot_invite_this_user">Kann diesen Benutzer nicht einladen</string>
-    <string name="user_not_found">Benutzer nicht gefunden</string>
     
     <!-- Preference level values -->
     <string-array name="pref_level_values">

--- a/mobile/app/src/main/res/values-km/strings.xml
+++ b/mobile/app/src/main/res/values-km/strings.xml
@@ -320,10 +320,7 @@
     <string name="presence_offline">មិនលើបណ្តាញ</string>
     <string name="error_checking_friend_status">កំហុសក្នុងការពិនិត្យស្ថានភាពមិត្ត</string>
     <string name="friend_added">បានបន្ថែមមិត្តដោយជោគជ័យ</string>
-    <string name="failed_to_add_friend">បរាជ័យក្នុងការបន្ថែមមិត្ត</string>
-    <string name="failed_to_send_invite">បរាជ័យក្នុងការផ្ញើការអញ្ជើញ</string>
     <string name="active_invitation_exists">ការអញ្ជើញសកម្មមានរួចហើយ</string>
     <string name="user_blocked_invites">អ្នកប្រើបានទប់ស្កាត់ការអញ្ជើញ</string>
     <string name="cannot_invite_this_user">មិនអាចអញ្ជើញអ្នកប្រើនេះបានទេ</string>
-    <string name="user_not_found">រកមិនឃើញអ្នកប្រើ</string>
 </resources>

--- a/mobile/app/src/main/res/values-mg/strings.xml
+++ b/mobile/app/src/main/res/values-mg/strings.xml
@@ -320,10 +320,7 @@
     <string name="presence_offline">Tsy an-tserasera</string>
     <string name="error_checking_friend_status">Fahadisoana tamin\'ny fanamarinana ny toe-javatra namana</string>
     <string name="friend_added">Namana nanampy tamim-pahombiazana</string>
-    <string name="failed_to_add_friend">Tsy nahomby ny fanampy namana</string>
-    <string name="failed_to_send_invite">Tsy nahomby ny fandefasana fanasana</string>
     <string name="active_invitation_exists">Fanasana mavitrika efa misy</string>
     <string name="user_blocked_invites">Ny mpampiasa dia nanakana ny fanasana</string>
     <string name="cannot_invite_this_user">Tsy afaka manasa io mpampiasa io</string>
-    <string name="user_not_found">Mpampiasa tsy hita</string>
 </resources>

--- a/mobile/app/src/main/res/values-pl/strings.xml
+++ b/mobile/app/src/main/res/values-pl/strings.xml
@@ -348,12 +348,9 @@
     <string name="presence_offline">Offline</string>
     <string name="error_checking_friend_status">Błąd sprawdzania statusu znajomego</string>
     <string name="friend_added">Znajomy dodany pomyślnie</string>
-    <string name="failed_to_add_friend">Nie udało się dodać znajomego</string>
-    <string name="failed_to_send_invite">Nie udało się wysłać zaproszenia</string>
     <string name="active_invitation_exists">Aktywne zaproszenie już istnieje</string>
     <string name="user_blocked_invites">Użytkownik zablokował zaproszenia</string>
     <string name="cannot_invite_this_user">Nie można zaprosić tego użytkownika</string>
-    <string name="user_not_found">Użytkownik nie znaleziony</string>
     
     <!-- Preference level values -->
     <string-array name="pref_level_values">

--- a/mobile/app/src/main/res/values-so/strings.xml
+++ b/mobile/app/src/main/res/values-so/strings.xml
@@ -320,10 +320,7 @@
     <string name="presence_offline">Offline</string>
     <string name="error_checking_friend_status">Khalad xaqiijinta xaaladda saaxiibka</string>
     <string name="friend_added">Saaxiibka si guul leh ayaa loo daray</string>
-    <string name="failed_to_add_friend">Lama darin karo saaxiibka</string>
-    <string name="failed_to_send_invite">Lama dirin karo casuumada</string>
     <string name="active_invitation_exists">Casumo firfircoon ayaa jira</string>
     <string name="user_blocked_invites">Isticmaaluhu wuu xannibay casumadaha</string>
     <string name="cannot_invite_this_user">Lama casumi karo isticmaalahaas</string>
-    <string name="user_not_found">Isticmaaluhu lama helin</string>
 </resources>

--- a/mobile/app/src/main/res/values-ur/strings.xml
+++ b/mobile/app/src/main/res/values-ur/strings.xml
@@ -347,12 +347,9 @@
     <string name="presence_offline">آف لائن</string>
     <string name="error_checking_friend_status">دوست کی حیثیت چیک کرنے میں خرابی</string>
     <string name="friend_added">دوست کامیابی سے شامل ہوا</string>
-    <string name="failed_to_add_friend">دوست شامل کرنے میں ناکام</string>
-    <string name="failed_to_send_invite">دعوت بھیجنے میں ناکام</string>
     <string name="active_invitation_exists">فعال دعوت پہلے سے موجود ہے</string>
     <string name="user_blocked_invites">صارف نے دعوتیں بلاک کر دی ہیں</string>
     <string name="cannot_invite_this_user">اس صارف کو دعوت نہیں دی جا سکتی</string>
-    <string name="user_not_found">صارف نہیں ملا</string>
     
     <!-- Preference level values -->
     <string-array name="pref_level_values">

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -344,10 +344,7 @@
     <string name="presence_offline">Offline</string>
     <string name="error_checking_friend_status">Error checking friend status</string>
     <string name="friend_added">Friend added successfully</string>
-    <string name="failed_to_add_friend">Failed to add friend</string>
-    <string name="failed_to_send_invite">Failed to send invite</string>
     <string name="active_invitation_exists">Active invitation already exists</string>
     <string name="user_blocked_invites">User has blocked invites</string>
     <string name="cannot_invite_this_user">Cannot invite this user</string>
-    <string name="user_not_found">User not found</string>
 </resources>


### PR DESCRIPTION
## Summary
- remove duplicate friend-related string resources from the base strings file and every affected locale to prevent merge conflicts during resource merging

## Testing
- ./gradlew :app:merge_prodReleaseResources *(fails: missing `soccer_secret_key` in secrets/)*

------
https://chatgpt.com/codex/tasks/task_e_68ebb8d1e4788330b1e914de3d2fa10e