### PR TITLE
Allow run animation to progress during kick

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -1199,13 +1199,6 @@ public class Field {
             runPlayerLastFrameTime = now;
         }
 
-        // Pause run frame progression while the kick animation is active so that
-        // the running animation restarts from the first frame once the kick ends.
-        if (kickAnimationActive) {
-            runPlayerLastFrameTime = now;
-            return;
-        }
-
         long elapsed = now - runPlayerLastFrameTime;
         if (RunPlayerSprite.FRAME_DURATION_MS > 0 && elapsed >= RunPlayerSprite.FRAME_DURATION_MS) {
             long framesToAdvance = elapsed / RunPlayerSprite.FRAME_DURATION_MS;


### PR DESCRIPTION
## Summary
- keep run animation progressing during kicks so delayed opponent sprites start running on schedule

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69245d3a475c833092c8b44cc81b121e)