### PR TITLE
Use TAG_Soccer across mobile logging helpers

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/AnalyticsManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/AnalyticsManager.java
@@ -12,7 +12,7 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics;
  * Implements GA4 recommended events for auth and tournament funnels
  */
 public class AnalyticsManager {
-    private static final String TAG = "AnalyticsManager";
+    private static final String TAG = "TAG_Soccer";
     
     private FirebaseAnalytics firebaseAnalytics;
     private FirebaseCrashlytics crashlytics;

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/AnalyticsTestActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/AnalyticsTestActivity.java
@@ -11,7 +11,7 @@ import androidx.annotation.Nullable;
  * This demonstrates all the analytics features working together
  */
 public class AnalyticsTestActivity extends BaseActivity {
-    private static final String TAG = "AnalyticsTest";
+    private static final String TAG = "TAG_Soccer";
     
     private AnalyticsManager analyticsManager;
     private RemoteConfigHelper remoteConfigHelper;

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/AnonymousLinkPromptHelper.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/AnonymousLinkPromptHelper.java
@@ -12,7 +12,7 @@ import com.google.firebase.auth.FirebaseAuth;
  * Implements progressive prompting as suggested in the user research plan
  */
 public class AnonymousLinkPromptHelper {
-    private static final String TAG = "AnonymousLinkPrompt";
+    private static final String TAG = "TAG_Soccer";
     
     /**
      * Show prompt to anonymous user to save their progress by linking account

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/InAppMessagingHelper.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/InAppMessagingHelper.java
@@ -14,7 +14,7 @@ import com.google.firebase.auth.FirebaseAuth;
  * Implements targeted messaging as suggested in the user research plan
  */
 public class InAppMessagingHelper {
-    private static final String TAG = "InAppMessaging";
+    private static final String TAG = "TAG_Soccer";
     
     // SharedPreferences keys for tracking message display
     private static final String PREF_KEY_MESSAGES_SHOWN = "messages_shown_count";

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/LanguageManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/LanguageManager.java
@@ -22,7 +22,7 @@ public class LanguageManager {
     /** Preferences file name used across the entire app. */
     public static final String PREFS_FILE = "app_prefs";
 
-    private static final String TAG = "LanguageManager";
+    private static final String TAG = "TAG_Soccer";
     public static final String PREF_LANGUAGE_CODE = "language_code";
     
     // Language code to display name resource mapping

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RemoteConfigHelper.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RemoteConfigHelper.java
@@ -10,7 +10,7 @@ import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings;
  * Implements experimentation features suggested in the user research plan
  */
 public class RemoteConfigHelper {
-    private static final String TAG = "RemoteConfigHelper";
+    private static final String TAG = "TAG_Soccer";
     
     // Remote Config parameter keys
     public static final String SIGNUP_PROMPT_VARIANT = "signup_prompt_variant";

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SignupDeclineReasonDialog.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SignupDeclineReasonDialog.java
@@ -13,7 +13,7 @@ import androidx.appcompat.app.AlertDialog;
  * Implements one-tap research as suggested in the ChatGPT response
  */
 public class SignupDeclineReasonDialog {
-    private static final String TAG = "SignupDeclineDialog";
+    private static final String TAG = "TAG_Soccer";
     
     public interface OnReasonSelectedListener {
         void onReasonSelected(String reason);


### PR DESCRIPTION
## Summary
- update analytics and helper classes to log with the shared TAG_Soccer tag
- standardize dialog and language manager logging onto TAG_Soccer for consistency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3919edc70833093fa0210e8730eab