### PR TITLE
Fix running player sprite scaling

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -826,7 +826,9 @@ public class MenuActivity extends BaseActivity {
 
         Bitmap spriteSheet;
         try {
-            spriteSheet = BitmapFactory.decodeResource(getResources(), spriteSheetResId);
+            BitmapFactory.Options decodeOptions = new BitmapFactory.Options();
+            decodeOptions.inScaled = false;
+            spriteSheet = BitmapFactory.decodeResource(getResources(), spriteSheetResId, decodeOptions);
         } catch (Exception e) {
             Log.e(
                     "TAG_Soccer",


### PR DESCRIPTION
## Summary
- prevent the menu running-player spritesheet from being density-scaled when decoded so each frame width stays consistent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f93b1aea2483308aa3f7ba7e3a5a1b