### PR TITLE
Disable RecyclerView animations in InvitationsActivity to prevent crash

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/InvitationsActivity.java
@@ -157,6 +157,14 @@ public class InvitationsActivity extends BaseActivity {
         if (animator instanceof SimpleItemAnimator) {
             ((SimpleItemAnimator) animator).setSupportsChangeAnimations(false);
         }
+
+        // Recent RecyclerView versions can crash when animations are running while the
+        // adapter dataset is invalidated and the view is being remeasured (see
+        // DefaultItemAnimator#runPendingAnimations). Because InvitationsActivity updates the
+        // lists by calling notifyDataSetChanged() followed by requestLayout(), it is safer to
+        // disable the animator entirely so that RecyclerView never tries to operate on a null
+        // ViewHolder during those layout passes.
+        recyclerView.setItemAnimator(null);
     }
 
     // At the top of the class — keeps logcat tidy


### PR DESCRIPTION
## Summary
- disable the invitations RecyclerViews' item animator to avoid DefaultItemAnimator crashes when data is refreshed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb569d95e08330ac8166a3427bf8ba