### PR TITLE
Fix stationary player idle position during opponent run

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -1312,11 +1312,17 @@ public class Field {
         float blueCenterX = w2x(blueGridX);
         float blueCenterY = h2y(blueGridY);
 
-        // Save current sprite positions for use in idle animation
-        runFinalRedGridX = redGridX;
-        runFinalRedGridY = redGridY;
-        runFinalBlueGridX = blueGridX;
-        runFinalBlueGridY = blueGridY;
+        // Save current sprite positions for use in idle animation.
+        // Only update the player that is actually moving so the idle animation for
+        // the stationary opponent keeps using their previous position.
+        if (runMovingPlayer == 0) {
+            runFinalRedGridX = redGridX;
+            runFinalRedGridY = redGridY;
+        }
+        if (runMovingPlayer == 1) {
+            runFinalBlueGridX = blueGridX;
+            runFinalBlueGridY = blueGridY;
+        }
 
         // Calculate ball position
         float ballGridX = runStartGridX;


### PR DESCRIPTION
## Summary
- ensure run animation only updates the moving player's final grid position
- keep the stationary opponent's idle animation anchored to its last real position

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692469d600ec8330ac9a4e583501a7cb)