### PR TITLE
Fix Firestore clear to remove empty-doc subcollections

### DIFF
--- a/tools/copy-test-to-dev/copy-test-to-dev.js
+++ b/tools/copy-test-to-dev/copy-test-to-dev.js
@@ -22,7 +22,7 @@ const AUTH_BATCH_SIZE = 1000; // Firebase Admin SDK limit for listUsers
 /**
  * Recursively delete a document and all its subcollections
  */
-async function deleteDocumentRecursive(db, docRef) {
+async function deleteDocumentRecursive(docRef) {
   const subcollections = await docRef.listCollections();
   
   // Process all subcollections
@@ -31,7 +31,7 @@ async function deleteDocumentRecursive(db, docRef) {
     
     // Delete subcollection documents in parallel for better performance
     const deletePromises = subcollectionDocs.docs.map(doc => 
-      deleteDocumentRecursive(db, doc.ref)
+      deleteDocumentRecursive(doc.ref)
     );
     await Promise.all(deletePromises);
   }
@@ -392,16 +392,17 @@ async function main() {
       // Always clear DEV collection before copying
       console.log(`\n🗑️  Clearing DEV collection: ${collectionName}`);
       try {
-        const devSnapshot = await devDb.collection(collectionName).get();
+        const devDocRefs = await devDb.collection(collectionName).listDocuments();
         let deletedCount = 0;
+        const totalDocuments = devDocRefs.length;
         
-        for (const doc of devSnapshot.docs) {
-          await deleteDocumentRecursive(devDb, doc.ref);
+        for (const docRef of devDocRefs) {
+          await deleteDocumentRecursive(docRef);
           deletedCount++;
           
           // Log progress for every 50 documents
           if (deletedCount % 50 === 0) {
-            console.log(`   🗑️  Deleted ${deletedCount}/${devSnapshot.size} document(s)...`);
+            console.log(`   🗑️  Deleted ${deletedCount}/${totalDocuments} document(s)...`);
           }
         }
         


### PR DESCRIPTION
### Motivation

- Clearing DEV Firestore collections did not remove subcollections for documents that have no fields (empty documents), leaving leftover data behind.
- The recursive delete helper accepted an unused `db` parameter and passed it through unnecessary call sites.
- The existing clear loop used `get()` which doesn't enumerate document references for empty documents that still have subcollections.

### Description

- Simplified `deleteDocumentRecursive` by removing the unused `db` parameter and calling it with a document reference only (`docRef`).
- When clearing collections, replaced `collection(...).get()` with `collection(...).listDocuments()` to enumerate all document refs including empty documents with subcollections.
- Updated the delete loop to iterate `devDocRefs` and adjusted progress logging to use `totalDocuments` for accurate progress messages.
- Kept the Firestore copy logic unchanged so document data and subcollections are still copied recursively with `copyDocumentRecursive`.

### Testing

- No automated tests or CI jobs were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69593b73530483309b344a0eb4d297f3)