### PR TITLE
Fix idle sprite flashing during run animation

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -889,8 +889,13 @@ public class Field {
                 boolean redDelayActive = runActive && runRedDelayFrames > 0
                         && runPlayerFrameIndex < runRedDelayFrames;
 
-                boolean shouldDrawIdleBlue = !runActive || blueDelayActive;
-                boolean shouldDrawIdleRed = !runActive || redDelayActive;
+                boolean isRedMoving = runActive && runMovingPlayer == 0;
+                boolean isBlueMoving = runActive && runMovingPlayer == 1;
+
+                boolean shouldDrawIdleBlue = !runActive
+                        || (!isRedMoving && blueDelayActive);
+                boolean shouldDrawIdleRed = !runActive
+                        || (!isBlueMoving && redDelayActive);
                 boolean shouldAdvanceIdle = shouldDrawIdleBlue || shouldDrawIdleRed;
 
                 if (shouldAdvanceIdle) {


### PR DESCRIPTION
## Summary
- avoid drawing the idle sprite for the waiting player while the opponent's run animation is active
- keep idle animation timing logic unchanged for the active player

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69091992833c833086ac5af396197c9b