### PR TITLE
Ensure invitations lists remeasure after initial load

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
@@ -321,8 +321,8 @@ public class InvitationsActivity extends BaseActivity {
                         for (DocumentSnapshot invite : pendingInvites) {
                             Log.d("TAG_Soccer", getClass().getSimpleName() + ".listenForInvites: Pending invite ID: " + invite.getId());
                         }
-                        
-                        pendingAdapter.setData(pendingInvites);
+
+                        pendingAdapter.setData(pendingInvites, invitesList);
                     }
 
                     // Log what's displayed in UI after initial load
@@ -474,7 +474,7 @@ public class InvitationsActivity extends BaseActivity {
                         Log.d("TAG_Soccer", getClass().getSimpleName() + ".listenForPastInvites: Past invite ID: " + invite.getId());
                     }
 
-                    pastAdapter.setData(pastInvitesList);
+                    pastAdapter.setData(pastInvitesList, InvitationsActivity.this.pastInvitesList);
 
                     // Log what's displayed in UI after initial load
                     Log.d("TAG_Soccer", getClass().getSimpleName() + ".listenForPastInvites: After setData, UI shows " + pastAdapter.getItemCount() + " items in RecyclerView");

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/PastInviteAdapter.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/PastInviteAdapter.java
@@ -291,16 +291,25 @@ public class PastInviteAdapter extends RecyclerView.Adapter<PastInviteAdapter.VH
         }
     }
 
-    void setData(List<DocumentSnapshot> invites) {
+    void setData(@NonNull List<DocumentSnapshot> invites, @NonNull RecyclerView recyclerView) {
         docs.clear();
         docs.addAll(invites);
         notifyDataSetChanged();
-        
+
         // Log what's actually in the adapter after setData
         android.util.Log.d("TAG_Soccer", "PastInviteAdapter.setData: Adapter now contains " + docs.size() + " items");
         for (int i = 0; i < docs.size(); i++) {
             android.util.Log.d("TAG_Soccer", "PastInviteAdapter.setData: [" + i + "] ID: " + docs.get(i).getId());
         }
+
+        // Force RecyclerView to remeasure itself after the new dataset is applied
+        recyclerView.post(() -> {
+            recyclerView.requestLayout();
+
+            android.util.Log.d("TAG_Soccer", "PastInviteAdapter.setData: RecyclerView.getChildCount() = " + recyclerView.getChildCount());
+            android.util.Log.d("TAG_Soccer", "PastInviteAdapter.setData: RecyclerView.getLayoutManager().getItemCount() = " +
+                    (recyclerView.getLayoutManager() != null ? recyclerView.getLayoutManager().getItemCount() : "null"));
+        });
     }
 
     void appendData(@NonNull List<DocumentSnapshot> invites, @NonNull RecyclerView recyclerView) {

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/PendingInviteAdapter.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/PendingInviteAdapter.java
@@ -252,17 +252,26 @@ class PendingInviteAdapter extends RecyclerView.Adapter<PendingInviteAdapter.VH>
         }
     }
 
-    void setData(@NonNull List<DocumentSnapshot> invites) {
+    void setData(@NonNull List<DocumentSnapshot> invites, @NonNull RecyclerView recyclerView) {
         removePresenceSubscriptions();
         docs.clear();
         docs.addAll(invites);
         notifyDataSetChanged();
-        
+
         // Log what's actually in the adapter after setData
         android.util.Log.d("TAG_Soccer", "PendingInviteAdapter.setData: Adapter now contains " + docs.size() + " items");
         for (int i = 0; i < docs.size(); i++) {
             android.util.Log.d("TAG_Soccer", "PendingInviteAdapter.setData: [" + i + "] ID: " + docs.get(i).getId());
         }
+
+        // Force RecyclerView to remeasure itself after the new dataset is applied
+        recyclerView.post(() -> {
+            recyclerView.requestLayout();
+
+            android.util.Log.d("TAG_Soccer", "PendingInviteAdapter.setData: RecyclerView.getChildCount() = " + recyclerView.getChildCount());
+            android.util.Log.d("TAG_Soccer", "PendingInviteAdapter.setData: RecyclerView.getLayoutManager().getItemCount() = " +
+                    (recyclerView.getLayoutManager() != null ? recyclerView.getLayoutManager().getItemCount() : "null"));
+        });
     }
 
     void appendData(@NonNull List<DocumentSnapshot> invites, @NonNull RecyclerView recyclerView) {


### PR DESCRIPTION
## Summary
- force both invitations adapters to request a layout pass after replacing their data so the RecyclerViews expand correctly inside the ScrollView
- update InvitationsActivity to supply the RecyclerView instances when setting data, keeping the pagination logging intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fa81a7317883308cb0804d86d17e3b