### PR TITLE
Fix run animation timing after kick completion

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -1089,7 +1089,7 @@ public class Field {
         activeKickRedPlayerFrames = EMPTY_BITMAP_ARRAY;
         activeKickBluePlayerFrames = EMPTY_BITMAP_ARRAY;
 
-        // Start run animation after kick completes if it hasn't started already
+        // Start (or resync) run animation after the kick completes
         if (!runAnimationActive) {
             if (RunPlayerSprite.FRAME_DURATION_MS > 0 && elapsedSinceKickStart > 0L) {
                 int elapsedRunFrames = (int) (elapsedSinceKickStart / RunPlayerSprite.FRAME_DURATION_MS);
@@ -1100,6 +1100,10 @@ public class Field {
             int updatedDelay = Math.max(runRedDelayFrames, runBlueDelayFrames);
             runFrameLimit = runBaseFrameLimit + updatedDelay;
             runAnimationActive = true;
+            runPlayerFrameIndex = 0;
+            runPlayerLastFrameTime = referenceTime;
+        } else {
+            // Kick and run were started together; ensure run timing begins after kick
             runPlayerFrameIndex = 0;
             runPlayerLastFrameTime = referenceTime;
         }


### PR DESCRIPTION
## Summary
- resync run animation timing when the kick animation finishes
- ensure run frames start from the beginning instead of skipping ahead after kicks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69241fd2666883308108393c6a4810a4)