### PR TITLE
Align idle player sprites with ball center

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -1666,6 +1666,11 @@ public class Field {
             idleBlueCenterY = ballCenterY;
         }
 
+        // Align the idle sprite horizontally with the ball so its center matches the ball's
+        if (blueShouldBeCloser) {
+            idleBlueCenterX = ballCenterX;
+        }
+
         if (blueFrameCount > 0 && shouldDrawIdleBlue) {
             Bitmap spriteFrame = idleBluePlayerFrames[idlePlayerFrameIndex % blueFrameCount];
             if (spriteFrame != null && !spriteFrame.isRecycled()) {
@@ -1710,6 +1715,11 @@ public class Field {
         } else {
             idleRedCenterX = ballCenterX;
             idleRedCenterY = ballCenterY;
+        }
+
+        // Align the idle sprite horizontally with the ball so its center matches the ball's
+        if (redShouldBeCloser) {
+            idleRedCenterX = ballCenterX;
         }
 
         if (redFrameCount > 0 && shouldDrawIdleRed) {


### PR DESCRIPTION
## Summary
- ensure idle blue player X position aligns with the ball when positioned near it
- ensure idle red player X position aligns with the ball when positioned near it

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69223026bc9483308e44b31e2be4703f)