### PR TITLE
Check nickname against Cloud Function before saving

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/PickNicknameActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/PickNicknameActivity.java
@@ -6,6 +6,7 @@ import android.text.Editable;
 import android.text.InputFilter;
 import android.text.TextWatcher;
 import android.util.Log;
+import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Toast;
@@ -16,7 +17,9 @@ import androidx.activity.OnBackPressedCallback;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.SetOptions;
+import com.google.firebase.functions.FirebaseFunctions;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,6 +30,8 @@ public class PickNicknameActivity extends BaseActivity {
     private Toast nickToast;
     private static final int NICK_MAX = 20;
     private AnalyticsManager analyticsManager;
+    private View nicknameCheckProgress;
+    private FirebaseFunctions functions;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -39,6 +44,8 @@ public class PickNicknameActivity extends BaseActivity {
 
         editNickname = findViewById(R.id.editNickname);
         btnConfirm = findViewById(R.id.btnConfirmNickname);
+        nicknameCheckProgress = findViewById(R.id.nicknameCheckProgress);
+        functions = FirebaseFunctions.getInstance();
 
         editNickname.setFilters(new InputFilter[]{
                 new InputFilter.LengthFilter(NICK_MAX),
@@ -73,7 +80,7 @@ public class PickNicknameActivity extends BaseActivity {
     }
 
     private void saveNickname() {
-        String nickname = editNickname.getText().toString().trim();
+        final String nickname = editNickname.getText().toString().trim();
         if (nickname.isEmpty()) {
             Toast.makeText(this, R.string.nickname_required, Toast.LENGTH_SHORT).show();
             return;
@@ -83,13 +90,37 @@ public class PickNicknameActivity extends BaseActivity {
             return;
         }
 
-        String uid = FirebaseAuth.getInstance().getUid();
+        final String uid = FirebaseAuth.getInstance().getUid();
         if (uid == null) {
             Toast.makeText(this, R.string.not_logged_in, Toast.LENGTH_SHORT).show();
             return;
         }
 
         btnConfirm.setEnabled(false);
+        showNicknameCheckProgress(true);
+        checkNickname(nickname, (allowed, hadError) -> {
+            showNicknameCheckProgress(false);
+            if (hadError) {
+                btnConfirm.setEnabled(true);
+                Toast.makeText(PickNicknameActivity.this,
+                        R.string.network_error_checking_nickname,
+                        Toast.LENGTH_SHORT).show();
+                return;
+            }
+            if (!allowed) {
+                btnConfirm.setEnabled(true);
+                Toast.makeText(PickNicknameActivity.this,
+                        R.string.nickname_taken,
+                        Toast.LENGTH_SHORT).show();
+                return;
+            }
+
+            proceedWithSavingNickname(uid, nickname);
+        });
+    }
+
+
+    private void proceedWithSavingNickname(String uid, String nickname) {
         FirebaseFirestore db = FirebaseFirestore.getInstance();
 
         db.collection("users")
@@ -99,17 +130,17 @@ public class PickNicknameActivity extends BaseActivity {
                     if (!task.isSuccessful()) {
                         btnConfirm.setEnabled(true);
                         Log.e("TAG_Soccer", "Nickname check failed", task.getException());
-                          Toast.makeText(PickNicknameActivity.this,
-                                  R.string.network_error_checking_nickname,
-                                  Toast.LENGTH_SHORT).show();
+                        Toast.makeText(PickNicknameActivity.this,
+                                R.string.network_error_checking_nickname,
+                                Toast.LENGTH_SHORT).show();
                         return;
                     }
                     if (!task.getResult().isEmpty()) {
                         btnConfirm.setEnabled(true);
                         Log.e("TAG_Soccer", "Nickname already exists: " + nickname);
-                          Toast.makeText(PickNicknameActivity.this,
-                                  R.string.nickname_taken,
-                                  Toast.LENGTH_SHORT).show();
+                        Toast.makeText(PickNicknameActivity.this,
+                                R.string.nickname_taken,
+                                Toast.LENGTH_SHORT).show();
                         return;
                     }
 
@@ -123,10 +154,10 @@ public class PickNicknameActivity extends BaseActivity {
                                         .edit()
                                         .putString("nickname", nickname)
                                         .apply();
-                                  Toast.makeText(PickNicknameActivity.this,
-                                          R.string.nickname_saved,
-                                          Toast.LENGTH_SHORT).show();
-                                
+                                Toast.makeText(PickNicknameActivity.this,
+                                        R.string.nickname_saved,
+                                        Toast.LENGTH_SHORT).show();
+
                                 // Update user properties now that nickname is set
                                 FirebaseAuth auth = FirebaseAuth.getInstance();
                                 if (auth.getCurrentUser() != null) {
@@ -134,16 +165,16 @@ public class PickNicknameActivity extends BaseActivity {
                                     String language = LanguageManager.getCurrentLanguageCode(PickNicknameActivity.this);
                                     analyticsManager.setUserProperties(authMethod, "9.0", language, true);
                                 }
-                                
-                                // Show anonymous linking prompt if user is anonymous  
+
+                                // Show anonymous linking prompt if user is anonymous
                                 if (AnonymousLinkPromptHelper.shouldShowPrompt("pick_nickname")) {
                                     AnonymousLinkPromptHelper.showSaveProgressPrompt(
-                                        PickNicknameActivity.this, 
-                                        "pick_nickname", 
-                                        analyticsManager
+                                            PickNicknameActivity.this,
+                                            "pick_nickname",
+                                            analyticsManager
                                     );
                                 }
-                                          
+
                                 if (isTaskRoot()) {
                                     startActivity(new Intent(
                                             PickNicknameActivity.this,
@@ -153,11 +184,43 @@ public class PickNicknameActivity extends BaseActivity {
                             })
                             .addOnFailureListener(e -> {
                                 btnConfirm.setEnabled(true);
-                                  Toast.makeText(PickNicknameActivity.this,
-                                          R.string.nickname_save_failed,
-                                          Toast.LENGTH_SHORT).show();
+                                Toast.makeText(PickNicknameActivity.this,
+                                        R.string.nickname_save_failed,
+                                        Toast.LENGTH_SHORT).show();
                             });
                 });
+    }
+
+    private void showNicknameCheckProgress(boolean show) {
+        if (nicknameCheckProgress != null) {
+            nicknameCheckProgress.setVisibility(show ? View.VISIBLE : View.GONE);
+        }
+    }
+
+    private void checkNickname(String nickname, NicknameCheckCallback callback) {
+        functions
+                .getHttpsCallable("checkNickname")
+                .call(Collections.singletonMap("nickname", nickname))
+                .addOnSuccessListener(this, result -> {
+                    Object data = result.getData();
+                    if (data instanceof Map) {
+                        Object allowedValue = ((Map<?, ?>) data).get("allowed");
+                        if (allowedValue instanceof Boolean) {
+                            callback.onComplete((Boolean) allowedValue, false);
+                            return;
+                        }
+                    }
+                    Log.e("TAG_Soccer", "Invalid response from checkNickname function: " + data);
+                    callback.onComplete(false, true);
+                })
+                .addOnFailureListener(this, e -> {
+                    Log.e("TAG_Soccer", "checkNickname callable failed", e);
+                    callback.onComplete(false, true);
+                });
+    }
+
+    private interface NicknameCheckCallback {
+        void onComplete(boolean allowed, boolean hadError);
     }
 
 

--- a/mobile/app/src/main/res/layout/activity_pick_nickname.xml
+++ b/mobile/app/src/main/res/layout/activity_pick_nickname.xml
@@ -23,4 +23,27 @@
         android:text="@string/confirm"
         android:textAllCaps="false"
         android:textColor="@color/colorWhite" />
+
+    <LinearLayout
+        android:id="@+id/nicknameCheckProgress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:visibility="gone">
+
+        <ProgressBar
+            style="?android:attr/progressBarStyleSmall"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:indeterminate="true" />
+
+        <TextView
+            android:id="@+id/textCheckingNickname"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="@string/checking_nickname" />
+    </LinearLayout>
 </LinearLayout>

--- a/mobile/app/src/main/res/values-am/strings.xml
+++ b/mobile/app/src/main/res/values-am/strings.xml
@@ -226,6 +226,7 @@
     <string name="register_dialog_message">ይህን ተግባር ለመጠቀም መመዝገብ ያስፈልግዎታል። እንኳን ስም-አልባ በመሆን መመዝገብ ትችላላችሁ። መቀጠል ይፈልጋሉ?</string>
     <string name="proceed">ቀጥል</string>
     <string name="network_error_checking_nickname">ቅጽል ስም ሲረጋገጥ የአውታረ መረብ ስህተት ተፈጥሯል</string>
+    <string name="checking_nickname">ቅጽል ስም በመረጋገጥ ላይ…</string>
     <string name="nickname_taken">ቅጽል ስም ቀድሞ ተጠቅመዋል — ሌላ ይምረጡ</string>
     <string name="nickname_saved">ቅጽል ስም ተቀምጧል</string>
     <string name="nickname_save_failed">ቅጽል ስም ማቀመጥ አልተሳካም</string>

--- a/mobile/app/src/main/res/values-ar/strings.xml
+++ b/mobile/app/src/main/res/values-ar/strings.xml
@@ -207,6 +207,7 @@
     <string name="register_dialog_message">لاستخدام هذه الوظيفة عليك التسجيل. يمكنك التسجيل حتى بشكل مجهول. هل تريد المتابعة؟</string>
     <string name="proceed">متابعة</string>
     <string name="network_error_checking_nickname">خطأ في الشبكة أثناء التحقق من الاسم المستعار</string>
+    <string name="checking_nickname">جارٍ التحقق من الاسم المستعار…</string>
     <string name="nickname_taken">الاسم المستعار مستخدم بالفعل — اختر آخر</string>
     <string name="nickname_saved">تم حفظ الاسم المستعار</string>
     <string name="nickname_save_failed">فشل حفظ الاسم المستعار</string>

--- a/mobile/app/src/main/res/values-bn/strings.xml
+++ b/mobile/app/src/main/res/values-bn/strings.xml
@@ -236,6 +236,7 @@
     <string name="register_dialog_message">এই ফাংশনটি ব্যবহার করার জন্য আপনাকে নিজেকে নিবন্ধন করতে হবে। আপনি এমনকি বেনামেও নিবন্ধন করতে পারেন। আপনি কি এগিয়ে যেতে চান?</string>
     <string name="proceed">এগিয়ে যান</string>
     <string name="network_error_checking_nickname">ডাকনাম পরীক্ষা করার সময় নেটওয়ার্ক ত্রুটি</string>
+    <string name="checking_nickname">ডাকনাম যাচাই করা হচ্ছে…</string>
     <string name="nickname_taken">ডাকনাম ইতিমধ্যে নেওয়া হয়েছে - অন্যটি বেছে নিন</string>
     <string name="nickname_saved">ডাকনাম সংরক্ষণ</string>
     <string name="nickname_save_failed">ডাকনাম সংরক্ষণ করতে ব্যর্থ</string>

--- a/mobile/app/src/main/res/values-de/strings.xml
+++ b/mobile/app/src/main/res/values-de/strings.xml
@@ -236,6 +236,7 @@
     <string name="register_dialog_message">Um diese Funktion zu nutzen, müssen Sie sich registrieren. Sie können sich auch anonym registrieren. Möchten Sie fortfahren?</string>
     <string name="proceed">Fortfahren</string>
     <string name="network_error_checking_nickname">Netzwerkfehler beim Überprüfen des Spitznamens</string>
+    <string name="checking_nickname">Spitzname wird überprüft…</string>
     <string name="nickname_taken">Spitzname bereits genommen - wählen Sie einen anderen</string>
     <string name="nickname_saved">Spitzname gerettet</string>
     <string name="nickname_save_failed">Spitzname nicht speichern</string>

--- a/mobile/app/src/main/res/values-es/strings.xml
+++ b/mobile/app/src/main/res/values-es/strings.xml
@@ -236,6 +236,7 @@
     <string name="register_dialog_message">Para usar esta función necesitas registrarte. Puedes registrarte incluso de forma anónima. ¿Quieres continuar?</string>
     <string name="proceed">Continuar</string>
     <string name="network_error_checking_nickname">Error de red al verificar el apodo</string>
+    <string name="checking_nickname">Comprobando apodo…</string>
     <string name="nickname_taken">Apodo ya tomado - Elija otro</string>
     <string name="nickname_saved">Apodo guardado</string>
     <string name="nickname_save_failed">No se pudo salvar el apodo</string>

--- a/mobile/app/src/main/res/values-fa/strings.xml
+++ b/mobile/app/src/main/res/values-fa/strings.xml
@@ -207,6 +207,7 @@
     <string name="register_dialog_message">برای استفاده از این قابلیت باید ثبت‌نام کنید. می‌توانید حتی به صورت ناشناس ثبت‌نام کنید. آیا می‌خواهید ادامه دهید؟</string>
     <string name="proceed">ادامه</string>
     <string name="network_error_checking_nickname">خطای شبکه هنگام بررسی نام مستعار</string>
+    <string name="checking_nickname">در حال بررسی نام مستعار…</string>
     <string name="nickname_taken">این نام مستعار قبلاً استفاده شده است — نام دیگری انتخاب کنید</string>
     <string name="nickname_saved">نام مستعار ذخیره شد</string>
     <string name="nickname_save_failed">ذخیره نام مستعار ناموفق بود</string>

--- a/mobile/app/src/main/res/values-fr/strings.xml
+++ b/mobile/app/src/main/res/values-fr/strings.xml
@@ -239,6 +239,7 @@
     <string name="register_dialog_message">Pour utiliser cette fonction, vous devez vous inscrire. Vous pouvez même vous inscrire de manière anonyme. Voulez-vous continuer?</string>
     <string name="proceed">Continuer</string>
     <string name="network_error_checking_nickname">Erreur réseau lors de la vérification du pseudonyme</string>
+    <string name="checking_nickname">Vérification du pseudonyme…</string>
     <string name="nickname_taken">Pseudonyme déjà pris — choisissez-en un autre</string>
     <string name="nickname_saved">Pseudonyme enregistré</string>
     <string name="nickname_save_failed">Échec de l’enregistrement du pseudonyme</string>

--- a/mobile/app/src/main/res/values-hi/strings.xml
+++ b/mobile/app/src/main/res/values-hi/strings.xml
@@ -236,6 +236,7 @@
     <string name="register_dialog_message">इस फ़ंक्शन का उपयोग करने के लिए आपको स्वयं को पंजीकृत करना होगा। आप गुमनाम रूप से भी पंजीकरण कर सकते हैं। क्या आप आगे बढ़ना चाहते हैं?</string>
     <string name="proceed">आगे बढ़ें</string>
     <string name="network_error_checking_nickname">उपनाम की जाँच करते समय नेटवर्क त्रुटि</string>
+    <string name="checking_nickname">उपनाम की जाँच हो रही है…</string>
     <string name="nickname_taken">उपनाम पहले से ही लिया गया - एक और चुनें</string>
     <string name="nickname_saved">उपनाम बचाया</string>
     <string name="nickname_save_failed">उपनाम बचाने में विफल रहा</string>

--- a/mobile/app/src/main/res/values-km/strings.xml
+++ b/mobile/app/src/main/res/values-km/strings.xml
@@ -226,6 +226,7 @@
     <string name="register_dialog_message">ដើម្បីប្រើមុខងារនេះ អ្នកត្រូវតែចុះឈ្មោះ។ អ្នកអាចចុះឈ្មោះជាអនាមិកក៏បាន។ តើអ្នកចង់បន្តទេ?</string>
     <string name="proceed">បន្ត</string>
     <string name="network_error_checking_nickname">កំហុសបណ្តាញពេលពិនិត្យឈ្មោះហៅក្រៅ</string>
+    <string name="checking_nickname">កំពុងពិនិត្យឈ្មោះហៅក្រៅ…</string>
     <string name="nickname_taken">ឈ្មោះហៅក្រៅនេះត្រូវបានប្រើរួចហើយ — សូមជ្រើសឈ្មោះផ្សេង</string>
     <string name="nickname_saved">រក្សាទុកឈ្មោះហៅក្រៅរួច</string>
     <string name="nickname_save_failed">រក្សាទុកឈ្មោះហៅក្រៅមិនបានសម្រេច</string>

--- a/mobile/app/src/main/res/values-lo/strings.xml
+++ b/mobile/app/src/main/res/values-lo/strings.xml
@@ -226,6 +226,7 @@
     <string name="register_dialog_message">ເພື່ອໃຊ້ຟັງຊັນນີ້ທ່ານຕ້ອງລົງທະບຽນກ່ອນ. ທ່ານສາມາດລົງທະບຽນແບບນິລະນາມກໍໄດ້. ຈະສືບຕໍ່ບໍ?</string>
     <string name="proceed">ສືບຕໍ່</string>
     <string name="network_error_checking_nickname">ເກີດຂໍ້ຜິດພາດເນື່ອງຈາກເຄືອຂ່າຍໃນຂະນະກວດຊື່ເລັ່ນ</string>
+    <string name="checking_nickname">ກຳລັງກວດສອບຊື່ເລັ່ນ…</string>
     <string name="nickname_taken">ຊື່ເລັ່ນນີ້ຖືກໃຊ້ແລ້ວ — ກະລຸນາເລືອກຊື່ໃໝ່</string>
     <string name="nickname_saved">ບັນທຶກຊື່ເລັ່ນແລ້ວ</string>
     <string name="nickname_save_failed">ບັນທຶກຊື່ເລັ່ນບໍ່ສໍາເລັດ</string>

--- a/mobile/app/src/main/res/values-mg/strings.xml
+++ b/mobile/app/src/main/res/values-mg/strings.xml
@@ -226,6 +226,7 @@
     <string name="register_dialog_message">Mba hampiasana ity fiasa ity dia mila misoratra anarana ianao. Afaka misoratra anarana amin`ny tsy mitonona anarana mihitsy aza ianao. Te hanohy ve ianao?</string>
     <string name="proceed">Hanohy</string>
     <string name="network_error_checking_nickname">Nisy olana amin`ny tambajotra rehefa nizaha anaram-bositra</string>
+    <string name="checking_nickname">Manamarina anaram-bositra…</string>
     <string name="nickname_taken">Efa misy naka io anaram-bositra io — mifidiana iray hafa</string>
     <string name="nickname_saved">Voatahiry ny anaram-bositra</string>
     <string name="nickname_save_failed">Tsy nahomby ny fitahirizana anaram-bositra</string>

--- a/mobile/app/src/main/res/values-mn/strings.xml
+++ b/mobile/app/src/main/res/values-mn/strings.xml
@@ -226,6 +226,7 @@
     <string name="register_dialog_message">Энэ боломжийг ашиглахын тулд бүртгүүлэх шаардлагатай. Хүсвэл нэргүйгээр ч бүртгүүлж болно. Үргэлжлүүлэх үү?</string>
     <string name="proceed">Үргэлжлүүлэх</string>
     <string name="network_error_checking_nickname">Хоч нэр шалгах явцад сүлжээний алдаа гарлаа</string>
+    <string name="checking_nickname">Хоч нэрийг шалгаж байна…</string>
     <string name="nickname_taken">Энэ хоч нэрийг аль хэдийн авсан байна — өөр нэр сонгоно уу</string>
     <string name="nickname_saved">Хоч нэр хадгалагдлаа</string>
     <string name="nickname_save_failed">Хоч нэр хадгалж чадсангүй</string>

--- a/mobile/app/src/main/res/values-my/strings.xml
+++ b/mobile/app/src/main/res/values-my/strings.xml
@@ -226,6 +226,7 @@
     <string name="register_dialog_message">ဤလုပ်ဆောင်ချက်ကို သုံးရန် သင်သည် စာရင်းသွင်းရပါမည်။ အမည်မပါ အကောင့်ဖြင့်တောင် စာရင်းသွင်းနိုင်ပါသည်။ ဆက်လက်လုပ်ဆောင်လိုပါသလား?</string>
     <string name="proceed">ရှေ့ဆက်ပါ</string>
     <string name="network_error_checking_nickname">အမည်ပြောင်စစ်ဆေးနေစဉ် ကွန်ယက်ချိုးယွင်းသည်</string>
+    <string name="checking_nickname">အမည်ပြောင်ကို စစ်ဆေးနေသည်…</string>
     <string name="nickname_taken">အမည်ပြောင်ကို တစ်စုံတယောက် အသုံးပြုနေပြီး — တစ်ခုသစ်ရွေးချယ်ပါ</string>
     <string name="nickname_saved">အမည်ပြောင်ကို သိမ်းဆည်းထားပါသည်</string>
     <string name="nickname_save_failed">အမည်ပြောင်ကို သိမ်းဆည်းရန် မအောင်မြင်ပါ။</string>

--- a/mobile/app/src/main/res/values-ne/strings.xml
+++ b/mobile/app/src/main/res/values-ne/strings.xml
@@ -236,6 +236,7 @@
     <string name="register_dialog_message">यो सुविधा प्रयोग गर्नको लागि तपाईंले आफूलाई दर्ता गर्न आवश्यक छ। तपाईं अज्ञात रूपमा पनि दर्ता गर्न सक्नुहुन्छ। के तपाईं अगाडि बढ्न चाहनुहुन्छ?</string>
     <string name="proceed">अगाडि बढ्नुहोस्</string>
     <string name="network_error_checking_nickname">नेटवर्क त्रुटि उपनाम जाँच गर्दा नेटवर्क त्रुटि</string>
+    <string name="checking_nickname">उपनाम जाँच्दै…</string>
     <string name="nickname_taken">उपनाम पहिले नै लिइएको छ - अर्को छनौट गर्नुहोस्</string>
     <string name="nickname_saved">उपनाम बचत भयो</string>
     <string name="nickname_save_failed">उपनाम बचत गर्न असफल भयो</string>

--- a/mobile/app/src/main/res/values-pl/strings.xml
+++ b/mobile/app/src/main/res/values-pl/strings.xml
@@ -237,6 +237,7 @@
     <string name="register_dialog_message">Aby korzystać z tej funkcji, musisz się zarejestrować. Możesz zarejestrować się nawet anonimowo. Czy chcesz kontynuować?</string>
     <string name="proceed">Kontynuuj</string>
     <string name="network_error_checking_nickname">Błąd sieci podczas sprawdzania pseudonimu</string>
+    <string name="checking_nickname">Sprawdzanie pseudonimu…</string>
     <string name="nickname_taken">Pseudonim już zabrany - wybierz inny</string>
     <string name="nickname_saved">Zapisany pseudonim</string>
     <string name="nickname_save_failed">Nie udało się zapisać pseudonim</string>

--- a/mobile/app/src/main/res/values-si/strings.xml
+++ b/mobile/app/src/main/res/values-si/strings.xml
@@ -226,6 +226,7 @@
     <string name="register_dialog_message">මෙම ක්‍රියාව භාවිතා කිරීමට ඔබ ලියාපදිංචි විය යුතුයි. ඔබට අනන්‍ය ලෙසවත් ලියාපදිංචි විය හැක. ඔබ ඉදිරියට යාමට කැමතිද?</string>
     <string name="proceed">ඉදිරියට යන්න</string>
     <string name="network_error_checking_nickname">අතුරු නාමය පරීක්ෂා කිරීමේදී ජාල දෝෂයක්</string>
+    <string name="checking_nickname">අතුරු නාමය පරීක්ෂා කරමින්…</string>
     <string name="nickname_taken">අතුරු නාමය දැනටමත් භාවිතයේ ඇත — වෙනත් එකක් තෝරන්න</string>
     <string name="nickname_saved">අතුරු නාමය සුරකින ලදී</string>
     <string name="nickname_save_failed">අතුරු නාමය සුරැකීමට අසමත් විය</string>

--- a/mobile/app/src/main/res/values-so/strings.xml
+++ b/mobile/app/src/main/res/values-so/strings.xml
@@ -226,6 +226,7 @@
     <string name="register_dialog_message">Si aad u isticmaasho shaqadan waa inaad isdiiwaangelisaa. Xitaa qarsoodi ayaad isku diiwaangelin kartaa. Ma rabtaa inaad sii waddo?</string>
     <string name="proceed">Sii wad</string>
     <string name="network_error_checking_nickname">Khalad shabakad ayaa dhacay marka la hubinayo naanayska</string>
+    <string name="checking_nickname">Naanayska ayaa la hubinayaa…</string>
     <string name="nickname_taken">Naanayskan hore ayaa loo qaatay — dooro mid kale</string>
     <string name="nickname_saved">Naanays waa la kaydiyay</string>
     <string name="nickname_save_failed">Ku guuldarraystay kaydinta naanayska</string>

--- a/mobile/app/src/main/res/values-sw/strings.xml
+++ b/mobile/app/src/main/res/values-sw/strings.xml
@@ -226,6 +226,7 @@
     <string name="register_dialog_message">Ili kutumia kipengele hiki unapaswa kujisajili. Unaweza hata kujisajili bila utambulisho. Unataka kuendelea?</string>
     <string name="proceed">Endelea</string>
     <string name="network_error_checking_nickname">Hitilafu ya mtandao wakati wa kukagua jina la utani</string>
+    <string name="checking_nickname">Inakagua jina la utani…</string>
     <string name="nickname_taken">Jina la utani tayari limetumika — chagua jingine</string>
     <string name="nickname_saved">Jina la utani limehifadhiwa</string>
     <string name="nickname_save_failed">Imeshindwa kuhifadhi jina la utani</string>

--- a/mobile/app/src/main/res/values-ur/strings.xml
+++ b/mobile/app/src/main/res/values-ur/strings.xml
@@ -236,6 +236,7 @@
     <string name="register_dialog_message">اس فنکشن کو استعمال کرنے کے لیے آپ کو اپنے آپ کو رجسٹر کرنے کی ضرورت ہے۔ آپ گمنام طور پر بھی رجسٹر کر سکتے ہیں۔ کیا آپ آگے بڑھنا چاہتے ہیں؟</string>
     <string name="proceed">آگے بڑھیں</string>
     <string name="network_error_checking_nickname">عرفی نام کی جانچ پڑتال کے دوران نیٹ ورک کی خرابی</string>
+    <string name="checking_nickname">عرفی نام کی جانچ جاری ہے…</string>
     <string name="nickname_taken">پہلے سے لیا گیا عرفی نام - ایک اور کا انتخاب کریں</string>
     <string name="nickname_saved">عرفی نام بچ گیا</string>
     <string name="nickname_save_failed">عرفیت کو بچانے میں ناکام</string>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -234,6 +234,7 @@
     <string name="register_dialog_message">In order to use this function you need to register yourself. You can register even anonymously. Do you want to proceed?</string>
     <string name="proceed">Proceed</string>
     <string name="network_error_checking_nickname">Network error while checking nickname</string>
+    <string name="checking_nickname">Checking nickname…</string>
     <string name="nickname_taken">Nickname already taken — choose another</string>
     <string name="nickname_saved">Nickname saved</string>
     <string name="nickname_save_failed">Failed to save nickname</string>


### PR DESCRIPTION
## Summary
- call the `checkNickname` Cloud Function before saving a nickname and handle failures
- show a progress indicator while the nickname check runs on the pick nickname screen
- add localized "Checking nickname…" strings for every supported language

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ddc81f51083309a63c867ef5ea78d)