### PR TITLE
Fix missing View import in InvitationsActivity

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
+import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
 


### PR DESCRIPTION
## Summary
- add the missing `android.view.View` import in `InvitationsActivity` so references to `View.VISIBLE` and `View.GONE` compile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ed65183b1c8330bfefe05a9d572dd0