### PR TITLE
Fix blue south-west run animation frame offset

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/RunBluePlayerSprite.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/RunBluePlayerSprite.java
@@ -6,7 +6,14 @@ import android.graphics.Bitmap;
 final class RunBluePlayerSprite {
 
     private static final int ROW_HEIGHT = 128;
-    private static final int FIRST_ROW_START_Y = 1 + ROW_HEIGHT * 8;
+    // The blue sprites occupy the lower half of the shared run sheet. The first
+    // blue row starts immediately after the red rows (8 * ROW_HEIGHT pixels). We
+    // intentionally avoid adding an extra offset here because doing so would
+    // push the final south-west row one pixel beyond the sheet's height (2048px),
+    // causing BitmapFactory to return an empty frame array. By using exactly
+    // ROW_HEIGHT * 8 we keep every blue frame—especially the south-west sequence
+    // used when moving (-1, -1)—within bounds so the animation never disappears.
+    private static final int FIRST_ROW_START_Y = ROW_HEIGHT * 8;
 
     private RunBluePlayerSprite() {
         // no instances


### PR DESCRIPTION
## Summary
- adjust the blue run sprite sheet row offset so the south-west frames stay within the image bounds
- document why the offset must not include the extra pixel to avoid empty frame arrays

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6907d16f38308330bc22c0ccdebfb7df