### PR TITLE
Allow run animation during kick playback

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -1232,6 +1232,15 @@ public class Field {
                 ? getRunFrame(blueFrames, blueFrameIndex, blueFrameCount)
                 : null;
 
+        // Avoid drawing the kicking player's run frames while the kick animation is active.
+        if (kickAnimationActive) {
+            if (runMovingPlayer == 0) {
+                redFrame = null;
+            } else if (runMovingPlayer == 1) {
+                blueFrame = null;
+            }
+        }
+
         float spriteHeight = canvas.getHeight() * flSpriteSize;
         if (spriteHeight <= 0f) {
             stopRunAnimation(now);
@@ -2008,9 +2017,11 @@ public class Field {
         kickRedFrameVisible = false;
         kickBlueFrameVisible = false;
         
-        // Draw kick animation if active, otherwise draw run animation
+        // Draw kick animation if active, but continue advancing/drawing run animation
+        // so opponent movement can start mid-kick after the configured delay.
         if (kickAnimationActive) {
             drawKickAnimation(canvas, ballState.radius);
+            drawRunAnimation(canvas, ballState.radius);
         } else {
             drawRunAnimation(canvas, ballState.radius);
         }


### PR DESCRIPTION
## Summary
- draw the run animation even while kick animation is active so delayed opponent movement becomes visible
- suppress the kicking player's run frames during kick playback to avoid double rendering

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692441b25a9c8330a3913d0739992e15)