### PR TITLE
Fix invitations list height after loading more

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
@@ -12,7 +12,6 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
-import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.firebase.Timestamp;
@@ -90,7 +89,7 @@ public class InvitationsActivity extends BaseActivity {
         invitesList = findViewById(R.id.invitesList);
         emptyText = findViewById(R.id.emptyInvites);
         loadMorePendingButton = findViewById(R.id.loadMorePendingButton);
-        invitesList.setLayoutManager(new LinearLayoutManager(this));
+        invitesList.setLayoutManager(new WrapContentLinearLayoutManager(this));
         pendingAdapter = new PendingInviteAdapter(this, this::acceptInvite);
         invitesList.setAdapter(pendingAdapter);
         pendingInvitesObserver = new RecyclerView.AdapterDataObserver() {
@@ -117,7 +116,7 @@ public class InvitationsActivity extends BaseActivity {
         pastInvitesLabel = findViewById(R.id.pastInvitesLabel);
         emptyPastInvites = findViewById(R.id.emptyPastInvites);
         loadMorePastButton = findViewById(R.id.loadMorePastButton);
-        pastInvitesList.setLayoutManager(new LinearLayoutManager(this));
+        pastInvitesList.setLayoutManager(new WrapContentLinearLayoutManager(this));
         pastAdapter = new PastInviteAdapter(this, this::sendInviteViaCF, this::addFriend);
         pastAdapter.setFriendUids(friendUids);
         pastInvitesList.setAdapter(pastAdapter);

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/WrapContentLinearLayoutManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/WrapContentLinearLayoutManager.java
@@ -1,0 +1,105 @@
+package piotr_gorczynski.soccer2;
+
+import android.content.Context;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+/**
+ * A {@link LinearLayoutManager} that measures all of its children so that the
+ * RecyclerView can expand to wrap its content when it is hosted inside a
+ * {@link android.widget.ScrollView}.
+ *
+ * <p>Android does not automatically remeasure a RecyclerView with
+ * {@code layout_height="wrap_content"} that lives inside a ScrollView. As a
+ * consequence the view keeps the height from its first measurement (often only
+ * enough to display a handful of rows) even after the adapter loads more data.
+ *
+ * <p>This layout manager solves the issue by calculating the required height in
+ * {@link #onMeasure(RecyclerView.Recycler, RecyclerView.State, int, int)} and by
+ * reporting that height back to the parent. The view is therefore resized on
+ * every layout pass, which allows additional pages of invitations to become
+ * visible as soon as they are appended to the adapter.</p>
+ */
+class WrapContentLinearLayoutManager extends LinearLayoutManager {
+
+    WrapContentLinearLayoutManager(Context context) {
+        super(context);
+    }
+
+    WrapContentLinearLayoutManager(Context context, int orientation, boolean reverseLayout) {
+        super(context, orientation, reverseLayout);
+    }
+
+    @Override
+    public boolean canScrollVertically() {
+        // The RecyclerView is nested inside a ScrollView, so it should delegate
+        // vertical scrolling to the parent container.
+        return false;
+    }
+
+    @Override
+    public void onMeasure(@NonNull RecyclerView.Recycler recycler,
+                          @NonNull RecyclerView.State state,
+                          int widthSpec,
+                          int heightSpec) {
+        if (state.isPreLayout()) {
+            // Fall back to default behaviour during pre-layout (animations).
+            super.onMeasure(recycler, state, widthSpec, heightSpec);
+            return;
+        }
+
+        final int widthMode = View.MeasureSpec.getMode(widthSpec);
+        final int widthSize = View.MeasureSpec.getSize(widthSpec);
+        final int heightMode = View.MeasureSpec.getMode(heightSpec);
+        final int heightSize = View.MeasureSpec.getSize(heightSpec);
+
+        int width = 0;
+        int height = getPaddingTop() + getPaddingBottom();
+
+        final int itemCount = getItemCount();
+        for (int position = 0; position < itemCount; position++) {
+            View view;
+            try {
+                view = recycler.getViewForPosition(position);
+            } catch (IndexOutOfBoundsException ex) {
+                break;
+            }
+
+            addView(view);
+            measureChildWithMargins(view, 0, 0);
+
+            final int measuredWidth = getDecoratedMeasuredWidth(view);
+            final int measuredHeight = getDecoratedMeasuredHeight(view);
+
+            width = Math.max(width, measuredWidth);
+            height += measuredHeight;
+
+            detachAndScrapView(view, recycler);
+
+            if (heightMode == View.MeasureSpec.AT_MOST && height >= heightSize) {
+                height = heightSize;
+                break;
+            }
+        }
+
+        width += getPaddingLeft() + getPaddingRight();
+
+        if (widthMode == View.MeasureSpec.EXACTLY) {
+            width = widthSize;
+        } else if (widthMode == View.MeasureSpec.AT_MOST) {
+            width = Math.min(width, widthSize);
+        }
+
+        if (heightMode == View.MeasureSpec.EXACTLY) {
+            height = heightSize;
+        } else if (heightMode == View.MeasureSpec.AT_MOST) {
+            height = Math.min(height, heightSize);
+        }
+
+        setMeasuredDimension(width, height);
+    }
+}
+


### PR DESCRIPTION
## Summary
- replace the invitations RecyclerView layout managers with a wrap-content aware variant
- add a custom LinearLayoutManager that measures all children so the list expands after pagination

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68fa8a0315648330aaa316fed36fa2e1