### PR TITLE
Align animation delays with kick cycle expectations

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -967,7 +967,7 @@ public class Field {
             return;
         }
 
-        if (kickPlayerFrameIndex < RUN_DELAY_CYCLES_FROM_KICK) {
+        if (kickPlayerFrameIndex <= RUN_DELAY_CYCLES_FROM_KICK) {
             return;
         }
 
@@ -1724,7 +1724,7 @@ public class Field {
             long now = SystemClock.uptimeMillis();
             boolean kickDelayActive = ballKickDelayFrames > 0
                     && kickAnimationActive
-                    && kickPlayerFrameIndex < ballKickDelayFrames;
+                    && kickPlayerFrameIndex <= ballKickDelayFrames;
 
             if (kickDelayActive) {
                 ballGridX = ballStartGridX;


### PR DESCRIPTION
## Summary
- delay the opponent run release until the kick animation surpasses the configured wait frame
- keep the ball stationary through the kick delay frame so movement begins on the expected cycle

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692472bb39248330a433d32c7a47c2c0)