### PR TITLE
Add running player sprite animation to field view

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -9,6 +9,7 @@ import android.graphics.Rect;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.RectF;
+import android.os.SystemClock;
 import androidx.core.content.ContextCompat;
 
 import android.text.TextPaint;
@@ -27,6 +28,7 @@ public class Field {
     private final float flDots;
     private final float flText;
     private final float flLinesWidth;
+    private final float flSpriteSize;
     private final Paint pField;
     private final Paint pFieldBorder;
     private final Paint pDots;
@@ -36,6 +38,7 @@ public class Field {
     private final Rect rField;
     private final Rect rText;
     private final Bitmap ballBitmap;
+    private final Bitmap[] runningPlayerFrames;
     private final String sPlayer0;
     private final String sPlayer1;
     private final int gameType;
@@ -47,6 +50,9 @@ public class Field {
     private long remainingTime0, remainingTime1;
 
     private Long turnStartTime;
+    private final boolean showRunningPlayerSprite;
+    private int runningPlayerFrameIndex = 0;
+    private long runningPlayerLastFrameTime = 0L;
 
     public Field(Context current, ArrayList<MoveTo> argMoves, ArrayList<MoveTo> argPossibleMoves, int argGameType, String player0Name, String player1Name, int localPlayerIndex) {
 
@@ -104,11 +110,20 @@ public class Field {
             flLinesWidth = res.getFraction(R.fraction.flLinesWidth,1,1);
             flDots= res.getFraction(R.fraction.flDots,1,1);
             flText = res.getFraction(R.fraction.flText,1,1);
+            flSpriteSize = res.getFraction(R.fraction.flSpriteSize,1,1);
             intFieldWidth = res.getInteger(R.integer.intFieldHalfWidth)*2;
             intFieldHeight = res.getInteger(R.integer.intFieldHalfHeight)*2;
         } catch (Exception e) {
             Log.e("TAG_Soccer", getClass().getSimpleName() + ".<init>: Failed to load field resources", e);
             throw new RuntimeException("Failed to load field configuration resources", e);
+        }
+
+        showRunningPlayerSprite = gameType == 1 || gameType == 2;
+        if (showRunningPlayerSprite) {
+            runningPlayerFrames = RunningPlayerSprite.getFrames(current);
+            runningPlayerLastFrameTime = SystemClock.uptimeMillis();
+        } else {
+            runningPlayerFrames = new Bitmap[0];
         }
 
         pPlayer0=new Paint();
@@ -401,6 +416,39 @@ public class Field {
 
         RectF dst = new RectF(cx - radius, cy - radius, cx + radius, cy + radius);
         canvas.drawBitmap(ballBitmap, null, dst, null);
+
+        if (showRunningPlayerSprite && runningPlayerFrames.length > 0 && flSpriteSize > 0f) {
+            long now = SystemClock.uptimeMillis();
+            if (runningPlayerLastFrameTime == 0L) {
+                runningPlayerLastFrameTime = now;
+            }
+            long elapsed = now - runningPlayerLastFrameTime;
+            if (elapsed >= RunningPlayerSprite.FRAME_DURATION_MS) {
+                long framesToAdvance = elapsed / RunningPlayerSprite.FRAME_DURATION_MS;
+                runningPlayerFrameIndex = (int) ((runningPlayerFrameIndex + framesToAdvance) % runningPlayerFrames.length);
+                long remainder = elapsed % RunningPlayerSprite.FRAME_DURATION_MS;
+                runningPlayerLastFrameTime = now - remainder;
+            }
+
+            Bitmap spriteFrame = runningPlayerFrames[runningPlayerFrameIndex];
+            if (spriteFrame != null && !spriteFrame.isRecycled()) {
+                float spriteHeight = canvas.getHeight() * flSpriteSize;
+                if (spriteHeight > 0f) {
+                    float spriteWidth = spriteHeight * spriteFrame.getWidth() / (float) spriteFrame.getHeight();
+                    float spriteTop = cy + radius + dotSize;
+                    float spriteBottom = spriteTop + spriteHeight;
+                    if (spriteBottom > canvas.getHeight()) {
+                        float overflow = spriteBottom - canvas.getHeight();
+                        spriteTop -= overflow;
+                        spriteBottom = canvas.getHeight();
+                    }
+                    float spriteLeft = cx - spriteWidth / 2f;
+                    float spriteRight = cx + spriteWidth / 2f;
+                    RectF spriteDst = new RectF(spriteLeft, spriteTop, spriteRight, spriteBottom);
+                    canvas.drawBitmap(spriteFrame, null, spriteDst, null);
+                }
+            }
+        }
 
 
         // Turn indicator

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RunningPlayerSprite.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RunningPlayerSprite.java
@@ -1,0 +1,125 @@
+package piotr_gorczynski.soccer2;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+
+/**
+ * Lazily loads and caches the running player sprite sheet that is also used on the menu screen.
+ * Only the first row of frames is required for the in-game animation, which matches the default
+ * menu animation.
+ */
+final class RunningPlayerSprite {
+
+    private static final String TAG = "TAG_Soccer";
+
+    private static final int FRAME_COUNT = 22;
+    private static final int FRAME_WIDTH = 128;
+    private static final int FRAME_HEIGHT = 128;
+    static final long FRAME_DURATION_MS = 250L;
+
+    private static Bitmap[] cachedFrames;
+
+    private RunningPlayerSprite() {
+        // no instances
+    }
+
+    static synchronized Bitmap[] getFrames(Context context) {
+        if (cachedFrames != null) {
+            return cachedFrames;
+        }
+
+        if (context == null) {
+            Log.w(TAG, RunningPlayerSprite.class.getSimpleName() + ".getFrames: context is null");
+            cachedFrames = new Bitmap[0];
+            return cachedFrames;
+        }
+
+        int spriteSheetResId = context.getResources().getIdentifier(
+                "spritesheet",
+                "drawable",
+                context.getPackageName()
+        );
+        if (spriteSheetResId == 0) {
+            Log.w(TAG, RunningPlayerSprite.class.getSimpleName() + ".getFrames: spritesheet resource missing");
+            cachedFrames = new Bitmap[0];
+            return cachedFrames;
+        }
+
+        Bitmap spriteSheet;
+        try {
+            BitmapFactory.Options decodeOptions = new BitmapFactory.Options();
+            decodeOptions.inScaled = false;
+            spriteSheet = BitmapFactory.decodeResource(context.getResources(), spriteSheetResId, decodeOptions);
+        } catch (Exception e) {
+            Log.e(TAG, RunningPlayerSprite.class.getSimpleName() + ".getFrames: Failed to decode sprite sheet", e);
+            cachedFrames = new Bitmap[0];
+            return cachedFrames;
+        }
+
+        if (spriteSheet == null) {
+            Log.w(TAG, RunningPlayerSprite.class.getSimpleName() + ".getFrames: sprite sheet decoding returned null");
+            cachedFrames = new Bitmap[0];
+            return cachedFrames;
+        }
+
+        int sheetWidth = spriteSheet.getWidth();
+        int sheetHeight = spriteSheet.getHeight();
+        if (sheetWidth <= 0 || sheetHeight <= 0) {
+            Log.w(TAG, RunningPlayerSprite.class.getSimpleName() + ".getFrames: invalid sheet dimensions");
+            spriteSheet.recycle();
+            cachedFrames = new Bitmap[0];
+            return cachedFrames;
+        }
+
+        int framesAvailable = Math.min(FRAME_COUNT, sheetWidth / FRAME_WIDTH);
+        if (framesAvailable <= 0) {
+            Log.w(TAG, RunningPlayerSprite.class.getSimpleName() + ".getFrames: no frames available in sheet");
+            spriteSheet.recycle();
+            cachedFrames = new Bitmap[0];
+            return cachedFrames;
+        }
+
+        int usableHeight = Math.min(FRAME_HEIGHT, sheetHeight);
+        Bitmap[] frames = new Bitmap[framesAvailable];
+        for (int i = 0; i < framesAvailable; i++) {
+            int sourceX = i * FRAME_WIDTH;
+            int frameWidth = Math.min(FRAME_WIDTH, sheetWidth - sourceX);
+            if (frameWidth <= 0) {
+                break;
+            }
+            try {
+                frames[i] = Bitmap.createBitmap(
+                        spriteSheet,
+                        sourceX,
+                        0,
+                        frameWidth,
+                        usableHeight
+                );
+            } catch (IllegalArgumentException e) {
+                Log.e(TAG, RunningPlayerSprite.class.getSimpleName() + ".getFrames: failed to create frame " + i, e);
+                recycleFrames(frames);
+                frames = new Bitmap[0];
+                break;
+            }
+        }
+
+        spriteSheet.recycle();
+        cachedFrames = frames;
+        return cachedFrames;
+    }
+
+    private static void recycleFrames(@Nullable Bitmap[] frames) {
+        if (frames == null) {
+            return;
+        }
+        for (Bitmap frame : frames) {
+            if (frame != null && !frame.isRecycled()) {
+                frame.recycle();
+            }
+        }
+    }
+}

--- a/mobile/app/src/main/res/values/constants.xml
+++ b/mobile/app/src/main/res/values/constants.xml
@@ -5,6 +5,7 @@
     <fraction name="flDots">1%</fraction>
     <fraction name="flText">3%</fraction>
     <fraction name="flLinesWidth">0.5%</fraction>
+    <fraction name="flSpriteSize">15%</fraction>
     <integer name="intFieldHalfWidth">3</integer>
     <integer name="intFieldHalfHeight">4</integer>
 </resources>


### PR DESCRIPTION
## Summary
- add shared loader for the running player sprite sheet used by the menu animation
- draw the animated running player below the ball in the field for local games using a configurable size
- expose a new fraction constant so the sprite height is a percentage of the screen

## Testing
- ./gradlew lint *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fe7ee41c848330ad16796fa7725722