### PR TITLE
Ensure run animation final positions persist

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -1361,11 +1361,11 @@ public class Field {
         // Save current sprite positions for use in idle animation.
         // Only update the player that is actually moving so the idle animation for
         // the stationary opponent keeps using their previous position.
-        if (runMovingPlayer == 0) {
+        if (redFrameIndex >= 0) {
             runFinalRedGridX = redGridX;
             runFinalRedGridY = redGridY;
         }
-        if (runMovingPlayer == 1) {
+        if (blueFrameIndex >= 0) {
             runFinalBlueGridX = blueGridX;
             runFinalBlueGridY = blueGridY;
             Log.d("TAG_Soccer", getClass().getSimpleName() + ".drawRunAnimation: "


### PR DESCRIPTION
## Summary
- update run animation bookkeeping to capture final sprite positions whenever frames advance
- keep idle animation aligned with the latest run position even when the moving player flag is inconsistent

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69256cb9767883308c1f1f72c5d3e097)