### PR TITLE
Prevent leaving tournaments after registration closes

### DIFF
--- a/firebase/functions/leave-tournament/index.js
+++ b/firebase/functions/leave-tournament/index.js
@@ -32,6 +32,15 @@ exports.leaveTournament = functions.https.onCall(async (data, context) => {
       throw new functions.https.HttpsError('failed-precondition', 'Tournament already started.');
     }
 
+    const regDeadline = t.registrationDeadline &&
+      typeof t.registrationDeadline.toDate === 'function'
+        ? t.registrationDeadline.toDate()
+        : null;
+
+    if (regDeadline && regDeadline.getTime() <= Date.now()) {
+      throw new functions.https.HttpsError('failed-precondition', 'Registration already closed.');
+    }
+
     tx.delete(pRef);
     tx.update(tRef, {
       participantsCount: admin.firestore.FieldValue.increment(-1)

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentAdapter.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentAdapter.java
@@ -157,7 +157,7 @@ public class TournamentAdapter
                             boolean joinedAlready = p.exists();
                             if (joinedAlready) {
                                 h.joinBtn.setEnabled(false);
-                                h.leaveBtn.setEnabled(true);
+                                h.leaveBtn.setEnabled(!closed);
                             } else {
                                 h.joinBtn.setEnabled(!full && !closed);
                                 h.leaveBtn.setEnabled(false);


### PR DESCRIPTION
## Summary
- disable the Leave button on tournaments whose registration deadline has passed
- add a backend guard in the leaveTournament function to reject leave requests after registration closes

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68fe4ef8500c8330881b14f76c678d9d