### PR TITLE
Prevent disappearing blue sprite during run delays

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -1828,14 +1828,16 @@ public class Field {
         boolean isBlueMoving = runActive && hasBlueRunFrames && !runBlueCompleted
                 && runPlayerFrameIndex >= runBlueDelayFrames;
 
-        boolean shouldDrawIdleBlue = !runBlueFrameVisible && !kickBlueFrameVisible && (!runActive
+        boolean shouldDrawIdleBlue = !kickBlueFrameVisible && (!runActive
                 || runBlueCompleted
                 || (isRedMoving && blueDelayActive)
-                || (!isRedMoving && !isBlueMoving));
-        boolean shouldDrawIdleRed = !runRedFrameVisible && !kickRedFrameVisible && (!runActive
+                || (!isRedMoving && !isBlueMoving)
+                || (isBlueMoving && !runBlueFrameVisible));
+        boolean shouldDrawIdleRed = !kickRedFrameVisible && (!runActive
                 || runRedCompleted
                 || (isBlueMoving && redDelayActive)
-                || (!isBlueMoving && !isRedMoving));
+                || (!isBlueMoving && !isRedMoving)
+                || (isRedMoving && !runRedFrameVisible));
         boolean shouldAdvanceIdle = shouldDrawIdleBlue || shouldDrawIdleRed;
 
         if (!shouldDrawIdleBlue && !runBlueFrameVisible && !kickBlueFrameVisible) {


### PR DESCRIPTION
## Summary
- allow idle sprites to draw when a run frame is missing so the blue player does not vanish
- mirror the fallback for both teams to keep sprites visible during run/kick transitions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692495aa4c948330aa411e4944ab8869)