### PR TITLE
Add env and doc limit args to firestore export tool

### DIFF
--- a/tools/firestore-export-structure/exportStructure.bat
+++ b/tools/firestore-export-structure/exportStructure.bat
@@ -1,5 +1,5 @@
 @echo off
 echo Exporting Firestore structure...
-node --no-deprecation index.js
+node --no-deprecation index.js %1 %2
 echo Done.
 pause

--- a/tools/firestore-export-structure/index.js
+++ b/tools/firestore-export-structure/index.js
@@ -1,5 +1,29 @@
 const admin = require("firebase-admin");
-const serviceAccount = require("../../secrets/serviceAccountKey.dev.json");
+const path = require("path");
+
+const [envArg, limitArg] = process.argv.slice(2);
+const env = (envArg || "").toLowerCase();
+const validEnvs = ["dev", "test", "prod"];
+
+if (!validEnvs.includes(env)) {
+  console.error("Usage: node index.js <dev|test|prod> <docLimit>");
+  process.exit(1);
+}
+
+const docLimit = Number.parseInt(limitArg, 10);
+if (!Number.isInteger(docLimit) || docLimit <= 0) {
+  console.error("docLimit must be a positive integer.");
+  process.exit(1);
+}
+
+const serviceAccountPath = path.join(
+  __dirname,
+  "..",
+  "..",
+  "secrets",
+  `serviceAccountKey.${env}.json`
+);
+const serviceAccount = require(serviceAccountPath);
 
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount)
@@ -18,7 +42,7 @@ function inferType(value) {
 }
 
 async function describeCollectionRecursive(collRef, indent = "") {
-  const snapshot = await collRef.limit(2).get();
+  const snapshot = await collRef.limit(docLimit).get();
   console.log(`${indent}📁 ${collRef.path}`);
 
   if (snapshot.empty) {
@@ -46,5 +70,7 @@ async function describeCollectionRecursive(collRef, indent = "") {
   for (const collRef of topLevelCollections) {
     await describeCollectionRecursive(collRef);
   }
-  console.log("✅ Schema (based on up to 2 docs per collection) extracted.");
+  console.log(
+    `✅ Schema (based on up to ${docLimit} docs per collection) extracted.`
+  );
 })();


### PR DESCRIPTION
### Motivation
- Allow running the Firestore structure exporter against different environments and with a configurable per-collection sample size.
- Remove the hard-coded dev service account and fixed 2-document sample size.

### Description
- Parse CLI arguments for environment and document limit (`process.argv`) and validate `env` against `dev|test|prod` and `docLimit` as a positive integer.
- Resolve the service account file from `secrets/serviceAccountKey.<env>.json` and initialize `firebase-admin` with it.
- Replace the hard-coded `2` document limit with `docLimit` when calling `collRef.limit(...)` and update the summary message to show the limit.
- Update `exportStructure.bat` to forward the two arguments (`%1 %2`) to `node index.js`.

### Testing
- No automated tests were run for these changes.
- Basic sanity checks were performed during development (script argument validation will error on invalid input).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695946817e888330a59eca076066df76)