### PR TITLE
Fix invitations screen background and text colors

### DIFF
--- a/mobile/app/src/main/res/layout/activity_invitations.xml
+++ b/mobile/app/src/main/res/layout/activity_invitations.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:background="@color/colorWhite">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/invitations_toolbar"
@@ -19,6 +20,7 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
+        android:background="@color/colorWhite"
         android:clipToPadding="false"
         android:paddingStart="20dp"
         android:paddingTop="20dp"

--- a/mobile/app/src/main/res/layout/item_past_invite.xml
+++ b/mobile/app/src/main/res/layout/item_past_invite.xml
@@ -3,14 +3,16 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="8dp">
+    android:padding="8dp"
+    android:background="@color/colorWhite">
 
     <TextView
         android:id="@+id/nickname"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:textStyle="bold"
-        android:textSize="16sp" />
+        android:textSize="16sp"
+        android:textColor="@color/colorBlack" />
 
     <TextView
         android:id="@+id/inviteReceivedAndStatus"

--- a/mobile/app/src/main/res/layout/item_pending_invite.xml
+++ b/mobile/app/src/main/res/layout/item_pending_invite.xml
@@ -3,14 +3,16 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="8dp">
+    android:padding="8dp"
+    android:background="@color/colorWhite">
 
     <TextView
         android:id="@+id/nickname"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:textStyle="bold"
-        android:textSize="16sp" />
+        android:textSize="16sp"
+        android:textColor="@color/colorBlack" />
 
     <TextView
         android:id="@+id/inviteReceivedAndStatus"


### PR DESCRIPTION
## Summary
- set the invitations activity container to use the standard white background
- ensure pending and past invite list rows keep a white background with black primary text

## Testing
- ./gradlew lintVitalRelease *(fails: task not found in project)*
- ./gradlew lint *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fbb1892e848330bb20dbf72eec45da