### PR TITLE
Add missing translations for friend invite status messages

### DIFF
--- a/mobile/app/src/main/res/values-es/strings.xml
+++ b/mobile/app/src/main/res/values-es/strings.xml
@@ -360,5 +360,10 @@
     <string name="presence_user_online">%1$s estado: En línea</string>
     <string name="presence_user_last_seen">%1$s estado: Visto por última vez %2$s</string>
     <string name="presence_user_offline">%1$s estado: Desconectado</string>
+    <string name="error_checking_friend_status">Error al comprobar el estado del amigo</string>
+    <string name="friend_added">Amigo agregado correctamente</string>
+    <string name="active_invitation_exists">Ya existe una invitación activa</string>
+    <string name="user_blocked_invites">El usuario ha bloqueado las invitaciones</string>
+    <string name="cannot_invite_this_user">No se puede invitar a este usuario</string>
 
 </resources>

--- a/mobile/app/src/main/res/values-fa/strings.xml
+++ b/mobile/app/src/main/res/values-fa/strings.xml
@@ -309,5 +309,10 @@
     <string name="presence_user_online">%1$s وضعیت: آنلاین</string>
     <string name="presence_user_last_seen">%1$s وضعیت: آخرین بار دیده شد %2$s</string>
     <string name="presence_user_offline">%1$s وضعیت: آفلاین</string>
+    <string name="error_checking_friend_status">خطا در بررسی وضعیت دوست</string>
+    <string name="friend_added">دوست با موفقیت اضافه شد</string>
+    <string name="active_invitation_exists">دعوت فعال از قبل وجود دارد</string>
+    <string name="user_blocked_invites">کاربر دعوت‌ها را مسدود کرده است</string>
+    <string name="cannot_invite_this_user">نمی‌توان این کاربر را دعوت کرد</string>
 
 </resources>

--- a/mobile/app/src/main/res/values-fr/strings.xml
+++ b/mobile/app/src/main/res/values-fr/strings.xml
@@ -357,5 +357,10 @@
     <string name="presence_user_online">%1$s statut: En ligne</string>
     <string name="presence_user_last_seen">%1$s statut: Vu pour la dernière fois %2$s</string>
     <string name="presence_user_offline">%1$s statut: Hors ligne</string>
+    <string name="error_checking_friend_status">Erreur lors de la vérification du statut de l’ami</string>
+    <string name="friend_added">Ami ajouté avec succès</string>
+    <string name="active_invitation_exists">Une invitation active existe déjà</string>
+    <string name="user_blocked_invites">L’utilisateur a bloqué les invitations</string>
+    <string name="cannot_invite_this_user">Impossible d’inviter cet utilisateur</string>
 
 </resources>

--- a/mobile/app/src/main/res/values-hi/strings.xml
+++ b/mobile/app/src/main/res/values-hi/strings.xml
@@ -362,5 +362,10 @@
     <string name="presence_user_online">%1$s स्थिति: ऑनलाइन</string>
     <string name="presence_user_last_seen">%1$s स्थिति: अंतिम बार देखा गया %2$s</string>
     <string name="presence_user_offline">%1$s स्थिति: ऑफ़लाइन</string>
+    <string name="error_checking_friend_status">मित्र की स्थिति जांचने में त्रुटि</string>
+    <string name="friend_added">मित्र सफलतापूर्वक जोड़ा गया</string>
+    <string name="active_invitation_exists">एक सक्रिय निमंत्रण पहले से मौजूद है</string>
+    <string name="user_blocked_invites">उपयोगकर्ता ने निमंत्रण अवरुद्ध कर दिए हैं</string>
+    <string name="cannot_invite_this_user">इस उपयोगकर्ता को आमंत्रित नहीं कर सकते</string>
 
 </resources>

--- a/mobile/app/src/main/res/values-lo/strings.xml
+++ b/mobile/app/src/main/res/values-lo/strings.xml
@@ -328,5 +328,10 @@
     <string name="presence_user_online">%1$s ສະຖານະ: ອອນໄລນ໌</string>
     <string name="presence_user_last_seen">%1$s ສະຖານະ: ເຫັນຄັ້ງສຸດທ້າຍ %2$s</string>
     <string name="presence_user_offline">%1$s ສະຖານະ: ອອບໄລນ໌</string>
+    <string name="error_checking_friend_status">ຂໍ້ຜິດພາດໃນການກວດສອບສະຖານະໝູ່</string>
+    <string name="friend_added">ເພີ່ມໝູ່ສຳເລັດແລ້ວ</string>
+    <string name="active_invitation_exists">ມີຄຳເຊີນທີ່ກຳລັງໃຊ້ຢູ່ແລ້ວ</string>
+    <string name="user_blocked_invites">ຜູ້ໃຊ້ໄດ້ບລັອກຄຳເຊີນ</string>
+    <string name="cannot_invite_this_user">ບໍ່ສາມາດເຊີນຜູ້ໃຊ້ນີ້ໄດ້</string>
 
 </resources>

--- a/mobile/app/src/main/res/values-mn/strings.xml
+++ b/mobile/app/src/main/res/values-mn/strings.xml
@@ -328,5 +328,10 @@
     <string name="presence_user_online">%1$s төлөв: Онлайн</string>
     <string name="presence_user_last_seen">%1$s төлөв: Сүүлд харагдсан %2$s</string>
     <string name="presence_user_offline">%1$s төлөв: Оффлайн</string>
+    <string name="error_checking_friend_status">Найзын төлөв шалгахад алдаа гарлаа</string>
+    <string name="friend_added">Найзыг амжилттай нэмлээ</string>
+    <string name="active_invitation_exists">Идэвхтэй урилга аль хэдийн байна</string>
+    <string name="user_blocked_invites">Хэрэглэгч урилга хаасан байна</string>
+    <string name="cannot_invite_this_user">Энэ хэрэглэгчийг урих боломжгүй</string>
 
 </resources>

--- a/mobile/app/src/main/res/values-my/strings.xml
+++ b/mobile/app/src/main/res/values-my/strings.xml
@@ -328,5 +328,10 @@
     <string name="presence_user_online">%1$s အခြေအနေ: အွန်လိုင်း</string>
     <string name="presence_user_last_seen">%1$s အခြေအနေ: နောက်ဆုံးမြင်တွေ့ %2$s</string>
     <string name="presence_user_offline">%1$s အခြေအနေ: အော့ဖ်လိုင်း</string>
+    <string name="error_checking_friend_status">သူငယ်ချင်းအခြေအနေကို စစ်ဆေးရာတွင် အမှားဖြစ်ပေါ်ခဲ့သည်</string>
+    <string name="friend_added">သူငယ်ချင်းကို အောင်မြင်စွာ ထည့်ပြီးပြီ</string>
+    <string name="active_invitation_exists">လက်ရှိ ဖိတ်ကြားစာတစ်စောင် ရှိနေပြီးသားဖြစ်သည်</string>
+    <string name="user_blocked_invites">အသုံးပြုသူက ဖိတ်ကြားစာများကို တားမြစ်ထားသည်</string>
+    <string name="cannot_invite_this_user">ဤအသုံးပြုသူကို ဖိတ်ခေါ်၍ မရပါ</string>
 
 </resources>

--- a/mobile/app/src/main/res/values-ne/strings.xml
+++ b/mobile/app/src/main/res/values-ne/strings.xml
@@ -362,5 +362,10 @@
     <string name="presence_user_online">%1$s स्थिति: अनलाइन</string>
     <string name="presence_user_last_seen">%1$s स्थिति: अन्तिम पटक देखिएको %2$s</string>
     <string name="presence_user_offline">%1$s स्थिति: अफलाइन</string>
+    <string name="error_checking_friend_status">साथीको स्थिति जाँच्दा त्रुटि</string>
+    <string name="friend_added">साथी सफलतापूर्वक थपियो</string>
+    <string name="active_invitation_exists">सक्रिय निमन्त्रणा पहिले नै अवस्थित छ</string>
+    <string name="user_blocked_invites">प्रयोगकर्ताले निमन्त्रणा रोक्का गरेको छ</string>
+    <string name="cannot_invite_this_user">यस प्रयोगकर्तालाई निमन्त्रणा गर्न सकिँदैन</string>
 
 </resources>

--- a/mobile/app/src/main/res/values-si/strings.xml
+++ b/mobile/app/src/main/res/values-si/strings.xml
@@ -328,5 +328,10 @@
     <string name="presence_user_online">%1$s තත්ත්වය: සබැඳිව</string>
     <string name="presence_user_last_seen">%1$s තත්ත්වය: අවසන් වරට දුටු %2$s</string>
     <string name="presence_user_offline">%1$s තත්ත්වය: අසම්බන්ධිත</string>
+    <string name="error_checking_friend_status">මිතුරන්ගේ තත්වය පරීක්ෂා කිරීමේ දෝෂයක්</string>
+    <string name="friend_added">මිතුරා සාර්ථකව එකතු කළා</string>
+    <string name="active_invitation_exists">ක්‍රියාත්මක ආරාධනයක් දැනටමත් ඇත</string>
+    <string name="user_blocked_invites">පරිශීලකයා ආරාධනා අවහිර කර ඇත</string>
+    <string name="cannot_invite_this_user">මෙම පරිශීලකයාට ආරාධනා කළ නොහැක</string>
 
 </resources>

--- a/mobile/app/src/main/res/values-sw/strings.xml
+++ b/mobile/app/src/main/res/values-sw/strings.xml
@@ -328,5 +328,10 @@
     <string name="presence_user_online">%1$s hali: Mtandaoni</string>
     <string name="presence_user_last_seen">%1$s hali: Alionekana mwisho %2$s</string>
     <string name="presence_user_offline">%1$s hali: Nje ya mtandao</string>
+    <string name="error_checking_friend_status">Hitilafu katika kuangalia hali ya rafiki</string>
+    <string name="friend_added">Rafiki ameongezwa kwa mafanikio</string>
+    <string name="active_invitation_exists">Mwaliko unaoendelea tayari upo</string>
+    <string name="user_blocked_invites">Mtumiaji amezuia mialiko</string>
+    <string name="cannot_invite_this_user">Haiwezekani kumwalika mtumiaji huyu</string>
 
 </resources>


### PR DESCRIPTION
## Summary
- add translations for the new friend status and invitation strings across Spanish, Persian, French, Hindi, Lao, Mongolian, Burmese, Nepali, Sinhala, and Swahili locale resources

## Testing
- not run (resource change only)


------
https://chatgpt.com/codex/tasks/task_e_690625e227888330b64015740f6a1a18