### PR TITLE
Ensure idle sprites remain visible during run delay

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -893,9 +893,11 @@ public class Field {
                 boolean isBlueMoving = runActive && runMovingPlayer == 1;
 
                 boolean shouldDrawIdleBlue = !runActive
-                        || (!isRedMoving && blueDelayActive);
+                        || (isRedMoving && blueDelayActive)
+                        || (!isRedMoving && !isBlueMoving);
                 boolean shouldDrawIdleRed = !runActive
-                        || (!isBlueMoving && redDelayActive);
+                        || (isBlueMoving && redDelayActive)
+                        || (!isBlueMoving && !isRedMoving);
                 boolean shouldAdvanceIdle = shouldDrawIdleBlue || shouldDrawIdleRed;
 
                 if (shouldAdvanceIdle) {


### PR DESCRIPTION
## Summary
- adjust idle sprite visibility logic so the non-active player stays in idle animation until its run delay elapses
- keep idle sprites visible when no run animation is active or no moving player is detected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6909afce86108330a03d7043cb2f47f0