### PR TITLE
Use idle spritesheet for running player animation

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -86,7 +86,7 @@ public class MenuActivity extends BaseActivity {
     static final String PREF_LAST_INVITES_SEEN_TIMESTAMP = "lastInvitesSeenTimestamp";
     private static final String PREF_LAST_ACTIVE_TIMESTAMP = "lastActiveTimestamp";
 
-    private static final int RUNNING_PLAYER_FRAME_COUNT = 22;
+    private static final int RUNNING_PLAYER_FRAME_COUNT = 35;
     private static final int RUNNING_PLAYER_FRAME_WIDTH = 128;
     private static final int RUNNING_PLAYER_FRAME_HEIGHT = 128;
     private static final long RUNNING_PLAYER_FRAME_DURATION_MS = 125L;
@@ -960,14 +960,14 @@ public class MenuActivity extends BaseActivity {
         }
 
         int spriteSheetResId = getResources().getIdentifier(
-                "spritesheet",
+                "spritesheet_idle",
                 "drawable",
                 getPackageName()
         );
         if (spriteSheetResId == 0) {
             Log.w(
                     "TAG_Soccer",
-                    getClass().getSimpleName() + ".setupRunningPlayerAnimation: spritesheet resource missing"
+                    getClass().getSimpleName() + ".setupRunningPlayerAnimation: spritesheet_idle resource missing"
             );
             runningPlayerView.setVisibility(View.GONE);
             return;
@@ -990,7 +990,7 @@ public class MenuActivity extends BaseActivity {
         if (spriteSheet == null) {
             Log.w(
                     "TAG_Soccer",
-                    getClass().getSimpleName() + ".setupRunningPlayerAnimation: spritesheet resource missing"
+                    getClass().getSimpleName() + ".setupRunningPlayerAnimation: spritesheet_idle resource missing"
             );
             runningPlayerView.setVisibility(View.GONE);
             return;

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RunningPlayerSprite.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RunningPlayerSprite.java
@@ -16,7 +16,7 @@ final class RunningPlayerSprite {
 
     private static final String TAG = "TAG_Soccer";
 
-    private static final int FRAME_COUNT = 22;
+    private static final int FRAME_COUNT = 35;
     private static final int FRAME_WIDTH = 128;
     private static final int FRAME_HEIGHT = 128;
     static final long FRAME_DURATION_MS = 250L;
@@ -39,12 +39,12 @@ final class RunningPlayerSprite {
         }
 
         int spriteSheetResId = context.getResources().getIdentifier(
-                "spritesheet",
+                "spritesheet_idle",
                 "drawable",
                 context.getPackageName()
         );
         if (spriteSheetResId == 0) {
-            Log.w(TAG, RunningPlayerSprite.class.getSimpleName() + ".getFrames: spritesheet resource missing");
+            Log.w(TAG, RunningPlayerSprite.class.getSimpleName() + ".getFrames: spritesheet_idle resource missing");
             cachedFrames = new Bitmap[0];
             return cachedFrames;
         }


### PR DESCRIPTION
## Summary
- update the cached running player frames to use the new `spritesheet_idle` drawable with all 35 frames
- point the menu animation loader at `spritesheet_idle` and align its frame count with the new sheet

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6905336c0f508330ab157a52727f25b1