### PR TITLE
Enable Vertex AI API in Firebase Cloud Build pipeline

### DIFF
--- a/gcp/cloud-build/enable_firebase_apis.yaml
+++ b/gcp/cloud-build/enable_firebase_apis.yaml
@@ -53,6 +53,7 @@ steps:
         enable_api "identitytoolkit.googleapis.com"
         enable_api "apikeys.googleapis.com"
         enable_api "firebasedatabase.googleapis.com"
+        enable_api "aiplatform.googleapis.com"
 
 
         echo "🎉 All required Firebase APIs are enabled."


### PR DESCRIPTION
## Summary
- add Vertex AI API to the list of services enabled by the Firebase API Cloud Build script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690cfa5b1b3c8330b316e8757782a1e4