### PR TITLE
Fix Firebase app ID selection in Cloud Build config

### DIFF
--- a/gcp/cloud-build/download_google_services.yaml
+++ b/gcp/cloud-build/download_google_services.yaml
@@ -54,7 +54,7 @@ steps:
         echo "🔍 Firebase apps output:"
         cat /workspace/apps_list.txt
 
-        app_id=$(grep ANDROID /workspace/apps_list.txt | grep -v "App ID" | awk -F '│' '{print $3}' | xargs)
+        app_id=$(grep ANDROID /workspace/apps_list.txt | grep -v "App ID" | awk -F '│' '{print $3}' | head -n 1 | xargs)
 
         if [ -z "$app_id" ]; then
           echo "❌ Firebase Android app ID not found."


### PR DESCRIPTION
### Motivation
- The build failed when multiple Android apps were returned because the script passed multiple app IDs to `firebase apps:sdkconfig`.
- The intent is to download a single `google-services.json` for the appropriate Android app rather than passing multiple IDs.

### Description
- Updated `gcp/cloud-build/download_google_services.yaml` to select only the first Android app ID using `head -n 1` in the extraction pipeline. 
- The `app_id` extraction now uses `grep ANDROID | awk -F '│' '{print $3}' | head -n 1 | xargs` to avoid concatenating multiple IDs.
- This prevents passing multiple IDs to `firebase apps:sdkconfig` and writes the downloaded config to `/workspace/google-services.json` as before.

### Testing
- No automated tests were run for this config-only change.
- The change is limited to the Cloud Build YAML step for app ID selection and does not modify application code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958e24563388330aadda5fdbc93420b)