### PR TITLE
Disable ball animation for online games

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -616,7 +616,9 @@ public class Field {
         ballTargetGridX = targetGridX;
         ballTargetGridY = targetGridY;
 
-        if (!animationsEnabled) {
+        boolean shouldAnimateBall = animationsEnabled && gameType != 3;
+
+        if (!shouldAnimateBall) {
             ballStartGridX = targetGridX;
             ballStartGridY = targetGridY;
             ballDirectionX = 0f;


### PR DESCRIPTION
## Summary
- prevent the ball animation from running when the game type is 3 so the ball snaps to its destination

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690b511fe0c8833099f978533ab21787