### PR TITLE
Fix duplicate onDestroy implementation

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
@@ -323,6 +323,12 @@ public class InvitationsActivity extends BaseActivity {
         if (pastAdapter != null && pastInvitesObserver != null) {
             pastAdapter.unregisterAdapterDataObserver(pastInvitesObserver);
         }
+        if (invitesSub != null) {
+            invitesSub.remove();
+        }
+        if (pastInvitesSub != null) {
+            pastInvitesSub.remove();
+        }
     }
 
     private void addFriend(@NonNull String targetUid) {
@@ -395,13 +401,6 @@ public class InvitationsActivity extends BaseActivity {
                     }
                 });
     }
-
-    @Override protected void onDestroy() {
-        super.onDestroy();
-        if (invitesSub != null) invitesSub.remove();
-        if (pastInvitesSub != null) pastInvitesSub.remove();
-    }
-
     @Override
     public boolean onSupportNavigateUp() {
         finish();


### PR DESCRIPTION
## Summary
- merge the duplicate `onDestroy` overrides in `InvitationsActivity`
- ensure both adapter cleanup and listener removals occur in the single lifecycle callback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ecd5738bb483309705bfcd3f89489e