### PR TITLE
Refresh invite stats after returning from waiting screen

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FriendAdapter.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FriendAdapter.java
@@ -299,6 +299,14 @@ public class FriendAdapter extends RecyclerView.Adapter<FriendAdapter.VH> {
                 });
     }
 
+    void invalidateInviteStatsFor(@NonNull String uid) {
+        inviteStatsCache.remove(uid);
+        int idx = indexForUid(uid);
+        if (idx != RecyclerView.NO_POSITION) {
+            notifyItemChanged(idx);
+        }
+    }
+
     private void fetchMatchStats(@NonNull String targetUid, @NonNull VH h) {
         if (currentUserId == null) {
             h.matchStats.setText("");

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FriendsListActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FriendsListActivity.java
@@ -45,6 +45,8 @@ public class FriendsListActivity extends BaseActivity {
     private FirebaseFirestore db;
     private Spinner sortSpinner;
     private int currentSortMode = SORT_BY_LAST_SEEN;  // Default to sort by last seen
+    @Nullable
+    private String pendingInviteStatsRefreshUid;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -97,6 +99,16 @@ public class FriendsListActivity extends BaseActivity {
     protected void onStart() {
         super.onStart();
         loadFriends();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        if (pendingInviteStatsRefreshUid != null && adapter != null) {
+            adapter.invalidateInviteStatsFor(pendingInviteStatsRefreshUid);
+            pendingInviteStatsRefreshUid = null;
+        }
     }
 
     private void loadFriends() {
@@ -249,6 +261,7 @@ public class FriendsListActivity extends BaseActivity {
                     @SuppressWarnings("unchecked")
                     String inviteId = (String)((java.util.Map<String,Object>)java.util.Objects.requireNonNull(res.getData())).get("inviteId");
                     if (inviteId != null) {
+                        pendingInviteStatsRefreshUid = targetUid;
                         startActivity(new Intent(this, WaitingActivity.class).putExtra("inviteId", inviteId));
                     }
                 })


### PR DESCRIPTION
## Summary
- track the friend that received an invite so the friends list can refresh when the screen resumes
- invalidate cached invite statistics for the friend after returning from the waiting screen so the item updates

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68eea424ce688330afe8ef53050ffafa