### PR TITLE
Hide past invites empty state and update add friend translations

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
@@ -41,6 +41,7 @@ public class InvitationsActivity extends BaseActivity {
     TextView pastInvitesLabel;
     TextView emptyPastInvites;
     PastInviteAdapter pastAdapter;
+    RecyclerView.AdapterDataObserver pastInvitesObserver;
 
     FirebaseFirestore db;
     FirebaseAuth auth;
@@ -75,6 +76,23 @@ public class InvitationsActivity extends BaseActivity {
         pastInvitesList.setLayoutManager(new LinearLayoutManager(this));
         pastAdapter = new PastInviteAdapter(this, this::sendInviteViaCF, this::addFriend);
         pastInvitesList.setAdapter(pastAdapter);
+        pastInvitesObserver = new RecyclerView.AdapterDataObserver() {
+            @Override
+            public void onChanged() {
+                updatePastInvitesEmptyState();
+            }
+
+            @Override
+            public void onItemRangeInserted(int positionStart, int itemCount) {
+                updatePastInvitesEmptyState();
+            }
+
+            @Override
+            public void onItemRangeRemoved(int positionStart, int itemCount) {
+                updatePastInvitesEmptyState();
+            }
+        };
+        pastAdapter.registerAdapterDataObserver(pastInvitesObserver);
 
         db = FirebaseFirestore.getInstance();
         auth = FirebaseAuth.getInstance();
@@ -282,14 +300,29 @@ public class InvitationsActivity extends BaseActivity {
                         pastInvitesList.add(doc);
                     }
 
-                    // Data is already sorted by createdAt in descending order (latest to oldest)
-                    if (pastInvitesList.isEmpty()) {
-                        emptyPastInvites.setVisibility(View.VISIBLE);
-                    } else {
-                        emptyPastInvites.setVisibility(View.GONE);
-                    }
                     pastAdapter.setData(pastInvitesList);
+                    updatePastInvitesEmptyState();
                 });
+    }
+
+    private void updatePastInvitesEmptyState() {
+        if (emptyPastInvites == null || pastAdapter == null) {
+            return;
+        }
+
+        if (pastAdapter.getItemCount() == 0) {
+            emptyPastInvites.setVisibility(View.VISIBLE);
+        } else {
+            emptyPastInvites.setVisibility(View.GONE);
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (pastAdapter != null && pastInvitesObserver != null) {
+            pastAdapter.unregisterAdapterDataObserver(pastInvitesObserver);
+        }
     }
 
     private void addFriend(@NonNull String targetUid) {

--- a/mobile/app/src/main/res/values-am/strings.xml
+++ b/mobile/app/src/main/res/values-am/strings.xml
@@ -114,7 +114,7 @@
     <string name="failed_to_load_nickname">ቅጽል ስምን መጫን አልተሳካም።</string>
     <string name="search">ፈልግ</string>
     <string name="load_more">ተጨማሪ አስገባ</string>
-    <string name="add_friend_label">አክል</string>
+    <string name="add_friend_label">ወደ ጓደኞች አክል</string>
     <string name="invite_blocked">%1$s ግብዣዎችን አግዷል።</string>
     <string name="invites_blocked_notification">ሌሎች ተጫዋቾች “ጓደኛን ጋብዝ” ተግባር በመጠቀም ሊጋብዙዎት አይችሉም። ይህን በቅንብሮች ውስጥ መቀየር ትችላላችሁ።</string>
     <string name="pending_game_invitations">በመጠባበቅ ያሉ የጨዋታ ግብዣዎች</string>

--- a/mobile/app/src/main/res/values-ar/strings.xml
+++ b/mobile/app/src/main/res/values-ar/strings.xml
@@ -95,7 +95,7 @@
     <string name="failed_to_load_nickname">فشل تحميل الاسم المستعار.</string>
     <string name="search">بحث</string>
     <string name="load_more">تحميل المزيد</string>
-    <string name="add_friend_label">إضافة</string>
+    <string name="add_friend_label">أضف إلى الأصدقاء</string>
     <string name="invite_blocked">%1$s قام بحظر الدعوات.</string>
     <string name="invites_blocked_notification">لا يمكن للاعبين الآخرين دعوتك عبر وظيفة "ادعُ صديقاً". يمكنك تغيير ذلك في الإعدادات.</string>
     <string name="pending_game_invitations">دعوات اللعب المعلقة</string>

--- a/mobile/app/src/main/res/values-bn/strings.xml
+++ b/mobile/app/src/main/res/values-bn/strings.xml
@@ -95,7 +95,7 @@
     <string name="failed_to_load_nickname">ডাকনাম লোড করতে ব্যর্থ।</string>
     <string name="search">অনুসন্ধান</string>
     <string name="load_more">আরো লোড করুন</string>
-    <string name="add_friend_label">যোগ করুন</string>
+    <string name="add_friend_label">বন্ধুদের মধ্যে যোগ করুন</string>
     <string name="invite_blocked">%1$s আমন্ত্রণ ব্লক করেছে।</string>
     <string name="invites_blocked_notification">অন্য খেলোয়াড়রা `বন্ধুকে আমন্ত্রণ জানান` ফাংশনের মাধ্যমে আপনাকে আমন্ত্রণ জানাতে পারবে না। আপনি সেটিংসে এটি পরিবর্তন করতে পারেন।</string>
     

--- a/mobile/app/src/main/res/values-de/strings.xml
+++ b/mobile/app/src/main/res/values-de/strings.xml
@@ -95,7 +95,7 @@
     <string name="failed_to_load_nickname">Spitzname konnte nicht geladen werden.</string>
     <string name="search">Suchen</string>
     <string name="load_more">Mehr laden</string>
-    <string name="add_friend_label">Hinzufügen</string>
+    <string name="add_friend_label">Zu Freunden hinzufügen</string>
     <string name="invite_blocked">%1$s hat Einladungen blockiert.</string>
     <string name="invites_blocked_notification">Andere Spieler können Sie nicht über die `Freund einladen`-Funktion einladen. Sie können dies in den Einstellungen ändern.</string>
     

--- a/mobile/app/src/main/res/values-es/strings.xml
+++ b/mobile/app/src/main/res/values-es/strings.xml
@@ -95,7 +95,7 @@
     <string name="failed_to_load_nickname">Error al cargar apodo.</string>
     <string name="search">Buscar</string>
     <string name="load_more">Cargar más</string>
-    <string name="add_friend_label">Agregar</string>
+    <string name="add_friend_label">Agregar a amigos</string>
     <string name="invite_blocked">%1$s bloqueó invitaciones.</string>
     <string name="invites_blocked_notification">Otros jugadores no pueden invitarte a través de la función `Invitar amigo`. Puedes cambiarlo en Configuración.</string>
     

--- a/mobile/app/src/main/res/values-fa/strings.xml
+++ b/mobile/app/src/main/res/values-fa/strings.xml
@@ -95,7 +95,7 @@
     <string name="failed_to_load_nickname">بارگذاری نام مستعار ناموفق بود.</string>
     <string name="search">جستجو</string>
     <string name="load_more">بارگذاری بیشتر</string>
-    <string name="add_friend_label">افزودن</string>
+    <string name="add_friend_label">افزودن به دوستان</string>
     <string name="invite_blocked">%1$s دعوت‌ها را مسدود کرده است.</string>
     <string name="invites_blocked_notification">بازیکنان دیگر نمی‌توانند از طریق «دعوت از دوست» شما را دعوت کنند. می‌توانید این گزینه را در تنظیمات تغییر دهید.</string>
     <string name="pending_game_invitations">دعوت‌های بازی در انتظار</string>

--- a/mobile/app/src/main/res/values-fr/strings.xml
+++ b/mobile/app/src/main/res/values-fr/strings.xml
@@ -102,7 +102,7 @@
     <string name="failed_to_load_nickname">Échec du chargement du pseudonyme.</string>
     <string name="search">Rechercher</string>
     <string name="load_more">Charger plus</string>
-    <string name="add_friend_label">Ajouter</string>
+    <string name="add_friend_label">Ajouter aux amis</string>
     <string name="invite_blocked">%1$s a bloqué les invitations.</string>
     <string name="invites_blocked_notification">Les autres joueurs ne peuvent pas vous inviter via « Inviter un ami ». Vous pouvez modifier ce réglage dans Paramètres.</string>
 

--- a/mobile/app/src/main/res/values-hi/strings.xml
+++ b/mobile/app/src/main/res/values-hi/strings.xml
@@ -95,7 +95,7 @@
     <string name="failed_to_load_nickname">उपनाम लोड करने में विफल।</string>
     <string name="search">खोजें</string>
     <string name="load_more">और लोड करें</string>
-    <string name="add_friend_label">जोड़ें</string>
+    <string name="add_friend_label">दोस्तों में जोड़ें</string>
     <string name="invite_blocked">%1$s ने आमंत्रण ब्लॉक कर दिए हैं।</string>
     <string name="invites_blocked_notification">अन्य खिलाड़ी आपको `मित्र को आमंत्रित करें` फ़ंक्शन के माध्यम से आमंत्रित नहीं कर सकते। आप इसे सेटिंग्स में बदल सकते हैं।</string>
     

--- a/mobile/app/src/main/res/values-km/strings.xml
+++ b/mobile/app/src/main/res/values-km/strings.xml
@@ -114,7 +114,7 @@
     <string name="failed_to_load_nickname">មិនអាចផ្ទុកឈ្មោះហៅក្រៅបានទេ។</string>
     <string name="search">ស្វែងរក</string>
     <string name="load_more">ផ្ទុកបន្ថែម</string>
-    <string name="add_friend_label">បន្ថែម</string>
+    <string name="add_friend_label">បន្ថែមទៅកាន់មិត្តភក្តិ</string>
     <string name="invite_blocked">%1$s បានទប់ស្កាត់ការអញ្ជើញ។</string>
     <string name="invites_blocked_notification">អ្នកលេងផ្សេងទៀតមិនអាចអញ្ជើញអ្នកតាមមុខងារ \`អញ្ជើញមិត្តភក្តិ\` បានទេ។ អ្នកអាចផ្លាស់ប្តូរវានៅក្នុងការកំណត់។</string>
     <string name="pending_game_invitations">ការអញ្ជើញល្បែងកំពុងរង់ចាំ</string>

--- a/mobile/app/src/main/res/values-lo/strings.xml
+++ b/mobile/app/src/main/res/values-lo/strings.xml
@@ -114,7 +114,7 @@
     <string name="failed_to_load_nickname">ໂຫລດຊື່ເລັ່ນບໍ່ສໍາເລັດ.</string>
     <string name="search">ຄົ້ນຫາ</string>
     <string name="load_more">ໂຫລດເພີ່ມ</string>
-    <string name="add_friend_label">ເພີ່ມ</string>
+    <string name="add_friend_label">ເພີ່ມເຂົ້າໝູ່ເພື່ອນ</string>
     <string name="invite_blocked">%1$s ປິດຮັບຄໍາເຊີນ.</string>
     <string name="invites_blocked_notification">ຜູ້ຫຼິ້ນອື່ນບໍ່ສາມາດເຊີນທ່ານຜ່ານຟັງຊັນ "ເຊີນໝູ່" ໄດ້. ທ່ານສາມາດປ່ຽນໄດ້ໃນການຕັ້ງຄ່າ.</string>
     <string name="pending_game_invitations">ຄໍາເຊີນເກມທີ່ລໍຖ້າ</string>

--- a/mobile/app/src/main/res/values-mg/strings.xml
+++ b/mobile/app/src/main/res/values-mg/strings.xml
@@ -114,7 +114,7 @@
     <string name="failed_to_load_nickname">Tsy voaray ny anaram-bositra.</string>
     <string name="search">Karohy</string>
     <string name="load_more">Ampidiro bebe kokoa</string>
-    <string name="add_friend_label">Ampio</string>
+    <string name="add_friend_label">Ampio amin'ny namana</string>
     <string name="invite_blocked">Nanakana fanasana i %1$s.</string>
     <string name="invites_blocked_notification">Ny mpilalao hafa tsy afaka manasa anao amin`ny fiasa `Asao namana`. Azonao ovaina ao amin`ny Fandrindrana izany.</string>
     <string name="pending_game_invitations">Fanasana lalao miandry</string>

--- a/mobile/app/src/main/res/values-mn/strings.xml
+++ b/mobile/app/src/main/res/values-mn/strings.xml
@@ -114,7 +114,7 @@
     <string name="failed_to_load_nickname">Хоч нэр ачаалж чадсангүй.</string>
     <string name="search">Хайх</string>
     <string name="load_more">Илүүг ачааллах</string>
-    <string name="add_friend_label">Нэмэх</string>
+    <string name="add_friend_label">Найзууд руу нэмэх</string>
     <string name="invite_blocked">%1$s урилга авахыг хаасан.</string>
     <string name="invites_blocked_notification">Бусад тоглогчид “Найзаа урих” функцаар таныг урих боломжгүй. Та үүнийг тохиргоонд өөрчилж болно.</string>
     <string name="pending_game_invitations">Хүлээгдэж буй тоглоомын урилгууд</string>

--- a/mobile/app/src/main/res/values-my/strings.xml
+++ b/mobile/app/src/main/res/values-my/strings.xml
@@ -114,7 +114,7 @@
     <string name="failed_to_load_nickname">အမည်ပြောင်တင်ရာ မအောင်မြင်ပါ။</string>
     <string name="search">ရှာဖွေပါ</string>
     <string name="load_more">နောက်ထပ်တင်ပါ</string>
-    <string name="add_friend_label">ထည့်ပါ</string>
+    <string name="add_friend_label">မိတ်ဆွေများထဲထည့်ပါ</string>
     <string name="invite_blocked">%1$s သည် ဖိတ်ကြားချက်များကို ပိတ်ဆို့ထားသည်။</string>
     <string name="invites_blocked_notification">အခြားကစားသူများသည် \`သူငယ်ချင်းကိုဖိတ်ကြားပါ\` ဖန်ရှင်မှတစ်ဆင့် သင့်ကို ဖိတ်ခေါ်မနိုင်ပါ။ သင်သည် ဆက်တင်များတွင် ပြင်ဆင်နိုင်ပါသည်။</string>
     <string name="pending_game_invitations">ဆိုင်းငံ့ထားသော ဂိမ်းဖိတ်ကြားချက်များ</string>

--- a/mobile/app/src/main/res/values-ne/strings.xml
+++ b/mobile/app/src/main/res/values-ne/strings.xml
@@ -95,7 +95,7 @@
     <string name="failed_to_load_nickname">उपनाम लोड गर्न असफल।</string>
     <string name="search">खोज्नुहोस्</string>
     <string name="load_more">थप लोड गर्नुहोस्</string>
-    <string name="add_friend_label">थप्नुहोस्</string>
+    <string name="add_friend_label">साथीहरूमा थप्नुहोस्</string>
     <string name="invite_blocked">%1$s ले निमन्त्रणाहरू ब्लक गरेको छ।</string>
     <string name="invites_blocked_notification">अन्य खेलाडीहरूले तपाईंलाई `मित्रलाई निमन्त्रणा दिनुहोस्` प्रकार्य मार्फत निमन्त्रणा दिन सक्दैनन्। तपाईं यसलाई सेटिङहरूमा परिवर्तन गर्न सक्नुहुन्छ।</string>
     

--- a/mobile/app/src/main/res/values-pl/strings.xml
+++ b/mobile/app/src/main/res/values-pl/strings.xml
@@ -95,7 +95,7 @@
     <string name="failed_to_load_nickname">Nie udało się wczytać pseudonimu.</string>
     <string name="search">Szukaj</string>
     <string name="load_more">Załaduj więcej</string>
-    <string name="add_friend_label">Dodaj</string>
+    <string name="add_friend_label">Dodaj do znajomych</string>
     <string name="invite_blocked">%1$s zablokował zaproszenia.</string>
     <string name="invites_blocked_notification">Inni gracze nie mogą Cię zapraszać przez funkcję "Zaproś znajomego". Możesz to zmienić w Ustawieniach.</string>
     

--- a/mobile/app/src/main/res/values-si/strings.xml
+++ b/mobile/app/src/main/res/values-si/strings.xml
@@ -114,7 +114,7 @@
     <string name="failed_to_load_nickname">අතුරු නාමය පූරණය කිරීමට අසමත් විය.</string>
     <string name="search">සොයන්න</string>
     <string name="load_more">තවත් පූරණය කරන්න</string>
-    <string name="add_friend_label">එක් කරන්න</string>
+    <string name="add_friend_label">මිතුරන් වෙත එක් කරන්න</string>
     <string name="invite_blocked">%1$s ආරාධනා අවහිර කර ඇත.</string>
     <string name="invites_blocked_notification">වෙනත් ක්‍රීඩකයින්ට \`මිතුරෙකු ආරාධනා කරන්න\` ක්‍රියාවලිය හරහා ඔබට ආරාධනා කිරීමට නොහැක. ඔබට එය සැකසුම් තුළ වෙනස් කළ හැක.</string>
     <string name="pending_game_invitations">අපේක්ෂිත ක්‍රීඩා ආරාධනා</string>

--- a/mobile/app/src/main/res/values-so/strings.xml
+++ b/mobile/app/src/main/res/values-so/strings.xml
@@ -114,7 +114,7 @@
     <string name="failed_to_load_nickname">Ku guuldarraystay soo dejinta naanayska.</string>
     <string name="search">Raadi</string>
     <string name="load_more">Soo bandhig kuwo kale</string>
-    <string name="add_friend_label">Ku dar</string>
+    <string name="add_friend_label">Ku dar saaxiibada</string>
     <string name="invite_blocked">%1$s wuu xannibay casuumaadaha.</string>
     <string name="invites_blocked_notification">Ciyaartoyda kale kuma casumi karaan shaqada `Saaxiib casumo`. Waxaad ka beddeli kartaa Dejinta.</string>
     <string name="pending_game_invitations">Casuumaadaha ciyaarta ee sugaya</string>

--- a/mobile/app/src/main/res/values-sw/strings.xml
+++ b/mobile/app/src/main/res/values-sw/strings.xml
@@ -114,7 +114,7 @@
     <string name="failed_to_load_nickname">Imeshindwa kupakia jina la utani.</string>
     <string name="search">Tafuta</string>
     <string name="load_more">Pakia zaidi</string>
-    <string name="add_friend_label">Ongeza</string>
+    <string name="add_friend_label">Ongeza kwa marafiki</string>
     <string name="invite_blocked">%1$s amezuia mialiko.</string>
     <string name="invites_blocked_notification">Wachezaji wengine hawawezi kukualika kupitia kipengele cha `Alika Rafiki`. Unaweza kubadilisha hili katika Mipangilio.</string>
     <string name="pending_game_invitations">Mialiko ya Mchezo Inayosubiri</string>

--- a/mobile/app/src/main/res/values-ur/strings.xml
+++ b/mobile/app/src/main/res/values-ur/strings.xml
@@ -95,7 +95,7 @@
     <string name="failed_to_load_nickname">عرفی نام لوڈ کرنے میں ناکام۔</string>
     <string name="search">تلاش</string>
     <string name="load_more">مزید لوڈ کریں</string>
-    <string name="add_friend_label">شامل کریں</string>
+    <string name="add_friend_label">دوستوں میں شامل کریں</string>
     <string name="invite_blocked">%1$s نے دعوتیں بلاک کر دی ہیں۔</string>
     <string name="invites_blocked_notification">دوسرے کھلاڑی آپ کو `دوست کو دعوت دیں` فنکشن کے ذریعے دعوت نہیں دے سکتے۔ آپ اسے سیٹنگز میں تبدیل کر سکتے ہیں۔</string>
     

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -74,7 +74,7 @@
     <string name="failed_to_load_nickname">Failed to load nickname.</string>
     <string name="search">Search</string>
     <string name="load_more">Load more</string>
-    <string name="add_friend_label">Add</string>
+    <string name="add_friend_label">Add to friends</string>
     <string name="invite_blocked">%1$s blocked invites.</string>
     <string name="invites_blocked_notification">Other players cannot invite you via `Invite a Friend` function. You can change it in Settings.</string>
     <string name="pending_game_invitations">Pending Game Invitations</string>


### PR DESCRIPTION
## Summary
- ensure the "no past invites" message responds to adapter changes so it hides when past invitations exist
- refresh the add-friend button label across all localized string resources to say "add to friends"

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ec164b97a08330addb88c6f97f8b3d