### PR TITLE
Sort ended tournaments by latest completion date

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentsActivity.java
@@ -15,6 +15,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.functions.FirebaseFunctions;
@@ -130,6 +131,18 @@ public class TournamentsActivity extends BaseActivity {
                     endedDocs.add(doc);
                 }
             }
+
+            // Sort ended tournaments by their matches deadline so the most recently
+            // finished tournaments appear first in the list shown to the user.
+            endedDocs.sort((left, right) -> {
+                Timestamp leftDeadline = left.getTimestamp("matchesDeadline");
+                Timestamp rightDeadline = right.getTimestamp("matchesDeadline");
+
+                long leftMillis = leftDeadline != null ? leftDeadline.toDate().getTime() : Long.MIN_VALUE;
+                long rightMillis = rightDeadline != null ? rightDeadline.toDate().getTime() : Long.MIN_VALUE;
+
+                return Long.compare(rightMillis, leftMillis);
+            });
 
             registeringAdapter.notifyDataSetChanged();
             runningAdapter.notifyDataSetChanged();


### PR DESCRIPTION
## Summary
- sort ended tournaments by their matches deadline so the most recently finished events appear first
- add the necessary Timestamp import for the new sorting logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fe8f43f7c88330a39d1518b7ffda9f