### PR TITLE
Refine pending invitations UI

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
@@ -4,13 +4,11 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.*;
+import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -35,11 +33,10 @@ import android.content.SharedPreferences;
 
 public class InvitationsActivity extends BaseActivity {
 
-    ListView invitesList;
+    RecyclerView invitesList;
     TextView emptyText;
-    ArrayAdapter<String> adapter;
-    final ArrayList<String> inviteDescriptions = new ArrayList<>();
-    final ArrayList<String> inviteIds = new ArrayList<>();
+    PendingInviteAdapter pendingAdapter;
+    RecyclerView.AdapterDataObserver pendingInvitesObserver;
 
     RecyclerView pastInvitesList;
     TextView pastInvitesLabel;
@@ -72,8 +69,26 @@ public class InvitationsActivity extends BaseActivity {
 
         invitesList = findViewById(R.id.invitesList);
         emptyText = findViewById(R.id.emptyInvites);
-        adapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, inviteDescriptions);
-        invitesList.setAdapter(adapter);
+        invitesList.setLayoutManager(new LinearLayoutManager(this));
+        pendingAdapter = new PendingInviteAdapter(this, this::acceptInvite);
+        invitesList.setAdapter(pendingAdapter);
+        pendingInvitesObserver = new RecyclerView.AdapterDataObserver() {
+            @Override
+            public void onChanged() {
+                updatePendingInvitesEmptyState();
+            }
+
+            @Override
+            public void onItemRangeInserted(int positionStart, int itemCount) {
+                updatePendingInvitesEmptyState();
+            }
+
+            @Override
+            public void onItemRangeRemoved(int positionStart, int itemCount) {
+                updatePendingInvitesEmptyState();
+            }
+        };
+        pendingAdapter.registerAdapterDataObserver(pendingInvitesObserver);
 
         pastInvitesList = findViewById(R.id.pastInvitesList);
         pastInvitesLabel = findViewById(R.id.pastInvitesLabel);
@@ -106,17 +121,6 @@ public class InvitationsActivity extends BaseActivity {
         listenForInvites();
         listenForPastInvites();
         loadFriends();
-
-        invitesList.setOnItemClickListener((parent, view, position, id) -> {
-            String inviteId = inviteIds.get(position);
-
-            new AlertDialog.Builder(this)
-                    .setTitle(R.string.accept_invitation_title)
-                    .setMessage(R.string.accept_invitation_message)
-                    .setPositiveButton(R.string.accept, (dialog, which) -> acceptInvite(inviteId))
-                    .setNegativeButton(R.string.cancel, null)
-                    .show();
-        });
 
     }
 
@@ -208,11 +212,9 @@ public class InvitationsActivity extends BaseActivity {
                                 Toast.makeText(this, userMsg, Toast.LENGTH_LONG).show();
 
                                 /* ⬇️  remove the stale item locally so the list refreshes */
-                                int idx = inviteIds.indexOf(invitationId);
-                                if (idx != -1) {
-                                    inviteIds.remove(idx);
-                                    inviteDescriptions.remove(idx);
-                                    refreshPendingInvitesView();
+                                if (pendingAdapter != null) {
+                                    pendingAdapter.removeInviteById(invitationId);
+                                    updatePendingInvitesEmptyState();
                                 }
                             });
 
@@ -237,17 +239,17 @@ public class InvitationsActivity extends BaseActivity {
                 .orderBy("expireAt")                // ← added
                 .addSnapshotListener((querySnapshot, e) -> {
                     if (e != null) {
-                        inviteDescriptions.clear();
-                        inviteIds.clear();
-                        refreshPendingInvitesView();
+                        if (pendingAdapter != null) {
+                            pendingAdapter.clear();
+                        }
                         emptyText.setVisibility(View.VISIBLE);
+                        updatePendingInvitesEmptyState();
                         Log.e("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName()
                                 + ": Listen failed", e);
                         return;
                     }
 
-                    inviteDescriptions.clear();
-                    inviteIds.clear();
+                    List<DocumentSnapshot> pendingInvites = new ArrayList<>();
 
                     long nowMillis = System.currentTimeMillis();      // 🕔 current client time
                     for (DocumentSnapshot doc : Objects.requireNonNull(querySnapshot)) {
@@ -258,71 +260,36 @@ public class InvitationsActivity extends BaseActivity {
                         if (exp != null && exp.toDate().getTime() <= nowMillis) {
                             continue;       // skip – TTL passed
                         }
-                        String fromUid = doc.getString("from");
-
-                        // optimistic placeholder
-                        inviteDescriptions.add("Invite from: ...");
-                        inviteIds.add(doc.getId());
-
-                        // async nickname lookup
-                        db.collection("users").document(Objects.requireNonNull(fromUid)).get()
-                                .addOnSuccessListener(userSnap -> {
-                                    String nick = userSnap.getString("nickname");
-                                    int idx = inviteIds.indexOf(doc.getId());
-                                    if (idx != -1 && nick != null) {
-                                        inviteDescriptions.set(idx, "Invite from: " + nick);
-                                        adapter.notifyDataSetChanged();
-                                    }
-                                });
+                        pendingInvites.add(doc);
                     }
 
-                    refreshPendingInvitesView();
+                    if (pendingAdapter != null) {
+                        pendingInvites.sort((left, right) -> {
+                            Timestamp leftCreatedAt = left.getTimestamp("createdAt");
+                            Timestamp rightCreatedAt = right.getTimestamp("createdAt");
+
+                            long leftMillis = leftCreatedAt != null ? leftCreatedAt.toDate().getTime() : Long.MAX_VALUE;
+                            long rightMillis = rightCreatedAt != null ? rightCreatedAt.toDate().getTime() : Long.MAX_VALUE;
+
+                            return Long.compare(leftMillis, rightMillis);
+                        });
+                        pendingAdapter.setData(pendingInvites);
+                    }
+
+                    updatePendingInvitesEmptyState();
                 });
     }
 
-    private void refreshPendingInvitesView() {
-        if (adapter == null || invitesList == null) {
+    private void updatePendingInvitesEmptyState() {
+        if (emptyText == null || pendingAdapter == null) {
             return;
         }
 
-        adapter.notifyDataSetChanged();
-
-        invitesList.post(this::updatePendingInvitesHeight);
-
-        if (inviteIds.isEmpty()) {
+        if (pendingAdapter.getItemCount() == 0) {
             emptyText.setVisibility(View.VISIBLE);
         } else {
             emptyText.setVisibility(View.GONE);
         }
-    }
-
-    private void updatePendingInvitesHeight() {
-        if (invitesList == null) {
-            return;
-        }
-
-        ListAdapter listAdapter = invitesList.getAdapter();
-        if (listAdapter == null) {
-            return;
-        }
-
-        int totalHeight = 0;
-        int listWidth = invitesList.getWidth();
-        if (listWidth <= 0) {
-            listWidth = invitesList.getResources().getDisplayMetrics().widthPixels;
-        }
-        int widthMeasureSpec = View.MeasureSpec.makeMeasureSpec(listWidth, View.MeasureSpec.AT_MOST);
-
-        for (int i = 0; i < listAdapter.getCount(); i++) {
-            View listItem = listAdapter.getView(i, null, invitesList);
-            listItem.measure(widthMeasureSpec, View.MeasureSpec.UNSPECIFIED);
-            totalHeight += listItem.getMeasuredHeight();
-        }
-
-        ViewGroup.LayoutParams params = invitesList.getLayoutParams();
-        params.height = totalHeight + invitesList.getDividerHeight() * Math.max(0, listAdapter.getCount() - 1);
-        invitesList.setLayoutParams(params);
-        invitesList.requestLayout();
     }
 
     private void listenForPastInvites() {
@@ -399,6 +366,12 @@ public class InvitationsActivity extends BaseActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
+        if (pendingAdapter != null && pendingInvitesObserver != null) {
+            pendingAdapter.unregisterAdapterDataObserver(pendingInvitesObserver);
+        }
+        if (pendingAdapter != null) {
+            pendingAdapter.removePresenceSubscriptions();
+        }
         if (pastAdapter != null && pastInvitesObserver != null) {
             pastAdapter.unregisterAdapterDataObserver(pastInvitesObserver);
         }

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/PendingInviteAdapter.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/PendingInviteAdapter.java
@@ -1,0 +1,303 @@
+package piotr_gorczynski.soccer2;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.DatabaseError;
+import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.FirebaseDatabase;
+import com.google.firebase.database.ValueEventListener;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class PendingInviteAdapter extends RecyclerView.Adapter<PendingInviteAdapter.VH> {
+
+    interface OnAcceptClick { void onAccept(@NonNull String inviteId); }
+
+    static class VH extends RecyclerView.ViewHolder {
+        final TextView inviteReceived;
+        final TextView nickname;
+        final TextView presence;
+        final Button acceptBtn;
+        DocumentSnapshot doc;
+        String uid;
+
+        VH(@NonNull View v) {
+            super(v);
+            nickname = v.findViewById(R.id.nickname);
+            inviteReceived = v.findViewById(R.id.inviteReceivedAndStatus);
+            presence = v.findViewById(R.id.presence);
+            acceptBtn = v.findViewById(R.id.acceptInviteBtn);
+        }
+    }
+
+    private final Context context;
+    private final OnAcceptClick acceptListener;
+    private final List<DocumentSnapshot> docs = new ArrayList<>();
+    private final Map<String, String> nickCache = new HashMap<>();
+    private final Map<String, String> presCache = new HashMap<>();
+    private final Map<String, Long> hbCache = new HashMap<>();
+    private final Map<String, Boolean> userDeletedCache = new HashMap<>();
+
+    private static final class RtdbSub {
+        final DatabaseReference ref;
+        final ValueEventListener listener;
+        RtdbSub(DatabaseReference ref, ValueEventListener listener) {
+            this.ref = ref;
+            this.listener = listener;
+        }
+    }
+
+    private final Map<String, RtdbSub> presSubs = new HashMap<>();
+
+    PendingInviteAdapter(@NonNull Context context, @NonNull OnAcceptClick acceptListener) {
+        this.context = context;
+        this.acceptListener = acceptListener;
+        setHasStableIds(true);
+    }
+
+    @NonNull
+    @Override
+    public VH onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View v = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_pending_invite, parent, false);
+        VH holder = new VH(v);
+        holder.acceptBtn.setOnClickListener(btn -> {
+            DocumentSnapshot doc = holder.doc;
+            if (doc == null) {
+                return;
+            }
+            String id = doc.getId();
+            if (id != null) {
+                acceptListener.onAccept(id);
+            }
+        });
+        return holder;
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return docs.get(position).getId().hashCode() & 0xffffffffL;
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull VH holder, int position, @NonNull List<Object> payloads) {
+        if (payloads.isEmpty()) {
+            onBindViewHolder(holder, position);
+            return;
+        }
+        String uid = holder.uid;
+        if (uid == null) {
+            return;
+        }
+        for (Object payload : payloads) {
+            if ("nickname".equals(payload)) {
+                String nick = nickCache.get(uid);
+                if (nick != null) {
+                    holder.nickname.setText(context.getString(R.string.invite_from_format, nick));
+                }
+            } else if ("presence".equals(payload)) {
+                String state = presCache.get(uid);
+                if (state != null) {
+                    bindPresence(holder, uid, state);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull VH holder, int position) {
+        DocumentSnapshot snapshot = docs.get(position);
+        holder.doc = snapshot;
+
+        String uid = snapshot.getString("from");
+        holder.uid = uid;
+
+        com.google.firebase.Timestamp createdAt = snapshot.getTimestamp("createdAt");
+        if (createdAt != null) {
+            holder.inviteReceived.setText(context.getString(
+                    R.string.invite_received_format,
+                    MatchAdapter.englishRelative(createdAt.toDate().getTime())));
+        } else {
+            holder.inviteReceived.setText("");
+        }
+
+        if (uid == null) {
+            holder.nickname.setText(context.getString(R.string.invite_from_loading));
+            holder.presence.setText("");
+            holder.acceptBtn.setEnabled(false);
+            return;
+        }
+
+        String cachedNick = nickCache.get(uid);
+        if (cachedNick == null) {
+            holder.nickname.setText(context.getString(R.string.invite_from_loading));
+            FirebaseFirestore.getInstance().collection("users").document(uid).get()
+                    .addOnSuccessListener(doc -> {
+                        if (doc.exists()) {
+                            String n = doc.getString("nickname");
+                            if (n != null) {
+                                nickCache.put(uid, n);
+                                notifyUidChanged(uid, "nickname");
+                            }
+                            Boolean deleted = doc.getBoolean("deleted");
+                            userDeletedCache.put(uid, deleted != null && deleted);
+                            notifyUidChanged(uid, "presence");
+                        } else {
+                            userDeletedCache.put(uid, true);
+                            notifyUidChanged(uid, "presence");
+                        }
+                    });
+        } else {
+            holder.nickname.setText(context.getString(R.string.invite_from_format, cachedNick));
+        }
+
+        String presenceState = presCache.get(uid);
+        if (presenceState == null) {
+            holder.presence.setText("…");
+            DatabaseReference ref = FirebaseDatabase.getInstance().getReference("status").child(uid);
+            ValueEventListener listener = new ValueEventListener() {
+                @Override
+                public void onDataChange(@NonNull DataSnapshot snap) {
+                    if (!snap.exists()) {
+                        presCache.put(uid, "offline");
+                        hbCache.put(uid, 0L);
+                        notifyUidChanged(uid, "presence");
+                        return;
+                    }
+                    String stateStr = snap.child("state").getValue(String.class);
+                    Long lastHbBox = snap.child("last_heartbeat").getValue(Long.class);
+                    long lastHb = lastHbBox != null ? lastHbBox : 0L;
+                    String state = "offline";
+                    if ("online".equals(stateStr)) {
+                        state = "online";
+                    } else if (lastHb > 0L) {
+                        state = "active";
+                    }
+                    presCache.put(uid, state);
+                    hbCache.put(uid, lastHb);
+                    notifyUidChanged(uid, "presence");
+                }
+
+                @Override
+                public void onCancelled(@NonNull DatabaseError error) { }
+            };
+            ref.addValueEventListener(listener);
+            presSubs.put(uid, new RtdbSub(ref, listener));
+        } else {
+            bindPresence(holder, uid, presenceState);
+        }
+
+        holder.acceptBtn.setEnabled(true);
+    }
+
+    private void bindPresence(@NonNull VH holder, @NonNull String uid, @NonNull String state) {
+        String username = nickCache.get(uid);
+        if (username == null) {
+            username = "User";
+        }
+
+        String label;
+        int colour;
+        switch (state) {
+            case "online":
+                label = context.getString(R.string.presence_user_online, username);
+                colour = ContextCompat.getColor(holder.itemView.getContext(), R.color.colorGreenDark);
+                break;
+            case "active":
+                long last = hbCache.getOrDefault(uid, 0L);
+                label = context.getString(R.string.presence_user_last_seen, username, MatchAdapter.englishRelative(last));
+                colour = ContextCompat.getColor(holder.itemView.getContext(), R.color.colorGreenDark);
+                break;
+            default:
+                label = context.getString(R.string.presence_user_offline, username);
+                colour = ContextCompat.getColor(holder.itemView.getContext(), R.color.colorGrey);
+                break;
+        }
+
+        holder.presence.setText(label);
+        holder.presence.setTextColor(colour);
+
+        Boolean isDeleted = userDeletedCache.get(uid);
+        boolean userDeleted = isDeleted != null && isDeleted;
+        boolean enabled = !userDeleted;
+        holder.acceptBtn.setEnabled(enabled);
+        holder.acceptBtn.setAlpha(enabled ? 1f : 0.3f);
+    }
+
+    @Override
+    public int getItemCount() {
+        return docs.size();
+    }
+
+    private void notifyUidChanged(@NonNull String uid, @NonNull Object payload) {
+        for (int i = 0; i < docs.size(); i++) {
+            String fromUid = docs.get(i).getString("from");
+            if (uid.equals(fromUid)) {
+                notifyItemChanged(i, payload);
+            }
+        }
+    }
+
+    void setData(@NonNull List<DocumentSnapshot> invites) {
+        removePresenceSubscriptions();
+        docs.clear();
+        docs.addAll(invites);
+        notifyDataSetChanged();
+    }
+
+    void clear() {
+        removePresenceSubscriptions();
+        docs.clear();
+        notifyDataSetChanged();
+    }
+
+    void removeInviteById(@NonNull String inviteId) {
+        for (int i = 0; i < docs.size(); i++) {
+            DocumentSnapshot snapshot = docs.get(i);
+            if (!inviteId.equals(snapshot.getId())) {
+                continue;
+            }
+            docs.remove(i);
+            notifyItemRemoved(i);
+            String uid = snapshot.getString("from");
+            if (uid != null) {
+                RtdbSub sub = presSubs.remove(uid);
+                if (sub != null) {
+                    sub.ref.removeEventListener(sub.listener);
+                }
+                nickCache.remove(uid);
+                presCache.remove(uid);
+                hbCache.remove(uid);
+                userDeletedCache.remove(uid);
+            }
+            break;
+        }
+    }
+
+    @Override
+    public void onDetachedFromRecyclerView(@NonNull RecyclerView recyclerView) {
+        super.onDetachedFromRecyclerView(recyclerView);
+        removePresenceSubscriptions();
+    }
+
+    void removePresenceSubscriptions() {
+        for (RtdbSub sub : presSubs.values()) {
+            sub.ref.removeEventListener(sub.listener);
+        }
+        presSubs.clear();
+    }
+}

--- a/mobile/app/src/main/res/layout/activity_invitations.xml
+++ b/mobile/app/src/main/res/layout/activity_invitations.xml
@@ -43,11 +43,11 @@
                 android:visibility="gone"
                 android:layout_marginBottom="16dp"/>
 
-            <ListView
+            <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/invitesList"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:nestedScrollingEnabled="true" />
+                android:nestedScrollingEnabled="false" />
 
             <TextView
                 android:id="@+id/pastInvitesLabel"

--- a/mobile/app/src/main/res/layout/item_pending_invite.xml
+++ b/mobile/app/src/main/res/layout/item_pending_invite.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/nickname"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:textSize="16sp" />
+
+    <TextView
+        android:id="@+id/inviteReceivedAndStatus"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="12sp"
+        android:textColor="@color/colorGrey"
+        android:layout_marginBottom="4dp" />
+
+    <TextView
+        android:id="@+id/presence"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="12sp"
+        android:textColor="@color/colorGrey" />
+
+    <Button
+        android:id="@+id/acceptInviteBtn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
+        android:text="@string/accept" />
+</LinearLayout>


### PR DESCRIPTION
## Summary
- replace the pending invitations ListView with a RecyclerView that mirrors the past invites presentation and keeps the empty state in sync
- add a dedicated PendingInviteAdapter and item layout with an Accept button that calls the existing acceptance flow while cleaning up presence listeners

## Testing
- :app:assembleDebug *(fails: Android SDK is not available in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed5af68b74833081479ae15eb51997