### PR TITLE
Fix idle sprite spacing during delayed run animation

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -950,6 +950,9 @@ public class Field {
                 if (spriteHeight > 0f) {
                     // Blue player above the ball, bottom touching the ball's top edge
                     boolean blueShouldBeCloser = currentTurn == 1;
+                    if (runActive && runMovingPlayer == 0 && blueDelayActive) {
+                        blueShouldBeCloser = false;
+                    }
                     float idleBlueCenterX = ballCenterX;
                     float idleBlueCenterY = ballCenterY;
                     if (runActive && runMovingPlayer == 0 && blueDelayActive) {
@@ -979,6 +982,9 @@ public class Field {
 
                     // Red player below the ball, top touching the ball's bottom edge
                     boolean redShouldBeCloser = currentTurn == 0;
+                    if (runActive && runMovingPlayer == 1 && redDelayActive) {
+                        redShouldBeCloser = false;
+                    }
                     float idleRedCenterX = ballCenterX;
                     float idleRedCenterY = ballCenterY;
                     if (runActive && runMovingPlayer == 1 && redDelayActive) {


### PR DESCRIPTION
## Summary
- keep the waiting player's idle sprite at its previous offset while the opponent's run animation delay is active
- mirror the spacing fix for both red and blue players so idle sprites no longer jump closer to the ball before their run starts

## Testing
- not run (Android project)

------
https://chatgpt.com/codex/tasks/task_e_6909cc99c09483309cf8aaa0a311a0c9