### PR TITLE
Sort past invites client-side to avoid Firestore index

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
@@ -287,7 +287,6 @@ public class InvitationsActivity extends BaseActivity {
         pastInvitesSub = db.collection("invitations")
                 .whereEqualTo("to", currentUserId)
                 .whereIn("status", java.util.Arrays.asList("accepted", "cancelled", "expired"))
-                .orderBy("createdAt", Query.Direction.DESCENDING)
                 .addSnapshotListener((querySnapshot, e) -> {
                     if (e != null) {
                         Log.e("TAG_Soccer", getClass().getSimpleName() + ".listenForPastInvites: Listen failed", e);
@@ -299,6 +298,16 @@ public class InvitationsActivity extends BaseActivity {
                     for (DocumentSnapshot doc : Objects.requireNonNull(querySnapshot)) {
                         pastInvitesList.add(doc);
                     }
+
+                    pastInvitesList.sort((left, right) -> {
+                        Timestamp leftCreatedAt = left.getTimestamp("createdAt");
+                        Timestamp rightCreatedAt = right.getTimestamp("createdAt");
+
+                        long leftMillis = leftCreatedAt != null ? leftCreatedAt.toDate().getTime() : Long.MIN_VALUE;
+                        long rightMillis = rightCreatedAt != null ? rightCreatedAt.toDate().getTime() : Long.MIN_VALUE;
+
+                        return Long.compare(rightMillis, leftMillis);
+                    });
 
                     pastAdapter.setData(pastInvitesList);
                     updatePastInvitesEmptyState();


### PR DESCRIPTION
## Summary
- remove the Firestore orderBy clause from the past invitations listener to avoid requiring a composite index
- sort the invitation snapshots locally by createdAt so the UI still shows the newest entries first

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ecdee1f81c8330b84aba7296d73f82