### PR TITLE
Prevent pulse handler from continuous rescheduling

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/GameView.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/GameView.java
@@ -53,12 +53,15 @@ public class GameView extends View {
     private Long turnStartsTime;
 
     private final Handler pulseHandler = new Handler(Looper.getMainLooper());
+    private boolean pulseScheduled = false;
     private final Runnable pulseRunnable = new Runnable() {
         @Override
         public void run() {
             if (shouldPulse()) {
                 invalidate();
                 pulseHandler.postDelayed(this, 1000); // set 16 to get  ~60 FPS
+            } else {
+                pulseScheduled = false;
             }
         }
     };
@@ -342,11 +345,13 @@ public class GameView extends View {
     }
 
     private void startPulseIfNeeded() {
-        if (shouldPulse()) {
-            pulseHandler.removeCallbacks(pulseRunnable);
+        boolean shouldPulse = shouldPulse();
+        if (shouldPulse && !pulseScheduled) {
+            pulseScheduled = true;
             pulseHandler.post(pulseRunnable);
-        } else {
+        } else if (!shouldPulse && pulseScheduled) {
             pulseHandler.removeCallbacks(pulseRunnable);
+            pulseScheduled = false;
         }
     }
 


### PR DESCRIPTION
## Summary
- track when the pulse runnable is scheduled to avoid reposting it on every draw
- stop the pulse when animations are no longer needed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692220957ee0833088456d3e0383cd2a)