### PR TITLE
Prevent idle sprite showing alongside run animation

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -522,8 +522,6 @@ public class Field {
         runPlayerFrameIndex = 0;
         runPlayerLastFrameTime = 0L;
         idlePlayerLastFrameTime = referenceTime;
-        runRedFrameVisible = false;
-        runBlueFrameVisible = false;
         runFrameLimit = RUN_FRAME_COUNT;
         runDirectionX = 0f;
         runDirectionY = 0f;
@@ -1268,6 +1266,8 @@ public class Field {
         BallState ballState = drawBall(canvas, dotSize, movePaint);
 
         // 4-5) Sprites
+        runRedFrameVisible = false;
+        runBlueFrameVisible = false;
         drawRunAnimation(canvas, ballState.radius);
         drawIdlePlayers(canvas, ballState, currentTurn);
 


### PR DESCRIPTION
## Summary
- keep the run sprite visibility flags intact through the frame in which the run animation stops
- reset the visibility flags at the start of each draw before rendering sprites

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690a65c6c9b88330b7337cfd19a59397