### PR TITLE
Align copy-test-to-dev Firestore cleanup logic with prod-to-test

### DIFF
--- a/tools/copy-test-to-dev/copy-test-to-dev.js
+++ b/tools/copy-test-to-dev/copy-test-to-dev.js
@@ -65,9 +65,12 @@ function isRetryableFirestoreError(error) {
 
 /**
  * Recursively delete a document and all its subcollections using BulkWriter
+ * Note: This function does not check if the document exists before deletion.
+ * For phantom documents (non-existent documents with subcollections), the document
+ * deletion is a no-op, but subcollections are still deleted.
  */
 async function deleteDocumentRecursive(docRef, bulkWriter) {
-  let deletedDocs = 1;
+  let deletedDocs = 1; // Count this document (will be no-op if phantom)
   let subcollectionsCount = 0;
   const subcollections = await docRef.listCollections();
   subcollectionsCount += subcollections.length;
@@ -386,34 +389,45 @@ async function clearFirestoreCollectionRecursive(targetDb, collectionPath) {
   let deletedCount = 0;
   let failedCount = 0;
   const PARALLEL_BATCH_SIZE = 50;
+  const BATCH_SIZE = 200;
 
+  // Use listDocuments() instead of get() to include phantom documents
+  // listDocuments() returns references to all documents, including those that don't exist
+  // We loop until no more documents are found, processing in batches
+  // Note: listDocuments() returns ALL document refs, but we process only BATCH_SIZE at a time
+  // to avoid overwhelming memory/network. After committing deletions, the next iteration
+  // will get the remaining documents (deleted ones won't be returned anymore).
   while (true) {
     const collectionRef = targetDb.collection(collectionPath);
-    const query = collectionRef
-      .orderBy(admin.firestore.FieldPath.documentId())
-      .limit(200);
-
-    const snapshot = await query.get();
-
-    if (snapshot.empty) {
+    
+    // Get document references (this includes phantoms)
+    // After deletions are committed, the next call should return remaining documents
+    const documentRefs = await collectionRef.listDocuments();
+    
+    if (documentRefs.length === 0) {
       break;
     }
 
     const bulkWriter = createConfiguredBulkWriter(targetDb);
     const docPromises = [];
     const failedDocs = [];
+    
+    // Process up to BATCH_SIZE documents in this iteration
+    // After we commit deletions, next iteration will get remaining documents
+    const refsToProcess = documentRefs.slice(0, BATCH_SIZE);
 
-    for (const doc of snapshot.docs) {
-      const promise = deleteDocumentRecursive(doc.ref, bulkWriter)
+    for (const docRef of refsToProcess) {
+      const promise = deleteDocumentRecursive(docRef, bulkWriter)
         .then(deleteResult => {
-          return { success: true, deleteResult, docId: doc.id };
+          return { success: true, deleteResult, docId: docRef.id };
         })
         .catch(error => {
-          return { success: false, error, docId: doc.id };
+          return { success: false, error, docId: docRef.id };
         });
 
       docPromises.push(promise);
 
+      // Process in smaller parallel batches for better performance
       if (docPromises.length >= PARALLEL_BATCH_SIZE) {
         const results = await Promise.all(docPromises);
         const counts = processBatchResults(results, deletedCount, failedCount, failedDocs, 'deleting');
@@ -428,6 +442,7 @@ async function clearFirestoreCollectionRecursive(targetDb, collectionPath) {
       }
     }
 
+    // Process any remaining promises in this batch
     if (docPromises.length > 0) {
       const results = await Promise.all(docPromises);
       const counts = processBatchResults(results, deletedCount, failedCount, failedDocs, 'deleting');
@@ -435,6 +450,8 @@ async function clearFirestoreCollectionRecursive(targetDb, collectionPath) {
       failedCount = counts.failedCount;
     }
 
+    // Commit all deletions before next iteration
+    // This ensures deleted documents won't appear in the next listDocuments() call
     console.log(`      🔄 Committing batch deletions...`);
     await bulkWriter.close();
   }


### PR DESCRIPTION
### Motivation
- Ensure `copy-test-to-dev` uses the same robust Firestore cleanup behavior as `copy-prod-to-test` to handle phantom documents and avoid skipping deletions.
- Prevent incomplete collection clears caused by cursor-based pagination while deleting documents.
- Improve reliability when deleting documents with nested subcollections and when documents do not exist but have subcollections.

### Description
- Updated `tools/copy-test-to-dev/copy-test-to-dev.js` to add phantom-document notes to `deleteDocumentRecursive` and to count the document deletion as a no-op when the doc is phantom.
- Reworked `clearFirestoreCollectionRecursive` to use `listDocuments()` with a `BATCH_SIZE` and process slices of document refs, committing deletions between iterations to avoid re-reading deleted docs.
- Kept parallel processing with `PARALLEL_BATCH_SIZE` and preserved existing `BulkWriter` retry handling via `createConfiguredBulkWriter`.
- Adjusted logging and doc ID handling to use the `docRef` references when deleting via `listDocuments()`.

### Testing
- No automated tests were run for this change.
- Changes were committed and staged in the repository (`tools/copy-test-to-dev/copy-test-to-dev.js`).
- Manual verification is recommended in a safe environment before running against production-like projects.
- No test failures recorded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a53104e04833087be3387e074adaa)