### PR TITLE
Align pending invites list with past invites

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
@@ -34,11 +34,10 @@ import android.content.SharedPreferences;
 
 public class InvitationsActivity extends BaseActivity {
 
-    ListView invitesList;
+    RecyclerView invitesList;
     TextView emptyText;
-    ArrayAdapter<String> adapter;
-    final ArrayList<String> inviteDescriptions = new ArrayList<>();
-    final ArrayList<String> inviteIds = new ArrayList<>();
+    PendingInviteAdapter pendingAdapter;
+    RecyclerView.AdapterDataObserver pendingInvitesObserver;
 
     RecyclerView pastInvitesList;
     TextView pastInvitesLabel;
@@ -71,8 +70,26 @@ public class InvitationsActivity extends BaseActivity {
 
         invitesList = findViewById(R.id.invitesList);
         emptyText = findViewById(R.id.emptyInvites);
-        adapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, inviteDescriptions);
-        invitesList.setAdapter(adapter);
+        invitesList.setLayoutManager(new LinearLayoutManager(this));
+        pendingAdapter = new PendingInviteAdapter(this, this::promptAcceptInvite);
+        invitesList.setAdapter(pendingAdapter);
+        pendingInvitesObserver = new RecyclerView.AdapterDataObserver() {
+            @Override
+            public void onChanged() {
+                updatePendingInvitesEmptyState();
+            }
+
+            @Override
+            public void onItemRangeInserted(int positionStart, int itemCount) {
+                updatePendingInvitesEmptyState();
+            }
+
+            @Override
+            public void onItemRangeRemoved(int positionStart, int itemCount) {
+                updatePendingInvitesEmptyState();
+            }
+        };
+        pendingAdapter.registerAdapterDataObserver(pendingInvitesObserver);
 
         pastInvitesList = findViewById(R.id.pastInvitesList);
         pastInvitesLabel = findViewById(R.id.pastInvitesLabel);
@@ -106,17 +123,17 @@ public class InvitationsActivity extends BaseActivity {
         listenForPastInvites();
         loadFriends();
 
-        invitesList.setOnItemClickListener((parent, view, position, id) -> {
-            String inviteId = inviteIds.get(position);
+    }
 
-            new AlertDialog.Builder(this)
-                    .setTitle(R.string.accept_invitation_title)
-                    .setMessage(R.string.accept_invitation_message)
-                    .setPositiveButton(R.string.accept, (dialog, which) -> acceptInvite(inviteId))
-                    .setNegativeButton(R.string.cancel, null)
-                    .show();
-        });
+    private void promptAcceptInvite(@NonNull DocumentSnapshot inviteDoc) {
+        String inviteId = inviteDoc.getId();
 
+        new AlertDialog.Builder(this)
+                .setTitle(R.string.accept_invitation_title)
+                .setMessage(R.string.accept_invitation_message)
+                .setPositiveButton(R.string.accept, (dialog, which) -> acceptInvite(inviteId))
+                .setNegativeButton(R.string.cancel, null)
+                .show();
     }
 
     // At the top of the class — keeps logcat tidy
@@ -207,15 +224,8 @@ public class InvitationsActivity extends BaseActivity {
                                 Toast.makeText(this, userMsg, Toast.LENGTH_LONG).show();
 
                                 /* ⬇️  remove the stale item locally so the list refreshes */
-                                int idx = inviteIds.indexOf(invitationId);
-                                if (idx != -1) {
-                                    inviteIds.remove(idx);
-                                    inviteDescriptions.remove(idx);
-                                    adapter.notifyDataSetChanged();
-                                    if (inviteIds.isEmpty()) {
-                                        emptyText.setVisibility(View.VISIBLE);
-                                    }
-                                }
+                                pendingAdapter.removeInvite(invitationId);
+                                updatePendingInvitesEmptyState();
                             });
 
                 })
@@ -239,17 +249,14 @@ public class InvitationsActivity extends BaseActivity {
                 .orderBy("expireAt")                // ← added
                 .addSnapshotListener((querySnapshot, e) -> {
                     if (e != null) {
-                        inviteDescriptions.clear();
-                        inviteIds.clear();
-                        adapter.notifyDataSetChanged();
+                        pendingAdapter.setData(new ArrayList<>());
                         emptyText.setVisibility(View.VISIBLE);
                         Log.e("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName()
                                 + ": Listen failed", e);
                         return;
                     }
 
-                    inviteDescriptions.clear();
-                    inviteIds.clear();
+                    List<DocumentSnapshot> pendingInvites = new ArrayList<>();
 
                     long nowMillis = System.currentTimeMillis();      // 🕔 current client time
                     for (DocumentSnapshot doc : Objects.requireNonNull(querySnapshot)) {
@@ -260,31 +267,24 @@ public class InvitationsActivity extends BaseActivity {
                         if (exp != null && exp.toDate().getTime() <= nowMillis) {
                             continue;       // skip – TTL passed
                         }
-                        String fromUid = doc.getString("from");
-
-                        // optimistic placeholder
-                        inviteDescriptions.add("Invite from: ...");
-                        inviteIds.add(doc.getId());
-
-                        // async nickname lookup
-                        db.collection("users").document(Objects.requireNonNull(fromUid)).get()
-                                .addOnSuccessListener(userSnap -> {
-                                    String nick = userSnap.getString("nickname");
-                                    int idx = inviteIds.indexOf(doc.getId());
-                                    if (idx != -1 && nick != null) {
-                                        inviteDescriptions.set(idx, "Invite from: " + nick);
-                                        adapter.notifyDataSetChanged();
-                                    }
-                                });
+                        pendingInvites.add(doc);
                     }
 
-                    adapter.notifyDataSetChanged();
-                    if (inviteIds.isEmpty()) {
-                        emptyText.setVisibility(View.VISIBLE);
-                    } else {
-                        emptyText.setVisibility(View.GONE);
-                    }
+                    pendingAdapter.setData(pendingInvites);
+                    updatePendingInvitesEmptyState();
                 });
+    }
+
+    private void updatePendingInvitesEmptyState() {
+        if (emptyText == null || pendingAdapter == null) {
+            return;
+        }
+
+        if (pendingAdapter.getItemCount() == 0) {
+            emptyText.setVisibility(View.VISIBLE);
+        } else {
+            emptyText.setVisibility(View.GONE);
+        }
     }
 
     private void listenForPastInvites() {
@@ -361,6 +361,12 @@ public class InvitationsActivity extends BaseActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
+        if (pendingAdapter != null && pendingInvitesObserver != null) {
+            pendingAdapter.unregisterAdapterDataObserver(pendingInvitesObserver);
+        }
+        if (pendingAdapter != null) {
+            pendingAdapter.clearSubscriptions();
+        }
         if (pastAdapter != null && pastInvitesObserver != null) {
             pastAdapter.unregisterAdapterDataObserver(pastInvitesObserver);
         }

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/PendingInviteAdapter.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/PendingInviteAdapter.java
@@ -1,0 +1,292 @@
+package piotr_gorczynski.soccer2;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.DatabaseError;
+import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.FirebaseDatabase;
+import com.google.firebase.database.ValueEventListener;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class PendingInviteAdapter extends RecyclerView.Adapter<PendingInviteAdapter.VH> {
+
+    interface OnAcceptClick { void onAccept(@NonNull DocumentSnapshot doc); }
+
+    static class VH extends RecyclerView.ViewHolder {
+        final TextView inviteReceivedAndStatus;
+        final TextView nickname;
+        final TextView presence;
+        final Button acceptBtn;
+        DocumentSnapshot doc;
+        String uid;
+
+        VH(@NonNull View itemView) {
+            super(itemView);
+            inviteReceivedAndStatus = itemView.findViewById(R.id.inviteReceivedAndStatus);
+            nickname = itemView.findViewById(R.id.nickname);
+            presence = itemView.findViewById(R.id.presence);
+            acceptBtn = itemView.findViewById(R.id.acceptInviteBtn);
+        }
+    }
+
+    private final Context context;
+    private final OnAcceptClick acceptListener;
+    private final List<DocumentSnapshot> docs = new ArrayList<>();
+    private final Map<String, String> nickCache = new HashMap<>();
+    private final Map<String, String> presCache = new HashMap<>();
+    private final Map<String, Long> hbCache = new HashMap<>();
+    private final Map<String, Boolean> userDeletedCache = new HashMap<>();
+
+    private static final class RtdbSub {
+        final DatabaseReference ref;
+        final ValueEventListener listener;
+
+        RtdbSub(DatabaseReference ref, ValueEventListener listener) {
+            this.ref = ref;
+            this.listener = listener;
+        }
+    }
+
+    private final Map<String, RtdbSub> presSubs = new HashMap<>();
+
+    PendingInviteAdapter(@NonNull Context context, @NonNull OnAcceptClick acceptListener) {
+        this.context = context;
+        this.acceptListener = acceptListener;
+        setHasStableIds(true);
+    }
+
+    @NonNull
+    @Override
+    public VH onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_pending_invite, parent, false);
+        VH holder = new VH(view);
+        holder.acceptBtn.setOnClickListener(v -> {
+            DocumentSnapshot doc = holder.doc;
+            if (doc != null) {
+                acceptListener.onAccept(doc);
+            }
+        });
+        return holder;
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return docs.get(position).getId().hashCode() & 0xffffffffL;
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull VH holder, int position, @NonNull List<Object> payloads) {
+        if (payloads.isEmpty()) {
+            onBindViewHolder(holder, position);
+            return;
+        }
+
+        String uid = holder.uid;
+        if (uid == null) {
+            return;
+        }
+
+        for (Object payload : payloads) {
+            if ("nickname".equals(payload)) {
+                String nick = nickCache.get(uid);
+                if (nick != null) {
+                    holder.nickname.setText(context.getString(R.string.invite_from_format, nick));
+                }
+            } else if ("presence".equals(payload)) {
+                String state = presCache.get(uid);
+                if (state != null) {
+                    bindPresence(holder, uid, state);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull VH holder, int position) {
+        DocumentSnapshot snapshot = docs.get(position);
+        holder.doc = snapshot;
+
+        String uid = snapshot.getString("from");
+        holder.uid = uid;
+
+        if (uid == null) {
+            holder.inviteReceivedAndStatus.setText("");
+            holder.nickname.setText(context.getString(R.string.invite_from_loading));
+            holder.presence.setText("");
+            holder.acceptBtn.setEnabled(false);
+            return;
+        }
+
+        holder.acceptBtn.setEnabled(true);
+        holder.acceptBtn.setAlpha(1f);
+
+        com.google.firebase.Timestamp createdAt = snapshot.getTimestamp("createdAt");
+        String relativeTime = "";
+        if (createdAt != null) {
+            long createdAtMillis = createdAt.toDate().getTime();
+            relativeTime = MatchAdapter.englishRelative(createdAtMillis);
+        }
+
+        if (!relativeTime.isEmpty()) {
+            holder.inviteReceivedAndStatus.setText(context.getString(R.string.invite_received_format, relativeTime));
+        } else {
+            holder.inviteReceivedAndStatus.setText("");
+        }
+
+        String nick = nickCache.get(uid);
+        if (nick == null) {
+            holder.nickname.setText(context.getString(R.string.invite_from_loading));
+            FirebaseFirestore.getInstance().collection("users").document(uid).get()
+                    .addOnSuccessListener(doc -> {
+                        if (doc.exists()) {
+                            String n = doc.getString("nickname");
+                            if (n != null) {
+                                nickCache.put(uid, n);
+                                notifyUidChanged(uid, "nickname");
+                            }
+
+                            Boolean deleted = doc.getBoolean("deleted");
+                            userDeletedCache.put(uid, deleted != null && deleted);
+                            notifyUidChanged(uid, "presence");
+                        } else {
+                            userDeletedCache.put(uid, true);
+                            notifyUidChanged(uid, "presence");
+                        }
+                    });
+        } else {
+            holder.nickname.setText(context.getString(R.string.invite_from_format, nick));
+        }
+
+        String state = presCache.get(uid);
+        if (state == null) {
+            holder.presence.setText("…");
+            DatabaseReference ref = FirebaseDatabase.getInstance().getReference("status").child(uid);
+            ValueEventListener listener = new ValueEventListener() {
+                @Override
+                public void onDataChange(@NonNull DataSnapshot snapshot) {
+                    if (!snapshot.exists()) {
+                        presCache.put(uid, "offline");
+                        hbCache.put(uid, 0L);
+                        notifyUidChanged(uid, "presence");
+                        return;
+                    }
+
+                    String stateStr = snapshot.child("state").getValue(String.class);
+                    Long lastHeartbeatBox = snapshot.child("last_heartbeat").getValue(Long.class);
+                    long lastHeartbeat = lastHeartbeatBox != null ? lastHeartbeatBox : 0L;
+
+                    String resolvedState = "offline";
+                    if ("online".equals(stateStr)) {
+                        resolvedState = "online";
+                    } else if (lastHeartbeat > 0L) {
+                        resolvedState = "active";
+                    }
+
+                    presCache.put(uid, resolvedState);
+                    hbCache.put(uid, lastHeartbeat);
+                    notifyUidChanged(uid, "presence");
+                }
+
+                @Override
+                public void onCancelled(@NonNull DatabaseError error) {
+                }
+            };
+            ref.addValueEventListener(listener);
+            presSubs.put(uid, new RtdbSub(ref, listener));
+        } else {
+            bindPresence(holder, uid, state);
+        }
+    }
+
+    private void bindPresence(@NonNull VH holder, @NonNull String uid, @NonNull String state) {
+        String nick = nickCache.get(uid);
+        if (nick == null) {
+            nick = "User";
+        }
+
+        int colour;
+        String label;
+        switch (state) {
+            case "online":
+                label = context.getString(R.string.presence_user_online, nick);
+                colour = ContextCompat.getColor(holder.itemView.getContext(), R.color.colorGreenDark);
+                break;
+            case "active":
+                long last = hbCache.getOrDefault(uid, 0L);
+                label = context.getString(R.string.presence_user_last_seen, nick, MatchAdapter.englishRelative(last));
+                colour = ContextCompat.getColor(holder.itemView.getContext(), R.color.colorGreenDark);
+                break;
+            default:
+                label = context.getString(R.string.presence_user_offline, nick);
+                colour = ContextCompat.getColor(holder.itemView.getContext(), R.color.colorGrey);
+                break;
+        }
+
+        holder.presence.setText(label);
+        holder.presence.setTextColor(colour);
+
+        Boolean deleted = userDeletedCache.get(uid);
+        boolean userDeleted = deleted != null && deleted;
+        holder.acceptBtn.setEnabled(!userDeleted);
+        holder.acceptBtn.setAlpha(userDeleted ? 0.3f : 1f);
+    }
+
+    @Override
+    public int getItemCount() {
+        return docs.size();
+    }
+
+    void setData(@NonNull List<DocumentSnapshot> invitations) {
+        docs.clear();
+        docs.addAll(invitations);
+        notifyDataSetChanged();
+    }
+
+    void removeInvite(@NonNull String inviteId) {
+        for (int i = 0; i < docs.size(); i++) {
+            if (inviteId.equals(docs.get(i).getId())) {
+                docs.remove(i);
+                notifyItemRemoved(i);
+                break;
+            }
+        }
+    }
+
+    private void notifyUidChanged(@NonNull String uid, @NonNull Object payload) {
+        for (int i = 0; i < docs.size(); i++) {
+            String fromUid = docs.get(i).getString("from");
+            if (uid.equals(fromUid)) {
+                notifyItemChanged(i, payload);
+            }
+        }
+    }
+
+    void clearSubscriptions() {
+        for (RtdbSub sub : presSubs.values()) {
+            sub.ref.removeEventListener(sub.listener);
+        }
+        presSubs.clear();
+    }
+
+    @Override
+    public void onDetachedFromRecyclerView(@NonNull RecyclerView recyclerView) {
+        super.onDetachedFromRecyclerView(recyclerView);
+        clearSubscriptions();
+    }
+}

--- a/mobile/app/src/main/res/layout/activity_invitations.xml
+++ b/mobile/app/src/main/res/layout/activity_invitations.xml
@@ -43,11 +43,11 @@
                 android:visibility="gone"
                 android:layout_marginBottom="16dp"/>
 
-            <ListView
+            <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/invitesList"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:nestedScrollingEnabled="true" />
+                android:nestedScrollingEnabled="false" />
 
             <TextView
                 android:id="@+id/pastInvitesLabel"

--- a/mobile/app/src/main/res/layout/item_pending_invite.xml
+++ b/mobile/app/src/main/res/layout/item_pending_invite.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/nickname"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:textSize="16sp" />
+
+    <TextView
+        android:id="@+id/inviteReceivedAndStatus"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="12sp"
+        android:textColor="@color/colorGrey"
+        android:layout_marginBottom="4dp" />
+
+    <TextView
+        android:id="@+id/presence"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="12sp"
+        android:textColor="@color/colorGrey" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginTop="8dp">
+
+        <Button
+            android:id="@+id/acceptInviteBtn"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:paddingStart="8dp"
+            android:paddingEnd="8dp"
+            android:text="@string/accept" />
+    </LinearLayout>
+</LinearLayout>


### PR DESCRIPTION
## Summary
- replace the pending invites ListView with a RecyclerView that reuses the past invite styling while exposing an Accept button
- introduce a PendingInviteAdapter and matching layout so pending invites share presence and nickname data binding with past invites

## Testing
- ./mobile/gradlew -p mobile app:assembleDebug *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ed50e0fa9883308a4c00b6aae0ac02