### PR TITLE
Prevent premature stop of run animation

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/Field.java
@@ -1459,11 +1459,6 @@ public class Field {
 
         if ((!redHasFrames || runRedCompleted) && (!blueHasFrames || runBlueCompleted)) {
             stopRunAnimation(now);
-            return;
-        }
-
-        if (runPlayerFrameIndex >= adjustedFrameLimit - 1) {
-            stopRunAnimation(now);
         }
     }
 


### PR DESCRIPTION
## Summary
- stop the run animation only when both players finish instead of when the frame index hits a limit to avoid idle snapping mid-run

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692586bada2c8330bf792336414185c7)