### PR TITLE
Use dev service account key for Firestore export

### DIFF
--- a/tools/firestore-export-structure/index.js
+++ b/tools/firestore-export-structure/index.js
@@ -1,5 +1,5 @@
 const admin = require("firebase-admin");
-const serviceAccount = require("./serviceAccountKey.json");
+const serviceAccount = require("../../secrets/serviceAccountKey.dev.json");
 
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount)


### PR DESCRIPTION
### Motivation
- Make the Firestore export script load the development service account key from the central `secrets` directory instead of a local file.
- Prevent accidental use of production credentials by explicitly referencing the dev key file.
- Align the script with the repository layout where tools live under `tools/` and secrets are stored at the repo root.

### Description
- Updated `tools/firestore-export-structure/index.js` to require `../../secrets/serviceAccountKey.dev.json` instead of `./serviceAccountKey.json`.
- No other runtime or logic changes were made to the export script.
- Changes were committed with the message `Use dev service account key for firestore export`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695918ab32e88330b1ddd8eab97fae9f)