### PR TITLE
Fix friend list sorting by last seen

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FriendAdapter.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FriendAdapter.java
@@ -8,6 +8,7 @@ import android.widget.Button;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.core.content.ContextCompat;
 
@@ -219,6 +220,11 @@ public class FriendAdapter extends RecyclerView.Adapter<FriendAdapter.VH> {
 
     private int indexForUid(@NonNull String uid) {
         for (int i=0;i<docs.size();i++) if (uid.equals(docs.get(i).getId())) return i; return -1;
+    }
+
+    @Nullable
+    Long getCachedHeartbeatFor(@NonNull String uid) {
+        return hbCache.get(uid);
     }
 
     void setData(List<DocumentSnapshot> friends) {

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FriendsListActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FriendsListActivity.java
@@ -192,8 +192,27 @@ public class FriendsListActivity extends BaseActivity {
                 .addOnSuccessListener(snapshot -> {
                     Map<String, Long> heartbeatMap = new HashMap<>();
                     for (String friendUid : friendUids) {
-                        Long lastHb = snapshot.child(friendUid).child("last_heartbeat").getValue(Long.class);
-                        heartbeatMap.put(friendUid, lastHb != null ? lastHb : 0L);
+                        Long lastHb = 0L;
+
+                        // Try to read the heartbeat as a generic number so we gracefully handle
+                        // any schema differences (Long vs Double) that may exist in existing data.
+                        Number hbNumber = snapshot.child(friendUid).child("last_heartbeat").getValue(Number.class);
+                        if (hbNumber != null) {
+                            lastHb = hbNumber.longValue();
+                        }
+
+                        // As a fallback, re-use the cached heartbeat value from the adapter if we
+                        // have already subscribed to presence updates for this friend.  This keeps
+                        // the sorting stable even when the status entry is temporarily missing in
+                        // the RTDB snapshot (for example right after a user goes offline).
+                        if (lastHb == 0L && adapter != null) {
+                            Long cachedHb = adapter.getCachedHeartbeatFor(friendUid);
+                            if (cachedHb != null) {
+                                lastHb = cachedHb;
+                            }
+                        }
+
+                        heartbeatMap.put(friendUid, lastHb);
                     }
 
                     Collections.sort(mutableDocs, new Comparator<DocumentSnapshot>() {


### PR DESCRIPTION
## Summary
- read realtime database heartbeat timestamps as generic numbers to avoid type mismatches
- fall back to cached heartbeat values so missing status entries do not break last seen ordering
- expose cached heartbeat access from the adapter for the sort routine

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f12899b0e48330bc9155bc3963c671