### PR TITLE
Remove duplicate invite strings from localized resources

### DIFF
--- a/mobile/app/src/main/res/values-es/strings.xml
+++ b/mobile/app/src/main/res/values-es/strings.xml
@@ -357,10 +357,5 @@
     <string name="presence_user_online">%1$s estado: En línea</string>
     <string name="presence_user_last_seen">%1$s estado: Visto por última vez %2$s</string>
     <string name="presence_user_offline">%1$s estado: Desconectado</string>
-    <string name="invite_and_add_to_friend">Invitar y Añadir como Amigo</string>
-    <string name="invite_received_format">Recibido %1$s</string>
-    <string name="invite_status_accepted">Estado: Aceptado</string>
-    <string name="invite_status_cancelled">Estado: Cancelado</string>
-    <string name="invite_status_expired">Estado: Expirado</string>
 
 </resources>

--- a/mobile/app/src/main/res/values-fa/strings.xml
+++ b/mobile/app/src/main/res/values-fa/strings.xml
@@ -303,10 +303,5 @@
     <string name="presence_user_online">%1$s وضعیت: آنلاین</string>
     <string name="presence_user_last_seen">%1$s وضعیت: آخرین بار دیده شد %2$s</string>
     <string name="presence_user_offline">%1$s وضعیت: آفلاین</string>
-    <string name="invite_and_add_to_friend">دعوت و افزودن به دوستان</string>
-    <string name="invite_received_format">دریافت شده %1$s</string>
-    <string name="invite_status_accepted">وضعیت: پذیرفته شده</string>
-    <string name="invite_status_cancelled">وضعیت: لغو شده</string>
-    <string name="invite_status_expired">وضعیت: منقضی شده</string>
 
 </resources>

--- a/mobile/app/src/main/res/values-fr/strings.xml
+++ b/mobile/app/src/main/res/values-fr/strings.xml
@@ -351,10 +351,5 @@
     <string name="presence_user_online">%1$s statut: En ligne</string>
     <string name="presence_user_last_seen">%1$s statut: Vu pour la dernière fois %2$s</string>
     <string name="presence_user_offline">%1$s statut: Hors ligne</string>
-    <string name="invite_and_add_to_friend">Inviter et Ajouter comme Ami</string>
-    <string name="invite_received_format">Reçu %1$s</string>
-    <string name="invite_status_accepted">Statut: Accepté</string>
-    <string name="invite_status_cancelled">Statut: Annulé</string>
-    <string name="invite_status_expired">Statut: Expiré</string>
 
 </resources>

--- a/mobile/app/src/main/res/values-hi/strings.xml
+++ b/mobile/app/src/main/res/values-hi/strings.xml
@@ -356,10 +356,5 @@
     <string name="presence_user_online">%1$s स्थिति: ऑनलाइन</string>
     <string name="presence_user_last_seen">%1$s स्थिति: अंतिम बार देखा गया %2$s</string>
     <string name="presence_user_offline">%1$s स्थिति: ऑफ़लाइन</string>
-    <string name="invite_and_add_to_friend">आमंत्रित करें और मित्र जोड़ें</string>
-    <string name="invite_received_format">प्राप्त %1$s</string>
-    <string name="invite_status_accepted">स्थिति: स्वीकृत</string>
-    <string name="invite_status_cancelled">स्थिति: रद्द</string>
-    <string name="invite_status_expired">स्थिति: समाप्त</string>
 
 </resources>

--- a/mobile/app/src/main/res/values-lo/strings.xml
+++ b/mobile/app/src/main/res/values-lo/strings.xml
@@ -322,10 +322,5 @@
     <string name="presence_user_online">%1$s ສະຖານະ: ອອນໄລນ໌</string>
     <string name="presence_user_last_seen">%1$s ສະຖານະ: ເຫັນຄັ້ງສຸດທ້າຍ %2$s</string>
     <string name="presence_user_offline">%1$s ສະຖານະ: ອອບໄລນ໌</string>
-    <string name="invite_and_add_to_friend">ເຊີນແລະເພີ່ມເປັນໝູ່</string>
-    <string name="invite_received_format">ໄດ້ຮັບ %1$s</string>
-    <string name="invite_status_accepted">ສະຖານະ: ຍອມຮັບແລ້ວ</string>
-    <string name="invite_status_cancelled">ສະຖານະ: ຍົກເລີກແລ້ວ</string>
-    <string name="invite_status_expired">ສະຖານະ: ໝົດອາຍຸແລ້ວ</string>
 
 </resources>

--- a/mobile/app/src/main/res/values-mn/strings.xml
+++ b/mobile/app/src/main/res/values-mn/strings.xml
@@ -322,10 +322,5 @@
     <string name="presence_user_online">%1$s төлөв: Онлайн</string>
     <string name="presence_user_last_seen">%1$s төлөв: Сүүлд харагдсан %2$s</string>
     <string name="presence_user_offline">%1$s төлөв: Оффлайн</string>
-    <string name="invite_and_add_to_friend">Урих ба Найз нэмэх</string>
-    <string name="invite_received_format">Хүлээн авсан %1$s</string>
-    <string name="invite_status_accepted">Төлөв: Зөвшөөрсөн</string>
-    <string name="invite_status_cancelled">Төлөв: Цуцалсан</string>
-    <string name="invite_status_expired">Төлөв: Дууссан</string>
 
 </resources>

--- a/mobile/app/src/main/res/values-my/strings.xml
+++ b/mobile/app/src/main/res/values-my/strings.xml
@@ -322,10 +322,5 @@
     <string name="presence_user_online">%1$s အခြေအနေ: အွန်လိုင်း</string>
     <string name="presence_user_last_seen">%1$s အခြေအနေ: နောက်ဆုံးမြင်တွေ့ %2$s</string>
     <string name="presence_user_offline">%1$s အခြေအနေ: အော့ဖ်လိုင်း</string>
-    <string name="invite_and_add_to_friend">ဖိတ်ကြားပြီး သူငယ်ချင်းအဖြစ်ထည့်ရန်</string>
-    <string name="invite_received_format">လက်ခံရရှိသည် %1$s</string>
-    <string name="invite_status_accepted">အခြေအနေ: လက်ခံပြီး</string>
-    <string name="invite_status_cancelled">အခြေအနေ: ပယ်ဖျက်ပြီး</string>
-    <string name="invite_status_expired">အခြေအနေ: သက်တမ်းကုန်ပြီး</string>
 
 </resources>

--- a/mobile/app/src/main/res/values-ne/strings.xml
+++ b/mobile/app/src/main/res/values-ne/strings.xml
@@ -356,10 +356,5 @@
     <string name="presence_user_online">%1$s स्थिति: अनलाइन</string>
     <string name="presence_user_last_seen">%1$s स्थिति: अन्तिम पटक देखिएको %2$s</string>
     <string name="presence_user_offline">%1$s स्थिति: अफलाइन</string>
-    <string name="invite_and_add_to_friend">निमन्त्रणा र साथी थप्नुहोस्</string>
-    <string name="invite_received_format">प्राप्त %1$s</string>
-    <string name="invite_status_accepted">स्थिति: स्वीकृत</string>
-    <string name="invite_status_cancelled">स्थिति: रद्द गरिएको</string>
-    <string name="invite_status_expired">स्थिति: म्याद समाप्त</string>
 
 </resources>

--- a/mobile/app/src/main/res/values-si/strings.xml
+++ b/mobile/app/src/main/res/values-si/strings.xml
@@ -322,10 +322,5 @@
     <string name="presence_user_online">%1$s තත්ත්වය: සබැඳිව</string>
     <string name="presence_user_last_seen">%1$s තත්ත්වය: අවසන් වරට දුටු %2$s</string>
     <string name="presence_user_offline">%1$s තත්ත්වය: අසම්බන්ධිත</string>
-    <string name="invite_and_add_to_friend">ආරාධනා කර මිතුරකු ලෙස එක් කරන්න</string>
-    <string name="invite_received_format">ලැබුණි %1$s</string>
-    <string name="invite_status_accepted">තත්ත්වය: පිළිගත්</string>
-    <string name="invite_status_cancelled">තත්ත්වය: අවලංගු</string>
-    <string name="invite_status_expired">තත්ත්වය: කල් ඉකුත්</string>
 
 </resources>

--- a/mobile/app/src/main/res/values-sw/strings.xml
+++ b/mobile/app/src/main/res/values-sw/strings.xml
@@ -322,10 +322,5 @@
     <string name="presence_user_online">%1$s hali: Mtandaoni</string>
     <string name="presence_user_last_seen">%1$s hali: Alionekana mwisho %2$s</string>
     <string name="presence_user_offline">%1$s hali: Nje ya mtandao</string>
-    <string name="invite_and_add_to_friend">Alika na Ongeza kama Rafiki</string>
-    <string name="invite_received_format">Imepokewa %1$s</string>
-    <string name="invite_status_accepted">Hali: Imekubaliwa</string>
-    <string name="invite_status_cancelled">Hali: Imefutwa</string>
-    <string name="invite_status_expired">Hali: Imeisha muda</string>
 
 </resources>


### PR DESCRIPTION
## Summary
- remove duplicate invite-related strings from multiple localized resources
- ensure each locale defines invite_and_add_to_friend only once to resolve resource merge conflicts

## Testing
- ./gradlew :app:merge_prodDebugResources *(fails: requires soccer_secret_key in secrets/)*

------
https://chatgpt.com/codex/tasks/task_e_68ecf580cb308330be8823060fa58b4a