### PR TITLE
Add menu loading message translations

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -12,6 +12,7 @@ import android.view.MenuItem;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.SystemClock;
 import android.util.Log;
 import android.view.View;
 import android.content.SharedPreferences;
@@ -86,6 +87,11 @@ public class MenuActivity extends BaseActivity {
     private final Handler adRetryHandler = new Handler(Looper.getMainLooper());
     private final Runnable adRetryRunnable = this::loadInterstitialAd;
     private boolean isAdLoading = false;
+    private View loadingOverlay;
+    private final Handler overlayHandler = new Handler(Looper.getMainLooper());
+    private final Runnable hideOverlayRunnable = this::hideLoadingOverlayImmediate;
+    private long loadingOverlayShownAtMs = 0L;
+    private static final long MIN_LOADING_OVERLAY_DURATION_MS = 250L;
 
     /**
      * Helper to fetch user details from Firestore and update prefs/UI. This is
@@ -620,8 +626,15 @@ public class MenuActivity extends BaseActivity {
                 return;
             }
         }
-        
+
         currentLanguage = LanguageManager.getCurrentLanguageCode(this);
+
+        loadingOverlay = findViewById(R.id.menu_loading_overlay);
+        if (loadingOverlay != null) {
+            loadingOverlay.setOnClickListener(v -> {
+                // consume clicks while loading to avoid double taps
+            });
+        }
 
         // Setup toolbar with defensive error handling
         try {
@@ -740,6 +753,48 @@ public class MenuActivity extends BaseActivity {
                 .show();
     }
 
+    private void showLoadingOverlay() {
+        if (loadingOverlay == null) {
+            return;
+        }
+        overlayHandler.removeCallbacks(hideOverlayRunnable);
+        loadingOverlayShownAtMs = SystemClock.elapsedRealtime();
+        if (loadingOverlay.getVisibility() != View.VISIBLE) {
+            loadingOverlay.setAlpha(0f);
+            loadingOverlay.setVisibility(View.VISIBLE);
+            loadingOverlay.animate().alpha(1f).setDuration(150L).start();
+        } else {
+            loadingOverlay.animate().cancel();
+            loadingOverlay.setAlpha(1f);
+        }
+    }
+
+    private void hideLoadingOverlayWithMinimumDuration() {
+        if (loadingOverlay == null) {
+            return;
+        }
+        long elapsed = SystemClock.elapsedRealtime() - loadingOverlayShownAtMs;
+        long delay = Math.max(0L, MIN_LOADING_OVERLAY_DURATION_MS - elapsed);
+        overlayHandler.removeCallbacks(hideOverlayRunnable);
+        overlayHandler.postDelayed(hideOverlayRunnable, delay);
+    }
+
+    private void hideLoadingOverlayImmediate() {
+        if (loadingOverlay == null) {
+            return;
+        }
+        if (loadingOverlay.getVisibility() != View.VISIBLE) {
+            return;
+        }
+        loadingOverlay.animate().cancel();
+        loadingOverlay.animate().alpha(0f).setDuration(150L).withEndAction(() -> {
+            if (loadingOverlay != null) {
+                loadingOverlay.setVisibility(View.GONE);
+                loadingOverlay.setAlpha(1f);
+            }
+        }).start();
+    }
+
     private void showRegistrationDialog() {
         new AlertDialog.Builder(this)
                 .setMessage(R.string.register_dialog_message)
@@ -757,11 +812,20 @@ public class MenuActivity extends BaseActivity {
     }
 
     private void showAdThenRun(Runnable action) {
+        showLoadingOverlay();
+        Runnable guardedAction = () -> {
+            try {
+                action.run();
+            } finally {
+                hideLoadingOverlayWithMinimumDuration();
+            }
+        };
+
         // Check consent before proceeding with ads logic
         if (!hasAdsConsent()) {
             Log.w("TAG_Soccer", getClass().getSimpleName() + ".showAdThenRun: No ads consent, running action directly");
             showConsentRequiredDialog();
-            action.run();
+            guardedAction.run();
             return;
         }
 
@@ -817,12 +881,12 @@ public class MenuActivity extends BaseActivity {
                                 e
                         );
                     })
-                    .addOnCompleteListener(task -> processAdLogic(action, prefs, resolvedFrequency[0]));
+                    .addOnCompleteListener(task -> processAdLogic(guardedAction, prefs, resolvedFrequency[0]));
         } else {
             // For unauthorized users, use FAILSAFE_AD_FREQUENCY directly
             resolvedFrequency[0] = FAILSAFE_AD_FREQUENCY;
             Log.d("TAG_Soccer", getClass().getSimpleName() + ".showAdThenRun: unauthorized user, using failsafe frequency=" + FAILSAFE_AD_FREQUENCY);
-            processAdLogic(action, prefs, resolvedFrequency[0]);
+            processAdLogic(guardedAction, prefs, resolvedFrequency[0]);
         }
     }
 
@@ -1109,6 +1173,7 @@ public class MenuActivity extends BaseActivity {
     protected void onDestroy() {
         super.onDestroy();
         adRetryHandler.removeCallbacks(adRetryRunnable);
+        overlayHandler.removeCallbacks(hideOverlayRunnable);
     }
 
     /**

--- a/mobile/app/src/main/res/drawable/loading_overlay_background.xml
+++ b/mobile/app/src/main/res/drawable/loading_overlay_background.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/colorGreenDark" />
+    <corners android:radius="12dp" />
+    <padding
+        android:left="16dp"
+        android:top="12dp"
+        android:right="16dp"
+        android:bottom="12dp" />
+    <size android:minWidth="120dp" android:minHeight="48dp" />
+</shape>

--- a/mobile/app/src/main/res/layout/activity_menu.xml
+++ b/mobile/app/src/main/res/layout/activity_menu.xml
@@ -1,27 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/colorWhite"
-    android:orientation="vertical"
-    android:gravity="center_horizontal">
+    android:background="@color/colorWhite">
 
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/menu_toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-        android:title="@string/app_name"
-        app:titleTextColor="@android:color/white" />
     <LinearLayout
-        android:id="@+id/menu_center_container"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
+        android:layout_height="match_parent"
         android:orientation="vertical"
-        android:gravity="center">
+        android:gravity="center_horizontal">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/menu_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+            android:title="@string/app_name"
+            app:titleTextColor="@android:color/white" />
+
+        <LinearLayout
+            android:id="@+id/menu_center_container"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:gravity="center">
 
     <TextView
         android:id="@+id/nicknameLabel"
@@ -104,5 +109,42 @@
         android:textColor="@color/colorWhite"
         android:textStyle="bold" />
 
+        </LinearLayout>
     </LinearLayout>
-</LinearLayout>
+
+    <FrameLayout
+        android:id="@+id/menu_loading_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/colorDimOverlay"
+        android:clickable="true"
+        android:focusable="true"
+        android:visibility="gone">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:background="@drawable/loading_overlay_background"
+            android:orientation="horizontal"
+            android:padding="24dp"
+            android:gravity="center_vertical">
+
+            <ProgressBar
+                style="@android:style/Widget.ProgressBar.Small"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:indeterminate="true" />
+
+            <TextView
+                android:id="@+id/menu_loading_message"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/menu_loading_message"
+                android:textColor="@color/colorWhite"
+                android:textStyle="bold" />
+        </LinearLayout>
+    </FrameLayout>
+
+</FrameLayout>

--- a/mobile/app/src/main/res/values-am/strings.xml
+++ b/mobile/app/src/main/res/values-am/strings.xml
@@ -316,6 +316,7 @@
     <string name="invite_status_cancelled">ሁኔታ: ተሰርዟል</string>
     <string name="invite_status_expired">ሁኔታ: ጊዜው አልፏል</string>
     <string name="invite_from_loading">በመጫን ላይ…</string>
+    <string name="menu_loading_message">በመጫን ላይ…</string>
     <string name="invite_from_format">ግብዣ ከ: %1$s</string>
     <string name="invite_received_and_status">ደርሷል: %1$s | %2$s</string>
     <string name="presence_online">መስመር ላይ</string>

--- a/mobile/app/src/main/res/values-ar/strings.xml
+++ b/mobile/app/src/main/res/values-ar/strings.xml
@@ -297,6 +297,7 @@
     <string name="invite_status_cancelled">الحالة: ملغاة</string>
     <string name="invite_status_expired">الحالة: منتهية الصلاحية</string>
     <string name="invite_from_loading">جارٍ التحميل…</string>
+    <string name="menu_loading_message">جارٍ التحميل…</string>
     <string name="invite_from_format">دعوة من: %1$s</string>
     <string name="invite_received_and_status">تم الاستلام: %1$s | %2$s</string>
     <string name="presence_online">متصل</string>

--- a/mobile/app/src/main/res/values-bn/strings.xml
+++ b/mobile/app/src/main/res/values-bn/strings.xml
@@ -343,6 +343,7 @@
     <string name="invite_status_cancelled">অবস্থা: বাতিল</string>
     <string name="invite_status_expired">অবস্থা: মেয়াদ শেষ</string>
     <string name="invite_from_loading">লোড হচ্ছে…</string>
+    <string name="menu_loading_message">লোড হচ্ছে…</string>
     <string name="invite_from_format">আমন্ত্রণ থেকে: %1$s</string>
     <string name="invite_received_and_status">প্রাপ্ত: %1$s | %2$s</string>
     <string name="presence_online">অনলাইন</string>

--- a/mobile/app/src/main/res/values-de/strings.xml
+++ b/mobile/app/src/main/res/values-de/strings.xml
@@ -344,6 +344,7 @@
     <string name="invite_status_cancelled">Status: Abgebrochen</string>
     <string name="invite_status_expired">Status: Abgelaufen</string>
     <string name="invite_from_loading">Lädt…</string>
+    <string name="menu_loading_message">Lädt…</string>
     <string name="invite_from_format">Einladung von: %1$s</string>
     <string name="invite_received_and_status">Erhalten: %1$s | %2$s</string>
     <string name="presence_online">Online</string>

--- a/mobile/app/src/main/res/values-es/strings.xml
+++ b/mobile/app/src/main/res/values-es/strings.xml
@@ -350,6 +350,7 @@
     <string name="invite_status_cancelled">Estado: Cancelado</string>
     <string name="invite_status_expired">Estado: Expirado</string>
     <string name="invite_from_loading">Cargando…</string>
+    <string name="menu_loading_message">Cargando…</string>
     <string name="invite_from_format">Invitación de: %1$s</string>
     <string name="invite_received_and_status">Recibido: %1$s | %2$s</string>
     <string name="presence_online">En línea</string>

--- a/mobile/app/src/main/res/values-fa/strings.xml
+++ b/mobile/app/src/main/res/values-fa/strings.xml
@@ -296,6 +296,7 @@
     <string name="invite_status_cancelled">وضعیت: لغو شده</string>
     <string name="invite_status_expired">وضعیت: منقضی شده</string>
     <string name="invite_from_loading">در حال بارگذاری…</string>
+    <string name="menu_loading_message">در حال بارگذاری…</string>
     <string name="invite_from_format">دعوت از: %1$s</string>
     <string name="invite_received_and_status">دریافت شد: %1$s | %2$s</string>
     <string name="presence_online">آنلاین</string>

--- a/mobile/app/src/main/res/values-fr/strings.xml
+++ b/mobile/app/src/main/res/values-fr/strings.xml
@@ -344,6 +344,7 @@
     <string name="invite_status_cancelled">Statut: Annulé</string>
     <string name="invite_status_expired">Statut: Expiré</string>
     <string name="invite_from_loading">Chargement…</string>
+    <string name="menu_loading_message">Chargement…</string>
     <string name="invite_from_format">Invitation de: %1$s</string>
     <string name="invite_received_and_status">Reçu: %1$s | %2$s</string>
     <string name="presence_online">En ligne</string>

--- a/mobile/app/src/main/res/values-hi/strings.xml
+++ b/mobile/app/src/main/res/values-hi/strings.xml
@@ -349,6 +349,7 @@
     <string name="invite_status_cancelled">स्थिति: रद्द किया गया</string>
     <string name="invite_status_expired">स्थिति: समाप्त हो गया</string>
     <string name="invite_from_loading">लोड हो रहा है…</string>
+    <string name="menu_loading_message">लोड हो रहा है…</string>
     <string name="invite_from_format">आमंत्रण से: %1$s</string>
     <string name="invite_received_and_status">प्राप्त हुआ: %1$s | %2$s</string>
     <string name="presence_online">ऑनलाइन</string>

--- a/mobile/app/src/main/res/values-km/strings.xml
+++ b/mobile/app/src/main/res/values-km/strings.xml
@@ -316,6 +316,7 @@
     <string name="invite_status_cancelled">ស្ថានភាព: បានលុបចោល</string>
     <string name="invite_status_expired">ស្ថានភាព: ផុតកំណត់</string>
     <string name="invite_from_loading">កំពុងផ្ទុក…</string>
+    <string name="menu_loading_message">កំពុងផ្ទុក…</string>
     <string name="invite_from_format">ការអញ្ជើញពី: %1$s</string>
     <string name="invite_received_and_status">បានទទួល: %1$s | %2$s</string>
     <string name="presence_online">លើបណ្តាញ</string>

--- a/mobile/app/src/main/res/values-lo/strings.xml
+++ b/mobile/app/src/main/res/values-lo/strings.xml
@@ -315,6 +315,7 @@
     <string name="invite_status_cancelled">ສະຖານະ: ຍົກເລີກແລ້ວ</string>
     <string name="invite_status_expired">ສະຖານະ: ໝົດອາຍຸແລ້ວ</string>
     <string name="invite_from_loading">ກຳລັງໂຫລດ…</string>
+    <string name="menu_loading_message">ກຳລັງໂຫລດ…</string>
     <string name="invite_from_format">ເຊື້ອເຊີນຈາກ: %1$s</string>
     <string name="invite_received_and_status">ໄດ້ຮັບ: %1$s | %2$s</string>
     <string name="presence_online">ອອນໄລນ໌</string>

--- a/mobile/app/src/main/res/values-mg/strings.xml
+++ b/mobile/app/src/main/res/values-mg/strings.xml
@@ -316,6 +316,7 @@
     <string name="invite_status_cancelled">Toe-javatra: Nofoanana</string>
     <string name="invite_status_expired">Toe-javatra: Lany daty</string>
     <string name="invite_from_loading">Mampiditra…</string>
+    <string name="menu_loading_message">Mampiditra…</string>
     <string name="invite_from_format">Fanasana avy amin\'ny: %1$s</string>
     <string name="invite_received_and_status">Voaray: %1$s | %2$s</string>
     <string name="presence_online">An-tserasera</string>

--- a/mobile/app/src/main/res/values-mn/strings.xml
+++ b/mobile/app/src/main/res/values-mn/strings.xml
@@ -315,6 +315,7 @@
     <string name="invite_status_cancelled">Төлөв: Цуцалсан</string>
     <string name="invite_status_expired">Төлөв: Хугацаа дууссан</string>
     <string name="invite_from_loading">Ачааллаж байна…</string>
+    <string name="menu_loading_message">Ачааллаж байна…</string>
     <string name="invite_from_format">Урилга -аас: %1$s</string>
     <string name="invite_received_and_status">Хүлээн авсан: %1$s | %2$s</string>
     <string name="presence_online">Онлайн</string>

--- a/mobile/app/src/main/res/values-my/strings.xml
+++ b/mobile/app/src/main/res/values-my/strings.xml
@@ -315,6 +315,7 @@
     <string name="invite_status_cancelled">အခြေအနေ: ပယ်ဖျက်ပြီး</string>
     <string name="invite_status_expired">အခြေအနေ: သက်တမ်းကုန်ဆုံးပြီး</string>
     <string name="invite_from_loading">ဖွင့်နေသည်…</string>
+    <string name="menu_loading_message">ဖွင့်နေသည်…</string>
     <string name="invite_from_format">ဖိတ်ခေါ်သူ: %1$s</string>
     <string name="invite_received_and_status">လက်ခံရရှိသည်: %1$s | %2$s</string>
     <string name="presence_online">အွန်လိုင်း</string>

--- a/mobile/app/src/main/res/values-ne/strings.xml
+++ b/mobile/app/src/main/res/values-ne/strings.xml
@@ -349,6 +349,7 @@
     <string name="invite_status_cancelled">स्थिति: रद्द गरियो</string>
     <string name="invite_status_expired">स्थिति: म्याद सकियो</string>
     <string name="invite_from_loading">लोड गर्दै…</string>
+    <string name="menu_loading_message">लोड गर्दै…</string>
     <string name="invite_from_format">निमन्त्रणा: %1$s बाट</string>
     <string name="invite_received_and_status">प्राप्त भयो: %1$s | %2$s</string>
     <string name="presence_online">अनलाइन</string>

--- a/mobile/app/src/main/res/values-pl/strings.xml
+++ b/mobile/app/src/main/res/values-pl/strings.xml
@@ -344,6 +344,7 @@
     <string name="invite_status_cancelled">Status: Anulowane</string>
     <string name="invite_status_expired">Status: Wygasłe</string>
     <string name="invite_from_loading">Ładowanie…</string>
+    <string name="menu_loading_message">Ładowanie…</string>
     <string name="invite_from_format">Zaproszenie od: %1$s</string>
     <string name="invite_received_and_status">Otrzymano: %1$s | %2$s</string>
     <string name="presence_online">Online</string>

--- a/mobile/app/src/main/res/values-si/strings.xml
+++ b/mobile/app/src/main/res/values-si/strings.xml
@@ -315,6 +315,7 @@
     <string name="invite_status_cancelled">තත්ත්වය: අවලංගු කළා</string>
     <string name="invite_status_expired">තත්ත්වය: කල් ඉකුත් වී ඇත</string>
     <string name="invite_from_loading">පූරණය වෙමින්…</string>
+    <string name="menu_loading_message">පූරණය වෙමින්…</string>
     <string name="invite_from_format">ආරාධනාව: %1$s ගෙන්</string>
     <string name="invite_received_and_status">ලැබුණි: %1$s | %2$s</string>
     <string name="presence_online">සබැඳිව</string>

--- a/mobile/app/src/main/res/values-so/strings.xml
+++ b/mobile/app/src/main/res/values-so/strings.xml
@@ -316,6 +316,7 @@
     <string name="invite_status_cancelled">Xaalad: La joojiyay</string>
     <string name="invite_status_expired">Xaalad: Waqtigii dhammaaday</string>
     <string name="invite_from_loading">Waa la rarayo…</string>
+    <string name="menu_loading_message">Waa la rarayo…</string>
     <string name="invite_from_format">Casumo ka: %1$s</string>
     <string name="invite_received_and_status">La helay: %1$s | %2$s</string>
     <string name="presence_online">Khadka</string>

--- a/mobile/app/src/main/res/values-sw/strings.xml
+++ b/mobile/app/src/main/res/values-sw/strings.xml
@@ -315,6 +315,7 @@
     <string name="invite_status_cancelled">Hali: Imefutwa</string>
     <string name="invite_status_expired">Hali: Imeisha muda</string>
     <string name="invite_from_loading">Inapakia…</string>
+    <string name="menu_loading_message">Inapakia…</string>
     <string name="invite_from_format">Mwaliko kutoka: %1$s</string>
     <string name="invite_received_and_status">Imepokelewa: %1$s | %2$s</string>
     <string name="presence_online">Mtandaoni</string>

--- a/mobile/app/src/main/res/values-ur/strings.xml
+++ b/mobile/app/src/main/res/values-ur/strings.xml
@@ -343,6 +343,7 @@
     <string name="invite_status_cancelled">حیثیت: منسوخ شدہ</string>
     <string name="invite_status_expired">حیثیت: ختم شدہ</string>
     <string name="invite_from_loading">لوڈ ہو رہا ہے…</string>
+    <string name="menu_loading_message">لوڈ ہو رہا ہے…</string>
     <string name="invite_from_format">دعوت از: %1$s</string>
     <string name="invite_received_and_status">موصول ہوا: %1$s | %2$s</string>
     <string name="presence_online">آن لائن</string>

--- a/mobile/app/src/main/res/values/colors.xml
+++ b/mobile/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="colorPlayer0">#FF2D2D</color>
     <color name="colorPlayer1">#2D2DFF</color>
     <color name="colorGrey">#808080</color>   <!-- medium gray -->
+    <color name="colorDimOverlay">#CC000000</color>
 </resources>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -340,6 +340,7 @@
     <string name="invite_status_cancelled">Status: Cancelled</string>
     <string name="invite_status_expired">Status: Expired</string>
     <string name="invite_from_loading">Loading…</string>
+    <string name="menu_loading_message">Loading…</string>
     <string name="invite_from_format">Invite from: %1$s</string>
     <string name="invite_received_and_status">Received: %1$s | %2$s</string>
     <string name="presence_online">Online</string>


### PR DESCRIPTION
## Summary
- add the missing `menu_loading_message` string to every localized `strings.xml`
- reuse the existing "Loading…" phrasing from each locale's `invite_from_loading` entry for consistency

## Testing
- `./gradlew lint` *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee4e584d488330b648d7ceedf8cd8d