### PR TITLE
Avoid duplicate missed invite notifications after viewing invites

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
@@ -59,6 +59,14 @@ public class InvitationsActivity extends BaseActivity {
     }
 
     @Override
+    protected void onResume() {
+        super.onResume();
+
+        SharedPreferences prefs = getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE);
+        prefs.edit().putLong(MenuActivity.PREF_LAST_INVITES_SEEN_TIMESTAMP, System.currentTimeMillis()).apply();
+    }
+
+    @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_invitations);

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -71,6 +71,7 @@ public class MenuActivity extends BaseActivity {
     private static final int NOTIFICATION_PERMISSION_REQUEST_CODE = 101;
 
     private static final String PREF_FCM_TOKEN = "fcmToken";
+    static final String PREF_LAST_INVITES_SEEN_TIMESTAMP = "lastInvitesSeenTimestamp";
     private static final String PREF_LAST_ACTIVE_TIMESTAMP = "lastActiveTimestamp";
 
     private boolean isBackendAvailable = true; // Track backend availability
@@ -1387,6 +1388,7 @@ public class MenuActivity extends BaseActivity {
 
         SharedPreferences prefs = getSharedPreferences(LanguageManager.PREFS_FILE, MODE_PRIVATE);
         long lastActiveTimestamp = prefs.getLong(PREF_LAST_ACTIVE_TIMESTAMP, 0L);
+        final long lastInvitesSeenTimestamp = prefs.getLong(PREF_LAST_INVITES_SEEN_TIMESTAMP, 0L);
         
         // Update timestamp for next check
         updateLastActiveTimestamp();
@@ -1456,6 +1458,15 @@ public class MenuActivity extends BaseActivity {
 
                     if (recentInvite == null) {
                         Log.d("TAG_Soccer", getClass().getSimpleName() + ".checkForMissedInvitations: No new invites after filtering");
+                        return;
+                    }
+
+                    if (mostRecentCreatedAt <= lastInvitesSeenTimestamp) {
+                        Log.d(
+                                "TAG_Soccer",
+                                getClass().getSimpleName()
+                                        + ".checkForMissedInvitations: Latest invite already viewed in InvitationsActivity; skipping dialog"
+                        );
                         return;
                     }
 


### PR DESCRIPTION
## Summary
- record when InvitationsActivity is resumed so the app knows the user has reviewed invites
- skip the missed invite dialog on MenuActivity resume when the newest invite was already viewed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ee3708ceac83308dc433f4199eb233