### PR TITLE
Refactor animation preference checks

### DIFF
--- a/docs/MENUACTIVITY_ANIMATION_START_FIX.md
+++ b/docs/MENUACTIVITY_ANIMATION_START_FIX.md
@@ -36,7 +36,7 @@ Modified the `runOnUiThread()` callback in `setupRunningPlayerAnimation()` to:
 2. Configure the view and click listeners
 3. **NEW**: Check if animation should start automatically:
    ```java
-   if (!isRunningPlayerAnimationStarted && areAnimationsEnabled()) {
+   if (!isRunningPlayerAnimationStarted && !areAnimationsDisabled()) {
        startRunningPlayerAnimation();
    }
    ```
@@ -63,7 +63,7 @@ runOnUiThread(() -> {
         // If activity is already started, begin animation immediately
         // This handles the case where onCreate->setupRunningPlayerAnimation starts
         // the background thread, then onStart is called before frames are loaded
-        if (!isRunningPlayerAnimationStarted && areAnimationsEnabled()) {
+        if (!isRunningPlayerAnimationStarted && !areAnimationsDisabled()) {
             startRunningPlayerAnimation();
         }
     }
@@ -88,7 +88,7 @@ runOnUiThread(() -> {
 
 1. **Consistent UX**: Animation always starts on first launch, matching user expectations
 2. **No Side Effects**: Doesn't interfere with normal operation when frames are already loaded
-3. **Respects Settings**: Still checks `areAnimationsEnabled()` before starting
+3. **Respects Settings**: Still checks the animation preference before starting
 4. **Minimal Code Change**: Single conditional check, surgical fix
 5. **Safe**: Uses existing animation start logic, no new bugs introduced
 

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -965,12 +965,12 @@ public class MenuActivity extends BaseActivity {
     }
 
     /**
-     * Helper method to check if animations are enabled in preferences
-     * @return true if animations are enabled, false otherwise
+     * Helper method to check if animations are disabled in preferences
+     * @return true if animations are disabled, false otherwise
      */
-    private boolean areAnimationsEnabled() {
+    private boolean areAnimationsDisabled() {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-        return prefs.getBoolean("animations_enabled", true);
+        return !prefs.getBoolean("animations_enabled", true);
     }
 
     /**
@@ -984,7 +984,7 @@ public class MenuActivity extends BaseActivity {
         }
         
         // Don't start if animations are disabled in settings
-        if (!areAnimationsEnabled()) {
+        if (areAnimationsDisabled()) {
             return false;
         }
         
@@ -1007,7 +1007,7 @@ public class MenuActivity extends BaseActivity {
             return;
         }
 
-        if (!areAnimationsEnabled()) {
+        if (areAnimationsDisabled()) {
             Log.d(
                     "TAG_Soccer",
                     getClass().getSimpleName() + ".setupRunningPlayerAnimation: Animations disabled in settings"
@@ -1255,7 +1255,7 @@ public class MenuActivity extends BaseActivity {
     }
 
     private void startRunningPlayerAnimation() {
-        if (!areAnimationsEnabled()) {
+        if (areAnimationsDisabled()) {
             Log.d(
                     "TAG_Soccer",
                     getClass().getSimpleName() + ".startRunningPlayerAnimation: Animations disabled in settings"
@@ -2201,7 +2201,7 @@ public class MenuActivity extends BaseActivity {
         boolean dialogShown = prefs.getBoolean(PREF_ANIMATION_INFO_SHOWN, false);
         
         // Only show dialog if it hasn't been shown before and animations are enabled
-        if (dialogShown || !areAnimationsEnabled()) {
+        if (dialogShown || areAnimationsDisabled()) {
             return;
         }
         


### PR DESCRIPTION
## Summary
- invert the animation preference helper to directly express when animations are disabled
- update animation checks to use the new helper without double-negating
- refresh documentation references to match the helper rename

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69388046080c8330bfedf0f59d8791fa)