### PR TITLE
Preserve idle player position during kick animation

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -671,9 +671,6 @@ public class Field {
                     runRedCompleted = false;
                     runBlueCompleted = false;
                     
-                    // Reset final positions when starting new animation
-                    resetRunFinalPositions();
-                    
                     // Initialize kick animation for the moving player
                     if (canStartKick && !kickFrameSet.isEmpty() && (movingPlayer == 0 || movingPlayer == 1)) {
                         kickAnimationActive = true;


### PR DESCRIPTION
## Summary
- keep the previous sprite position when starting kick animations so idle players do not snap horizontally

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922338dae4c83308cb9bbdd2c8932e0)