### PR TITLE
Align invite friend flow with Cloud Function

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
@@ -23,9 +23,12 @@ import com.google.firebase.functions.FirebaseFunctionsException;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import android.content.SharedPreferences;
 
@@ -45,6 +48,7 @@ public class InvitationsActivity extends BaseActivity {
 
     FirebaseFirestore db;
     FirebaseAuth auth;
+    private Set<String> friendUids = new HashSet<>();
 
     private ListenerRegistration invitesSub;   // keep handle so we can remove it later
     private ListenerRegistration pastInvitesSub;
@@ -75,6 +79,7 @@ public class InvitationsActivity extends BaseActivity {
         emptyPastInvites = findViewById(R.id.emptyPastInvites);
         pastInvitesList.setLayoutManager(new LinearLayoutManager(this));
         pastAdapter = new PastInviteAdapter(this, this::sendInviteViaCF, this::addFriend);
+        pastAdapter.setFriendUids(friendUids);
         pastInvitesList.setAdapter(pastAdapter);
         pastInvitesObserver = new RecyclerView.AdapterDataObserver() {
             @Override
@@ -99,6 +104,7 @@ public class InvitationsActivity extends BaseActivity {
 
         listenForInvites();
         listenForPastInvites();
+        loadFriends();
 
         invitesList.setOnItemClickListener((parent, view, position, id) -> {
             String inviteId = inviteIds.get(position);
@@ -314,6 +320,32 @@ public class InvitationsActivity extends BaseActivity {
                 });
     }
 
+    private void loadFriends() {
+        FirebaseUser currentUser = auth.getCurrentUser();
+        if (currentUser == null) {
+            Log.w("TAG_Soccer", getClass().getSimpleName() + ".loadFriends: User not signed-in");
+            return;
+        }
+
+        db.collection("users")
+                .document(currentUser.getUid())
+                .collection("friends")
+                .get()
+                .addOnSuccessListener(snap -> {
+                    Set<String> newFriendUids = new HashSet<>();
+                    for (DocumentSnapshot doc : snap.getDocuments()) {
+                        newFriendUids.add(doc.getId());
+                    }
+                    friendUids = newFriendUids;
+                    pastAdapter.setFriendUids(friendUids);
+                })
+                .addOnFailureListener(e -> {
+                    Log.e("TAG_Soccer", getClass().getSimpleName() + ".loadFriends: Failed to load friends", e);
+                    friendUids = new HashSet<>();
+                    pastAdapter.setFriendUids(friendUids);
+                });
+    }
+
     private void updatePastInvitesEmptyState() {
         if (emptyPastInvites == null || pastAdapter == null) {
             return;
@@ -341,26 +373,46 @@ public class InvitationsActivity extends BaseActivity {
     }
 
     private void addFriend(@NonNull String targetUid) {
-        String currentUserId = Objects.requireNonNull(auth.getCurrentUser()).getUid();
-        
-        // Add to both users' friends subcollections
-        db.collection("users").document(currentUserId).collection("friends").document(targetUid)
-                .set(Collections.singletonMap("addedAt", com.google.firebase.firestore.FieldValue.serverTimestamp()))
-                .addOnSuccessListener(aVoid -> {
-                    // Also add current user to target's friends
-                    db.collection("users").document(targetUid).collection("friends").document(currentUserId)
-                            .set(Collections.singletonMap("addedAt", com.google.firebase.firestore.FieldValue.serverTimestamp()))
-                            .addOnSuccessListener(aVoid2 -> {
-                                Toast.makeText(this, R.string.friend_added, Toast.LENGTH_SHORT).show();
-                            })
-                            .addOnFailureListener(e -> {
-                                Log.e("TAG_Soccer", getClass().getSimpleName() + ".addFriend: Error adding to target's friends", e);
-                                Toast.makeText(this, R.string.failed_to_add_friend, Toast.LENGTH_SHORT).show();
-                            });
+        FirebaseUser currentUser = auth.getCurrentUser();
+        if (currentUser == null) {
+            Log.e("TAG_Soccer", getClass().getSimpleName() + ".addFriend: User not signed-in");
+            Toast.makeText(this, R.string.must_log_in_to_accept_invites, Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        if (friendUids.contains(targetUid)) {
+            Toast.makeText(this, R.string.already_friends, Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        sendAddFriendViaCF(currentUser.getUid(), targetUid);
+    }
+
+    private void sendAddFriendViaCF(@NonNull String userId, @NonNull String friendId) {
+        Map<String, Object> data = new HashMap<>();
+        data.put("userId", userId);
+        data.put("friendId", friendId);
+
+        FirebaseFunctions.getInstance("us-central1")
+                .getHttpsCallable("addFriend")
+                .call(data)
+                .addOnSuccessListener(res -> {
+                    Toast.makeText(this, R.string.friend_added, Toast.LENGTH_SHORT).show();
+                    friendUids.add(friendId);
+                    pastAdapter.addFriendUid(friendId);
                 })
                 .addOnFailureListener(e -> {
-                    Log.e("TAG_Soccer", getClass().getSimpleName() + ".addFriend: Error adding friend", e);
-                    Toast.makeText(this, R.string.failed_to_add_friend, Toast.LENGTH_SHORT).show();
+                    String text = SafeStringFormatter.safeGetString(this, R.string.failed_to_add_friend);
+                    if (e instanceof FirebaseFunctionsException ffe) {
+                        String reason = ffe.getMessage();
+                        Log.e("TAG_Soccer", getClass().getSimpleName() + ".addFriend: addFriend failed: " + reason, ffe);
+                        if (reason != null && !reason.isEmpty()) {
+                            text = SafeStringFormatter.safeGetString(this, R.string.failed_to_add_friend_reason, reason);
+                        }
+                    } else {
+                        Log.e("TAG_Soccer", getClass().getSimpleName() + ".addFriend: addFriend failed", e);
+                    }
+                    Toast.makeText(this, text, Toast.LENGTH_SHORT).show();
                 });
     }
 

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/PastInviteAdapter.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/PastInviteAdapter.java
@@ -21,8 +21,10 @@ import com.google.firebase.firestore.FirebaseFirestore;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class PastInviteAdapter extends RecyclerView.Adapter<PastInviteAdapter.VH> {
 
@@ -58,6 +60,7 @@ public class PastInviteAdapter extends RecyclerView.Adapter<PastInviteAdapter.VH
     private final Map<String,Boolean> userDeletedCache = new HashMap<>();
     private static final class RtdbSub { final DatabaseReference ref; final ValueEventListener l; RtdbSub(DatabaseReference r, ValueEventListener l){this.ref=r;this.l=l;}}
     private final Map<String,RtdbSub> presSubs = new HashMap<>();
+    private Set<String> friendUids = new HashSet<>();
 
     PastInviteAdapter(Context context, OnInviteClick inviteListener, OnAddFriendClick addFriendListener) {
         this.context = context;
@@ -122,6 +125,8 @@ public class PastInviteAdapter extends RecyclerView.Adapter<PastInviteAdapter.VH
             h.presence.setText("");
             h.sendInviteBtn.setEnabled(false);
             h.addFriendBtn.setEnabled(false);
+            h.addFriendBtn.setAlpha(0.3f);
+            h.addFriendBtn.setText(R.string.add_friend_label);
             return;
         }
         
@@ -251,14 +256,21 @@ public class PastInviteAdapter extends RecyclerView.Adapter<PastInviteAdapter.VH
         // Enable/disable buttons based on user status
         Boolean isDeleted = userDeletedCache.get(uid);
         boolean userDeleted = isDeleted != null && isDeleted;
-        
+
         // Buttons are disabled if user is deleted OR if user is offline (no heartbeat data)
         long lastHeartbeat = hbCache.getOrDefault(uid, 0L);
         boolean isTrulyOffline = "offline".equalsIgnoreCase(state) && lastHeartbeat == 0L;
-        
+
         boolean enabled = !userDeleted && !isTrulyOffline;
+        boolean alreadyFriend = friendUids.contains(uid);
+
         h.sendInviteBtn.setEnabled(enabled);
-        h.addFriendBtn.setEnabled(enabled);
+        boolean canAddFriend = enabled && !alreadyFriend;
+        h.addFriendBtn.setEnabled(canAddFriend);
+        h.addFriendBtn.setAlpha(canAddFriend ? 1f : 0.3f);
+        h.addFriendBtn.setText(alreadyFriend
+                ? context.getString(R.string.already_friends)
+                : context.getString(R.string.add_friend_label));
     }
 
     @Override
@@ -277,6 +289,23 @@ public class PastInviteAdapter extends RecyclerView.Adapter<PastInviteAdapter.VH
         docs.clear();
         docs.addAll(invites);
         notifyDataSetChanged();
+    }
+
+    void setFriendUids(@NonNull Set<String> friendUids) {
+        this.friendUids = new HashSet<>(friendUids);
+        notifyDataSetChanged();
+    }
+
+    void addFriendUid(@NonNull String friendUid) {
+        if (!this.friendUids.add(friendUid)) {
+            return;
+        }
+        for (int i = 0; i < docs.size(); i++) {
+            String fromUid = docs.get(i).getString("from");
+            if (friendUid.equals(fromUid)) {
+                notifyItemChanged(i);
+            }
+        }
     }
 
     @Override

--- a/mobile/app/src/main/res/values-am/strings.xml
+++ b/mobile/app/src/main/res/values-am/strings.xml
@@ -115,6 +115,7 @@
     <string name="search">ፈልግ</string>
     <string name="load_more">ተጨማሪ አስገባ</string>
     <string name="add_friend_label">ወደ ጓደኞች አክል</string>
+    <string name="already_friends">ቀድሞ ጓደኛ ናቸው</string>
     <string name="invite_blocked">%1$s ግብዣዎችን አግዷል።</string>
     <string name="invites_blocked_notification">ሌሎች ተጫዋቾች “ጓደኛን ጋብዝ” ተግባር በመጠቀም ሊጋብዙዎት አይችሉም። ይህን በቅንብሮች ውስጥ መቀየር ትችላላችሁ።</string>
     <string name="pending_game_invitations">በመጠባበቅ ያሉ የጨዋታ ግብዣዎች</string>

--- a/mobile/app/src/main/res/values-ar/strings.xml
+++ b/mobile/app/src/main/res/values-ar/strings.xml
@@ -96,6 +96,7 @@
     <string name="search">بحث</string>
     <string name="load_more">تحميل المزيد</string>
     <string name="add_friend_label">أضف إلى الأصدقاء</string>
+    <string name="already_friends">أصدقاء بالفعل</string>
     <string name="invite_blocked">%1$s قام بحظر الدعوات.</string>
     <string name="invites_blocked_notification">لا يمكن للاعبين الآخرين دعوتك عبر وظيفة "ادعُ صديقاً". يمكنك تغيير ذلك في الإعدادات.</string>
     <string name="pending_game_invitations">دعوات اللعب المعلقة</string>

--- a/mobile/app/src/main/res/values-bn/strings.xml
+++ b/mobile/app/src/main/res/values-bn/strings.xml
@@ -96,6 +96,7 @@
     <string name="search">অনুসন্ধান</string>
     <string name="load_more">আরো লোড করুন</string>
     <string name="add_friend_label">বন্ধুদের মধ্যে যোগ করুন</string>
+    <string name="already_friends">ইতিমধ্যেই বন্ধু</string>
     <string name="invite_blocked">%1$s আমন্ত্রণ ব্লক করেছে।</string>
     <string name="invites_blocked_notification">অন্য খেলোয়াড়রা `বন্ধুকে আমন্ত্রণ জানান` ফাংশনের মাধ্যমে আপনাকে আমন্ত্রণ জানাতে পারবে না। আপনি সেটিংসে এটি পরিবর্তন করতে পারেন।</string>
     

--- a/mobile/app/src/main/res/values-de/strings.xml
+++ b/mobile/app/src/main/res/values-de/strings.xml
@@ -96,6 +96,7 @@
     <string name="search">Suchen</string>
     <string name="load_more">Mehr laden</string>
     <string name="add_friend_label">Zu Freunden hinzufügen</string>
+    <string name="already_friends">Bereits befreundet</string>
     <string name="invite_blocked">%1$s hat Einladungen blockiert.</string>
     <string name="invites_blocked_notification">Andere Spieler können Sie nicht über die `Freund einladen`-Funktion einladen. Sie können dies in den Einstellungen ändern.</string>
     

--- a/mobile/app/src/main/res/values-es/strings.xml
+++ b/mobile/app/src/main/res/values-es/strings.xml
@@ -96,6 +96,7 @@
     <string name="search">Buscar</string>
     <string name="load_more">Cargar más</string>
     <string name="add_friend_label">Agregar a amigos</string>
+    <string name="already_friends">Ya son amigos</string>
     <string name="invite_blocked">%1$s bloqueó invitaciones.</string>
     <string name="invites_blocked_notification">Otros jugadores no pueden invitarte a través de la función `Invitar amigo`. Puedes cambiarlo en Configuración.</string>
     

--- a/mobile/app/src/main/res/values-fa/strings.xml
+++ b/mobile/app/src/main/res/values-fa/strings.xml
@@ -96,6 +96,7 @@
     <string name="search">جستجو</string>
     <string name="load_more">بارگذاری بیشتر</string>
     <string name="add_friend_label">افزودن به دوستان</string>
+    <string name="already_friends">قبلاً دوست هستید</string>
     <string name="invite_blocked">%1$s دعوت‌ها را مسدود کرده است.</string>
     <string name="invites_blocked_notification">بازیکنان دیگر نمی‌توانند از طریق «دعوت از دوست» شما را دعوت کنند. می‌توانید این گزینه را در تنظیمات تغییر دهید.</string>
     <string name="pending_game_invitations">دعوت‌های بازی در انتظار</string>

--- a/mobile/app/src/main/res/values-fr/strings.xml
+++ b/mobile/app/src/main/res/values-fr/strings.xml
@@ -103,6 +103,7 @@
     <string name="search">Rechercher</string>
     <string name="load_more">Charger plus</string>
     <string name="add_friend_label">Ajouter aux amis</string>
+    <string name="already_friends">Déjà amis</string>
     <string name="invite_blocked">%1$s a bloqué les invitations.</string>
     <string name="invites_blocked_notification">Les autres joueurs ne peuvent pas vous inviter via « Inviter un ami ». Vous pouvez modifier ce réglage dans Paramètres.</string>
 

--- a/mobile/app/src/main/res/values-hi/strings.xml
+++ b/mobile/app/src/main/res/values-hi/strings.xml
@@ -96,6 +96,7 @@
     <string name="search">खोजें</string>
     <string name="load_more">और लोड करें</string>
     <string name="add_friend_label">दोस्तों में जोड़ें</string>
+    <string name="already_friends">पहले से दोस्त हैं</string>
     <string name="invite_blocked">%1$s ने आमंत्रण ब्लॉक कर दिए हैं।</string>
     <string name="invites_blocked_notification">अन्य खिलाड़ी आपको `मित्र को आमंत्रित करें` फ़ंक्शन के माध्यम से आमंत्रित नहीं कर सकते। आप इसे सेटिंग्स में बदल सकते हैं।</string>
     

--- a/mobile/app/src/main/res/values-km/strings.xml
+++ b/mobile/app/src/main/res/values-km/strings.xml
@@ -115,6 +115,7 @@
     <string name="search">ស្វែងរក</string>
     <string name="load_more">ផ្ទុកបន្ថែម</string>
     <string name="add_friend_label">បន្ថែមទៅកាន់មិត្តភក្តិ</string>
+    <string name="already_friends">ជាមិត្តរួចហើយ</string>
     <string name="invite_blocked">%1$s បានទប់ស្កាត់ការអញ្ជើញ។</string>
     <string name="invites_blocked_notification">អ្នកលេងផ្សេងទៀតមិនអាចអញ្ជើញអ្នកតាមមុខងារ \`អញ្ជើញមិត្តភក្តិ\` បានទេ។ អ្នកអាចផ្លាស់ប្តូរវានៅក្នុងការកំណត់។</string>
     <string name="pending_game_invitations">ការអញ្ជើញល្បែងកំពុងរង់ចាំ</string>

--- a/mobile/app/src/main/res/values-lo/strings.xml
+++ b/mobile/app/src/main/res/values-lo/strings.xml
@@ -115,6 +115,7 @@
     <string name="search">ຄົ້ນຫາ</string>
     <string name="load_more">ໂຫລດເພີ່ມ</string>
     <string name="add_friend_label">ເພີ່ມເຂົ້າໝູ່ເພື່ອນ</string>
+    <string name="already_friends">ເປັນໝູ່ກັນແລ້ວ</string>
     <string name="invite_blocked">%1$s ປິດຮັບຄໍາເຊີນ.</string>
     <string name="invites_blocked_notification">ຜູ້ຫຼິ້ນອື່ນບໍ່ສາມາດເຊີນທ່ານຜ່ານຟັງຊັນ "ເຊີນໝູ່" ໄດ້. ທ່ານສາມາດປ່ຽນໄດ້ໃນການຕັ້ງຄ່າ.</string>
     <string name="pending_game_invitations">ຄໍາເຊີນເກມທີ່ລໍຖ້າ</string>

--- a/mobile/app/src/main/res/values-mg/strings.xml
+++ b/mobile/app/src/main/res/values-mg/strings.xml
@@ -115,6 +115,7 @@
     <string name="search">Karohy</string>
     <string name="load_more">Ampidiro bebe kokoa</string>
     <string name="add_friend_label">Ampio amin`ny namana</string>
+    <string name="already_friends">Efa namana</string>
     <string name="invite_blocked">Nanakana fanasana i %1$s.</string>
     <string name="invites_blocked_notification">Ny mpilalao hafa tsy afaka manasa anao amin`ny fiasa `Asao namana`. Azonao ovaina ao amin`ny Fandrindrana izany.</string>
     <string name="pending_game_invitations">Fanasana lalao miandry</string>

--- a/mobile/app/src/main/res/values-mn/strings.xml
+++ b/mobile/app/src/main/res/values-mn/strings.xml
@@ -115,6 +115,7 @@
     <string name="search">Хайх</string>
     <string name="load_more">Илүүг ачааллах</string>
     <string name="add_friend_label">Найзууд руу нэмэх</string>
+    <string name="already_friends">Аль хэдийн найзууд</string>
     <string name="invite_blocked">%1$s урилга авахыг хаасан.</string>
     <string name="invites_blocked_notification">Бусад тоглогчид “Найзаа урих” функцаар таныг урих боломжгүй. Та үүнийг тохиргоонд өөрчилж болно.</string>
     <string name="pending_game_invitations">Хүлээгдэж буй тоглоомын урилгууд</string>

--- a/mobile/app/src/main/res/values-my/strings.xml
+++ b/mobile/app/src/main/res/values-my/strings.xml
@@ -115,6 +115,7 @@
     <string name="search">ရှာဖွေပါ</string>
     <string name="load_more">နောက်ထပ်တင်ပါ</string>
     <string name="add_friend_label">မိတ်ဆွေများထဲထည့်ပါ</string>
+    <string name="already_friends">မိတ်ဆွေဖြစ်ပြီးသားပါပြီ</string>
     <string name="invite_blocked">%1$s သည် ဖိတ်ကြားချက်များကို ပိတ်ဆို့ထားသည်။</string>
     <string name="invites_blocked_notification">အခြားကစားသူများသည် \`သူငယ်ချင်းကိုဖိတ်ကြားပါ\` ဖန်ရှင်မှတစ်ဆင့် သင့်ကို ဖိတ်ခေါ်မနိုင်ပါ။ သင်သည် ဆက်တင်များတွင် ပြင်ဆင်နိုင်ပါသည်။</string>
     <string name="pending_game_invitations">ဆိုင်းငံ့ထားသော ဂိမ်းဖိတ်ကြားချက်များ</string>

--- a/mobile/app/src/main/res/values-ne/strings.xml
+++ b/mobile/app/src/main/res/values-ne/strings.xml
@@ -96,6 +96,7 @@
     <string name="search">खोज्नुहोस्</string>
     <string name="load_more">थप लोड गर्नुहोस्</string>
     <string name="add_friend_label">साथीहरूमा थप्नुहोस्</string>
+    <string name="already_friends">पहिले नै साथी हुन्</string>
     <string name="invite_blocked">%1$s ले निमन्त्रणाहरू ब्लक गरेको छ।</string>
     <string name="invites_blocked_notification">अन्य खेलाडीहरूले तपाईंलाई `मित्रलाई निमन्त्रणा दिनुहोस्` प्रकार्य मार्फत निमन्त्रणा दिन सक्दैनन्। तपाईं यसलाई सेटिङहरूमा परिवर्तन गर्न सक्नुहुन्छ।</string>
     

--- a/mobile/app/src/main/res/values-pl/strings.xml
+++ b/mobile/app/src/main/res/values-pl/strings.xml
@@ -96,6 +96,7 @@
     <string name="search">Szukaj</string>
     <string name="load_more">Załaduj więcej</string>
     <string name="add_friend_label">Dodaj do znajomych</string>
+    <string name="already_friends">Już znajomi</string>
     <string name="invite_blocked">%1$s zablokował zaproszenia.</string>
     <string name="invites_blocked_notification">Inni gracze nie mogą Cię zapraszać przez funkcję "Zaproś znajomego". Możesz to zmienić w Ustawieniach.</string>
     

--- a/mobile/app/src/main/res/values-si/strings.xml
+++ b/mobile/app/src/main/res/values-si/strings.xml
@@ -115,6 +115,7 @@
     <string name="search">සොයන්න</string>
     <string name="load_more">තවත් පූරණය කරන්න</string>
     <string name="add_friend_label">මිතුරන් වෙත එක් කරන්න</string>
+    <string name="already_friends">දැනටමත් මිතුරන්</string>
     <string name="invite_blocked">%1$s ආරාධනා අවහිර කර ඇත.</string>
     <string name="invites_blocked_notification">වෙනත් ක්‍රීඩකයින්ට \`මිතුරෙකු ආරාධනා කරන්න\` ක්‍රියාවලිය හරහා ඔබට ආරාධනා කිරීමට නොහැක. ඔබට එය සැකසුම් තුළ වෙනස් කළ හැක.</string>
     <string name="pending_game_invitations">අපේක්ෂිත ක්‍රීඩා ආරාධනා</string>

--- a/mobile/app/src/main/res/values-so/strings.xml
+++ b/mobile/app/src/main/res/values-so/strings.xml
@@ -115,6 +115,7 @@
     <string name="search">Raadi</string>
     <string name="load_more">Soo bandhig kuwo kale</string>
     <string name="add_friend_label">Ku dar saaxiibada</string>
+    <string name="already_friends">Horeba waa saaxiibo</string>
     <string name="invite_blocked">%1$s wuu xannibay casuumaadaha.</string>
     <string name="invites_blocked_notification">Ciyaartoyda kale kuma casumi karaan shaqada `Saaxiib casumo`. Waxaad ka beddeli kartaa Dejinta.</string>
     <string name="pending_game_invitations">Casuumaadaha ciyaarta ee sugaya</string>

--- a/mobile/app/src/main/res/values-sw/strings.xml
+++ b/mobile/app/src/main/res/values-sw/strings.xml
@@ -115,6 +115,7 @@
     <string name="search">Tafuta</string>
     <string name="load_more">Pakia zaidi</string>
     <string name="add_friend_label">Ongeza kwa marafiki</string>
+    <string name="already_friends">Tayari marafiki</string>
     <string name="invite_blocked">%1$s amezuia mialiko.</string>
     <string name="invites_blocked_notification">Wachezaji wengine hawawezi kukualika kupitia kipengele cha `Alika Rafiki`. Unaweza kubadilisha hili katika Mipangilio.</string>
     <string name="pending_game_invitations">Mialiko ya Mchezo Inayosubiri</string>

--- a/mobile/app/src/main/res/values-ur/strings.xml
+++ b/mobile/app/src/main/res/values-ur/strings.xml
@@ -96,6 +96,7 @@
     <string name="search">تلاش</string>
     <string name="load_more">مزید لوڈ کریں</string>
     <string name="add_friend_label">دوستوں میں شامل کریں</string>
+    <string name="already_friends">پہلے ہی دوست ہیں</string>
     <string name="invite_blocked">%1$s نے دعوتیں بلاک کر دی ہیں۔</string>
     <string name="invites_blocked_notification">دوسرے کھلاڑی آپ کو `دوست کو دعوت دیں` فنکشن کے ذریعے دعوت نہیں دے سکتے۔ آپ اسے سیٹنگز میں تبدیل کر سکتے ہیں۔</string>
     

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
     <string name="search">Search</string>
     <string name="load_more">Load more</string>
     <string name="add_friend_label">Add to friends</string>
+    <string name="already_friends">Already friends</string>
     <string name="invite_blocked">%1$s blocked invites.</string>
     <string name="invites_blocked_notification">Other players cannot invite you via `Invite a Friend` function. You can change it in Settings.</string>
     <string name="pending_game_invitations">Pending Game Invitations</string>


### PR DESCRIPTION
## Summary
- load the current user's friend list when viewing past invites and call the addFriend Cloud Function instead of direct Firestore writes
- track friend UIDs in the past invite adapter so the "Add to friends" button is disabled and relabeled when the player is already a friend
- add a string resource for the "Already friends" label used in the adapter and translate it across all supported locales

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ecfd4b13848330bde0b8f676b00eaa