### PR TITLE
Align copy-test-to-dev script with prod-to-test logic

### DIFF
--- a/tools/copy-test-to-dev/copy-test-to-dev.js
+++ b/tools/copy-test-to-dev/copy-test-to-dev.js
@@ -19,88 +19,227 @@ const RTDB_PATHS = ['status'];
 // Batch size for authentication user operations
 const AUTH_BATCH_SIZE = 1000; // Firebase Admin SDK limit for listUsers
 
+function formatDuration(ms) {
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+
+  const seconds = ms / 1000;
+  if (seconds < 60) {
+    return `${seconds.toFixed(2)}s`;
+  }
+
+  const minutes = Math.floor(seconds / 60);
+  const remainder = (seconds % 60).toFixed(2);
+  return `${minutes}m ${remainder}s`;
+}
+
+function isRetryableFirestoreError(error) {
+  if (!error) {
+    return false;
+  }
+
+  const message = String(error.message || '').toLowerCase();
+  const retryableMessages = [
+    'total timeout of api',
+    'deadline exceeded',
+    'deadline-exceeded',
+    'etimedout',
+    'econnreset',
+    'unavailable',
+    'resource exhausted',
+    'too many requests',
+  ];
+
+  if (retryableMessages.some(text => message.includes(text))) {
+    return true;
+  }
+
+  const retryableCodes = new Set([4, 8, 13, 14, 429]);
+  if (retryableCodes.has(error.code)) {
+    return true;
+  }
+
+  return false;
+}
+
 /**
- * Recursively delete a document and all its subcollections
+ * Recursively delete a document and all its subcollections using BulkWriter
  */
-async function deleteDocumentRecursive(docRef) {
+async function deleteDocumentRecursive(docRef, bulkWriter) {
+  let deletedDocs = 1;
+  let subcollectionsCount = 0;
   const subcollections = await docRef.listCollections();
+  subcollectionsCount += subcollections.length;
 
   // Process all subcollections
   for (const subcollection of subcollections) {
     const subcollectionDocs = await subcollection.get();
 
     for (const doc of subcollectionDocs.docs) {
-      await deleteDocumentRecursive(doc.ref);
+      const result = await deleteDocumentRecursive(doc.ref, bulkWriter);
+      deletedDocs += result.documents;
+      subcollectionsCount += result.subcollections;
     }
   }
 
-  // Delete the document itself
-  await docRef.delete();
+  // Delete the document itself using BulkWriter
+  bulkWriter.delete(docRef);
+
+  return { documents: deletedDocs, subcollections: subcollectionsCount };
 }
 
 /**
- * Recursively copy a document and all its subcollections
+ * Recursively copy a document and all its subcollections using BulkWriter
  */
-async function copyDocumentRecursive(sourceDocRef, targetDocRef) {
+async function copyDocumentRecursive(sourceDocRef, targetDocRef, bulkWriter) {
+  let copiedDocs = 0;
+  let subcollectionsCount = 0;
   // Copy the document data
   const sourceDoc = await sourceDocRef.get();
   if (sourceDoc.exists) {
-    await targetDocRef.set(sourceDoc.data());
+    bulkWriter.set(targetDocRef, sourceDoc.data());
+    copiedDocs = 1;
   }
-  
+
   // Copy all subcollections
   const subcollections = await sourceDocRef.listCollections();
+  subcollectionsCount += subcollections.length;
   for (const subcollection of subcollections) {
     const subcollectionDocs = await subcollection.get();
     for (const doc of subcollectionDocs.docs) {
       const targetSubcollectionDocRef = targetDocRef.collection(subcollection.id).doc(doc.id);
-      await copyDocumentRecursive(doc.ref, targetSubcollectionDocRef);
+      const result = await copyDocumentRecursive(doc.ref, targetSubcollectionDocRef, bulkWriter);
+      copiedDocs += result.documents;
+      subcollectionsCount += result.subcollections;
     }
   }
+
+  return { documents: copiedDocs, subcollections: subcollectionsCount };
 }
 
 /**
- * Copy all documents from a Firestore collection
+ * Process batch results sequentially to avoid race conditions
+ * @param {Array} results - Array of result objects from Promise.all
+ * @param {number} successCounter - Current success count
+ * @param {number} failedCounter - Current failed count
+ * @param {Array} failedDocs - Array to store failed document information
+ * @param {string} operationType - Type of operation (e.g., 'copying', 'deleting')
+ * @returns {Object} Updated counts { successCount, failedCount }
+ */
+function processBatchResults(results, successCounter, failedCounter, failedDocs, operationType) {
+  let newSuccessCount = successCounter;
+  let newFailedCount = failedCounter;
+  
+  for (const result of results) {
+    if (result.success) {
+      newSuccessCount++;
+    } else {
+      console.error(`   ❌ Error ${operationType} document ${result.docId}:`, result.error.message);
+      failedDocs.push({ id: result.docId, message: result.error.message });
+      newFailedCount++;
+    }
+  }
+  
+  return { successCount: newSuccessCount, failedCount: newFailedCount };
+}
+
+/**
+ * Create and configure a BulkWriter with retry logic
+ * @param {FirebaseFirestore.Firestore} db - Firestore database instance
+ * @returns {FirebaseFirestore.BulkWriter} Configured BulkWriter instance
+ */
+function createConfiguredBulkWriter(db) {
+  const bulkWriter = db.bulkWriter();
+  
+  // Configure BulkWriter to handle retryable errors
+  bulkWriter.onWriteError((error) => {
+    if (isRetryableFirestoreError(error.error)) {
+      return true; // Retry
+    }
+    return false; // Don't retry
+  });
+  
+  return bulkWriter;
+}
+
+/**
+ * Copy all documents from a Firestore collection using BulkWriter
  */
 async function copyFirestoreCollection(sourceDb, targetDb, collectionName) {
   console.log(`\n📦 Copying Firestore collection: ${collectionName}`);
   
   try {
+    const collectionStart = Date.now();
+    const fetchStart = Date.now();
     const sourceSnapshot = await sourceDb.collection(collectionName).get();
+    const fetchDuration = Date.now() - fetchStart;
     
     if (sourceSnapshot.empty) {
-      console.log(`   ℹ️  Collection '${collectionName}' is empty in TEST`);
+      console.log(`   ℹ️  Collection '${collectionName}' is empty in TEST (${formatDuration(fetchDuration)} to read)`);
       return { success: 0, skipped: 0, failed: 0 };
     }
     
     console.log(`   📊 Found ${sourceSnapshot.size} document(s) in TEST`);
+    console.log(`   ⏱️  Read collection in ${formatDuration(fetchDuration)}`);
     
+    // Create a BulkWriter for efficient batch operations
+    const bulkWriter = createConfiguredBulkWriter(targetDb);
+
     let successCount = 0;
     let failedCount = 0;
-    
-    // Copy each document recursively (including subcollections)
-    for (const doc of sourceSnapshot.docs) {
-      try {
-        const sourceDocRef = sourceDb.collection(collectionName).doc(doc.id);
-        const targetDocRef = targetDb.collection(collectionName).doc(doc.id);
+    const failedDocs = [];
+
+    // Process documents in parallel batches for better performance
+    const PARALLEL_BATCH_SIZE = 50;
+    const docPromises = [];
+
+    for (let i = 0; i < sourceSnapshot.docs.length; i++) {
+      const doc = sourceSnapshot.docs[i];
+      const sourceDocRef = sourceDb.collection(collectionName).doc(doc.id);
+      const targetDocRef = targetDb.collection(collectionName).doc(doc.id);
+
+      const promise = copyDocumentRecursive(sourceDocRef, targetDocRef, bulkWriter)
+        .then(copyResult => {
+          return { success: true, copyResult, docId: doc.id };
+        })
+        .catch(error => {
+          return { success: false, error, docId: doc.id };
+        });
+
+      docPromises.push(promise);
+
+      // Process in batches to avoid overwhelming the system
+      if (docPromises.length >= PARALLEL_BATCH_SIZE || i === sourceSnapshot.docs.length - 1) {
+        const results = await Promise.all(docPromises);
+        const counts = processBatchResults(results, successCount, failedCount, failedDocs, 'copying');
+        successCount = counts.successCount;
+        failedCount = counts.failedCount;
         
-        await copyDocumentRecursive(sourceDocRef, targetDocRef);
-        successCount++;
-        
-        // Log progress for every 50 documents
-        if (successCount % 50 === 0) {
+        // Log progress every PARALLEL_BATCH_SIZE documents
+        if (successCount > 0 && (successCount % PARALLEL_BATCH_SIZE === 0 || successCount + failedCount === sourceSnapshot.size)) {
           console.log(`   📝 Copied ${successCount}/${sourceSnapshot.size} document(s)...`);
         }
-      } catch (error) {
-        console.error(`   ❌ Error copying document ${doc.id}:`, error.message);
-        failedCount++;
+        
+        docPromises.length = 0; // Clear the array
       }
     }
-    
+
+    // Close the BulkWriter and wait for all operations to complete
+    console.log(`   🔄 Committing all writes...`);
+    await bulkWriter.close();
+
     console.log(`   ✅ Successfully copied ${successCount} document(s) with subcollections`);
     if (failedCount > 0) {
       console.log(`   ⚠️  Failed to copy ${failedCount} document(s)`);
+      failedDocs.forEach(failure => {
+        console.log(`      ❌ ${failure.id}: ${failure.message}`);
+      });
     }
+
+    const collectionDuration = Date.now() - collectionStart;
+    const averageDuration = successCount > 0 ? collectionDuration / successCount : 0;
+    console.log(`   ⏱️  Collection copy time: ${formatDuration(collectionDuration)} (avg ${formatDuration(Math.round(averageDuration))}/doc)`);
     
     return { success: successCount, failed: failedCount };
   } catch (error) {
@@ -110,24 +249,29 @@ async function copyFirestoreCollection(sourceDb, targetDb, collectionName) {
 }
 
 /**
- * Clear all documents (and their subcollections) from a Firestore collection
+ * Clear all documents (and their subcollections) from a Firestore collection using BulkWriter
  */
 async function clearFirestoreCollection(targetDb, collectionName) {
   console.log(`\n🗑️  Clearing DEV collection: ${collectionName}`);
 
   const collectionRef = targetDb.collection(collectionName);
+
   let deletedCount = 0;
   let failedCount = 0;
-  let lastDoc = null;
+  const failedDocs = [];
+  const clearStart = Date.now();
 
+  // Process documents in parallel batches
+  const PARALLEL_BATCH_SIZE = 50;
+
+  // Keep deleting until no more documents are found
+  // Always query from the beginning to avoid pagination issues when deleting.
+  // Using cursor-based pagination (startAfter) while deleting causes document skipping
+  // because document positions shift as deletions occur, resulting in incomplete clearing.
   while (true) {
-    let query = collectionRef
+    const query = collectionRef
       .orderBy(admin.firestore.FieldPath.documentId())
       .limit(200);
-
-    if (lastDoc) {
-      query = query.startAfter(lastDoc);
-    }
 
     const snapshot = await query.get();
 
@@ -135,29 +279,168 @@ async function clearFirestoreCollection(targetDb, collectionName) {
       break;
     }
 
-    for (const doc of snapshot.docs) {
-      try {
-        await deleteDocumentRecursive(doc.ref);
-        deletedCount++;
+    // Create a new BulkWriter for each batch to ensure clean state.
+    // We must commit all deletions before querying again to prevent re-reading
+    // documents that should have been deleted, so we create a fresh BulkWriter
+    // for each iteration after closing the previous one.
+    const bulkWriter = createConfiguredBulkWriter(targetDb);
 
-        // Log progress for every 50 documents
-        if (deletedCount % 50 === 0) {
+    const docPromises = [];
+    for (const doc of snapshot.docs) {
+      const promise = deleteDocumentRecursive(doc.ref, bulkWriter)
+        .then(deleteResult => {
+          return { success: true, deleteResult, docId: doc.id };
+        })
+        .catch(error => {
+          return { success: false, error, docId: doc.id };
+        });
+
+      docPromises.push(promise);
+
+      // Process in batches to avoid overwhelming the system
+      if (docPromises.length >= PARALLEL_BATCH_SIZE) {
+        const results = await Promise.all(docPromises);
+        const counts = processBatchResults(results, deletedCount, failedCount, failedDocs, 'deleting');
+        deletedCount = counts.successCount;
+        failedCount = counts.failedCount;
+        
+        // Log progress every PARALLEL_BATCH_SIZE documents
+        if (deletedCount > 0 && deletedCount % PARALLEL_BATCH_SIZE === 0) {
           console.log(`   🗑️  Deleted ${deletedCount} document(s)...`);
         }
-      } catch (error) {
-        console.error(`   ❌ Error deleting document ${doc.id}:`, error.message);
-        failedCount++;
+        
+        docPromises.length = 0; // Clear the array
       }
     }
 
-    lastDoc = snapshot.docs[snapshot.docs.length - 1];
+    // Wait for remaining promises in this batch
+    if (docPromises.length > 0) {
+      const results = await Promise.all(docPromises);
+      const counts = processBatchResults(results, deletedCount, failedCount, failedDocs, 'deleting');
+      deletedCount = counts.successCount;
+      failedCount = counts.failedCount;
+    }
+
+    // Close the BulkWriter and commit all pending deletions before querying again
+    console.log(`   🔄 Committing batch deletions...`);
+    await bulkWriter.close();
   }
 
   console.log(`   ✅ Cleared ${deletedCount} document(s) with subcollections from DEV`);
   if (failedCount > 0) {
     console.log(`   ⚠️  Failed to delete ${failedCount} document(s)`);
+    failedDocs.forEach(failure => {
+      console.log(`      ❌ ${failure.id}: ${failure.message}`);
+    });
   }
 
+  const clearDuration = Date.now() - clearStart;
+  console.log(`   ⏱️  Collection clear time: ${formatDuration(clearDuration)} (avg ${formatDuration(Math.round(clearDuration / Math.max(1, deletedCount)))} /doc)`);
+
+  return { deleted: deletedCount, failed: failedCount };
+}
+
+/**
+ * Clear entire Firestore database by recursively deleting all collections
+ * This is more thorough than clearing individual collections as it also
+ * handles phantom documents (documents that don't exist but have subcollections)
+ */
+async function clearEntireFirestoreDatabase(targetDb) {
+  console.log('\n🗑️  Clearing ENTIRE DEV Firestore database');
+  console.log('   ⚠️  This will delete ALL collections and subcollections\n');
+
+  const clearStart = Date.now();
+  let totalDeleted = 0;
+  let totalFailed = 0;
+
+  try {
+    // List all root-level collections
+    const collections = await targetDb.listCollections();
+    console.log(`   📊 Found ${collections.length} root-level collection(s) in DEV`);
+
+    for (const collection of collections) {
+      console.log(`\n   🗑️  Clearing collection: ${collection.id}`);
+      const result = await clearFirestoreCollectionRecursive(targetDb, collection.id);
+      totalDeleted += result.deleted;
+      totalFailed += result.failed;
+    }
+
+    const clearDuration = Date.now() - clearStart;
+    console.log(`\n   ✅ Database clear complete: ${totalDeleted} document(s) deleted`);
+    if (totalFailed > 0) {
+      console.log(`   ⚠️  Failed to delete ${totalFailed} document(s)`);
+    }
+    console.log(`   ⏱️  Total clear time: ${formatDuration(clearDuration)}`);
+
+    return { deleted: totalDeleted, failed: totalFailed };
+  } catch (error) {
+    console.error(`   ❌ Error clearing database:`, error.message);
+    return { deleted: totalDeleted, failed: totalFailed, error: error.message };
+  }
+}
+
+/**
+ * Recursively clear all documents in a collection, including phantom documents with subcollections
+ */
+async function clearFirestoreCollectionRecursive(targetDb, collectionPath) {
+  let deletedCount = 0;
+  let failedCount = 0;
+  const PARALLEL_BATCH_SIZE = 50;
+
+  while (true) {
+    const collectionRef = targetDb.collection(collectionPath);
+    const query = collectionRef
+      .orderBy(admin.firestore.FieldPath.documentId())
+      .limit(200);
+
+    const snapshot = await query.get();
+
+    if (snapshot.empty) {
+      break;
+    }
+
+    const bulkWriter = createConfiguredBulkWriter(targetDb);
+    const docPromises = [];
+    const failedDocs = [];
+
+    for (const doc of snapshot.docs) {
+      const promise = deleteDocumentRecursive(doc.ref, bulkWriter)
+        .then(deleteResult => {
+          return { success: true, deleteResult, docId: doc.id };
+        })
+        .catch(error => {
+          return { success: false, error, docId: doc.id };
+        });
+
+      docPromises.push(promise);
+
+      if (docPromises.length >= PARALLEL_BATCH_SIZE) {
+        const results = await Promise.all(docPromises);
+        const counts = processBatchResults(results, deletedCount, failedCount, failedDocs, 'deleting');
+        deletedCount = counts.successCount;
+        failedCount = counts.failedCount;
+        
+        if (deletedCount > 0 && deletedCount % PARALLEL_BATCH_SIZE === 0) {
+          console.log(`      🗑️  Deleted ${deletedCount} document(s)...`);
+        }
+        
+        docPromises.length = 0;
+      }
+    }
+
+    if (docPromises.length > 0) {
+      const results = await Promise.all(docPromises);
+      const counts = processBatchResults(results, deletedCount, failedCount, failedDocs, 'deleting');
+      deletedCount = counts.successCount;
+      failedCount = counts.failedCount;
+    }
+
+    console.log(`      🔄 Committing batch deletions...`);
+    await bulkWriter.close();
+  }
+
+  console.log(`      ✅ Deleted ${deletedCount} document(s) from ${collectionPath}`);
+  
   return { deleted: deletedCount, failed: failedCount };
 }
 
@@ -367,11 +650,18 @@ async function main() {
   
   // Check for dry-run flag
   const dryRun = args.includes('--dry-run');
+  const clearTarget = args.includes('--clear-target');
+  const clearDatabase = args.includes('--clear-database');
   
   if (dryRun) {
     console.log('🔍 DRY RUN MODE - No data will be written to DEV\n');
-  } else {
-    console.log('⚠️  CLEAR AND COPY MODE - Existing data in DEV will be deleted before copying\n');
+  }
+  
+  if (clearDatabase && !dryRun) {
+    console.log('⚠️  CLEAR DATABASE MODE - ALL data in DEV Firestore will be deleted first\n');
+    console.log('   This is more thorough than --clear-target as it handles phantom documents\n');
+  } else if (clearTarget && !dryRun) {
+    console.log('⚠️  CLEAR TARGET MODE - Existing data in DEV will be deleted first\n');
   }
   
   // Load service account keys
@@ -422,6 +712,21 @@ async function main() {
     authentication: {}
   };
   
+  // Clear entire Firestore database if requested
+  if (clearDatabase && !dryRun) {
+    console.log('\n' + '='.repeat(60));
+    console.log('CLEARING ENTIRE FIRESTORE DATABASE');
+    console.log('='.repeat(60));
+    
+    try {
+      const clearResult = await clearEntireFirestoreDatabase(devDb);
+      results.databaseClear = clearResult;
+    } catch (error) {
+      console.error('   ❌ Error clearing database:', error.message);
+      results.databaseClear = { error: error.message };
+    }
+  }
+  
   // Copy Firestore collections
   console.log('\n' + '='.repeat(60));
   console.log('FIRESTORE COLLECTIONS');
@@ -439,11 +744,13 @@ async function main() {
         results.firestore[collectionName] = { error: error.message };
       }
     } else {
-      // Always clear DEV collection before copying
-      try {
-        await clearFirestoreCollection(devDb, collectionName);
-      } catch (error) {
-        console.error(`   ⚠️  Error clearing collection:`, error.message);
+      // Only clear individual collections if not using --clear-database
+      if (clearTarget && !clearDatabase) {
+        try {
+          await clearFirestoreCollection(devDb, collectionName);
+        } catch (error) {
+          console.error(`   ⚠️  Error clearing collection:`, error.message);
+        }
       }
       
       results.firestore[collectionName] = await copyFirestoreCollection(
@@ -478,13 +785,14 @@ async function main() {
         results.rtdb[pathName] = { error: error.message };
       }
     } else {
-      // Always clear DEV RTDB path before copying
-      console.log(`\n🗑️  Clearing DEV RTDB path: ${pathName}`);
-      try {
-        await devRtdb.ref(pathName).remove();
-        console.log(`   ✅ Cleared path from DEV`);
-      } catch (error) {
-        console.error(`   ⚠️  Error clearing path:`, error.message);
+      if (clearTarget || clearDatabase) {
+        console.log(`\n🗑️  Clearing DEV RTDB path: ${pathName}`);
+        try {
+          await devRtdb.ref(pathName).remove();
+          console.log(`   ✅ Cleared path from DEV`);
+        } catch (error) {
+          console.error(`   ⚠️  Error clearing path:`, error.message);
+        }
       }
       
       results.rtdb[pathName] = await copyRtdbPath(testRtdb, devRtdb, pathName);
@@ -514,8 +822,9 @@ async function main() {
       results.authentication.users = { error: error.message };
     }
   } else {
-    // Always clear DEV Authentication users before copying
-    results.authentication.cleared = await clearAuthenticationUsers(devAuth);
+    if (clearTarget || clearDatabase) {
+      results.authentication.cleared = await clearAuthenticationUsers(devAuth);
+    }
     
     results.authentication.users = await copyAuthenticationUsers(testAuth, devAuth);
   }
@@ -524,6 +833,18 @@ async function main() {
   console.log('\n' + '='.repeat(60));
   console.log('SUMMARY');
   console.log('='.repeat(60));
+  
+  if (results.databaseClear) {
+    console.log('\nDatabase Clear:');
+    if (results.databaseClear.error) {
+      console.log(`  ❌ Error - ${results.databaseClear.error}`);
+    } else {
+      console.log(`  🗑️  Deleted ${results.databaseClear.deleted} document(s) from entire database`);
+      if (results.databaseClear.failed > 0) {
+        console.log(`     ⚠️  Failed to delete ${results.databaseClear.failed} document(s)`);
+      }
+    }
+  }
   
   console.log('\nFirestore Collections:');
   for (const [collection, result] of Object.entries(results.firestore)) {


### PR DESCRIPTION
### Motivation

- Bring the TEST→DEV migration script in line with the PROD→TEST implementation to ensure consistent behavior and reliability when copying environments.
- Improve Firestore copy/delete performance and robustness for large datasets by using `BulkWriter` and retry handling.
- Provide explicit modes for clearing target data and for full database clears to avoid partial/deferred deletions.

### Description

- Ported BulkWriter-based Firestore copy and delete logic and updated recursive functions to `deleteDocumentRecursive(..., bulkWriter)` and `copyDocumentRecursive(..., bulkWriter)` to use `bulkWriter` for writes and deletes.
- Added utility helpers `formatDuration`, `isRetryableFirestoreError`, `createConfiguredBulkWriter`, and `processBatchResults` plus batched parallel processing (`PARALLEL_BATCH_SIZE`) and timing/logging around collection operations.
- Introduced `--clear-target` and `--clear-database` flag handling and implemented `clearEntireFirestoreDatabase` and `clearFirestoreCollectionRecursive` for thorough clearing with improved progress and summary reporting.
- Updated RTDB and Authentication flows to honor clear flags and improved DRY RUN reporting and summaries.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a421181c0833084ba2970fba765a7)