### PR TITLE
Avoid resetting run frame timer after kick

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -1171,7 +1171,11 @@ public class Field {
             runPlayerLastFrameTime = referenceTime;
         } else {
             // Kick and run were started together; ensure run timing begins after kick
-            runPlayerLastFrameTime = referenceTime;
+            // but avoid resetting an already running timer, which can stall frame
+            // advancement if the kick finishes mid-run.
+            if (runPlayerLastFrameTime == 0L) {
+                runPlayerLastFrameTime = referenceTime;
+            }
         }
 
         kickAnimationStartTime = 0L;


### PR DESCRIPTION
## Summary
- avoid resetting the run animation timer when a kick ends if the timer is already running
- prevent stalled frame advancement during consecutive run frames

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69246205669c8330af21aa7e6455fd39)