### PR TITLE
Add debug logs for idle sprite suppression during run

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -1838,6 +1838,26 @@ public class Field {
                 || (!isBlueMoving && !isRedMoving));
         boolean shouldAdvanceIdle = shouldDrawIdleBlue || shouldDrawIdleRed;
 
+        if (!shouldDrawIdleBlue && !runBlueFrameVisible && !kickBlueFrameVisible) {
+            Log.d("TAG_Soccer", getClass().getSimpleName() + ".drawIdlePlayers: "
+                    + "Skipping idle blue; runActive=" + runActive
+                    + ", isRedMoving=" + isRedMoving
+                    + ", isBlueMoving=" + isBlueMoving
+                    + ", blueDelayActive=" + blueDelayActive
+                    + ", runPlayerFrameIndex=" + runPlayerFrameIndex
+                    + ", runFrameLimit=" + runFrameLimit);
+        }
+
+        if (!shouldDrawIdleRed && !runRedFrameVisible && !kickRedFrameVisible) {
+            Log.d("TAG_Soccer", getClass().getSimpleName() + ".drawIdlePlayers: "
+                    + "Skipping idle red; runActive=" + runActive
+                    + ", isRedMoving=" + isRedMoving
+                    + ", isBlueMoving=" + isBlueMoving
+                    + ", redDelayActive=" + redDelayActive
+                    + ", runPlayerFrameIndex=" + runPlayerFrameIndex
+                    + ", runFrameLimit=" + runFrameLimit);
+        }
+
         if (shouldAdvanceIdle) {
             long elapsed = now - idlePlayerLastFrameTime;
             if (IdlePlayerSprite.FRAME_DURATION_MS > 0 && elapsed >= IdlePlayerSprite.FRAME_DURATION_MS) {


### PR DESCRIPTION
## Summary
- add detailed debug logging when idle sprites are skipped while run animation is active to track state

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69248f3364c083308cfb11f769ecf8b1)