### PR TITLE
Pause run animation during kick

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -1199,6 +1199,13 @@ public class Field {
             runPlayerLastFrameTime = now;
         }
 
+        // Pause run frame progression while the kick animation is active so that
+        // the running animation restarts from the first frame once the kick ends.
+        if (kickAnimationActive) {
+            runPlayerLastFrameTime = now;
+            return;
+        }
+
         long elapsed = now - runPlayerLastFrameTime;
         if (RunPlayerSprite.FRAME_DURATION_MS > 0 && elapsed >= RunPlayerSprite.FRAME_DURATION_MS) {
             long framesToAdvance = elapsed / RunPlayerSprite.FRAME_DURATION_MS;


### PR DESCRIPTION
## Summary
- pause run frame progression while a kick animation is active
- ensure running animation resumes from the first frame after the kick ends

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692451f7006c8330a6ad20a8d29fb34e)