### PR TITLE
Fix past invite list height measurement

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/WrapContentLinearLayoutManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/WrapContentLinearLayoutManager.java
@@ -79,10 +79,11 @@ class WrapContentLinearLayoutManager extends LinearLayoutManager {
 
             detachAndScrapView(view, recycler);
 
-            if (heightMode == View.MeasureSpec.AT_MOST && height >= heightSize) {
-                height = heightSize;
-                break;
-            }
+            // When hosted in a ScrollView the RecyclerView receives an AT_MOST
+            // height spec equal to the viewport size. Returning that limited
+            // height would prevent the ScrollView from growing to fit the
+            // entire list, so we intentionally ignore the bound and allow the
+            // view to report the full height that it requires.
         }
 
         width += getPaddingLeft() + getPaddingRight();
@@ -95,8 +96,6 @@ class WrapContentLinearLayoutManager extends LinearLayoutManager {
 
         if (heightMode == View.MeasureSpec.EXACTLY) {
             height = heightSize;
-        } else if (heightMode == View.MeasureSpec.AT_MOST) {
-            height = Math.min(height, heightSize);
         }
 
         setMeasuredDimension(width, height);


### PR DESCRIPTION
## Summary
- allow the wrap-content linear layout manager used by the past invites list to ignore the ScrollView height cap so the RecyclerView can expand to show all rows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb62b22a648330a101d8fa7b89d5c7