### PR TITLE
Fix Firebase SHA copy app ID lookup fallback

### DIFF
--- a/gcp/cloud-build/copy-sha-certificates.sh
+++ b/gcp/cloud-build/copy-sha-certificates.sh
@@ -25,14 +25,42 @@ echo "$apps_response" > /tmp/apps_response.json
 global_app_id=""
 echo "🔍 Searching for global app ID..."
 
+# Helper to get app ID for a package name
+get_app_id_for_package() {
+  local package_name="$1"
+
+  if command -v jq >/dev/null 2>&1; then
+    echo "$apps_response" | jq -r ".apps[] | select(.packageName == \"$package_name\") | .appId" 2>/dev/null || true
+    return
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$package_name" <<'PY' <<<"$apps_response"
+import json
+import sys
+
+package = sys.argv[1]
+data = json.load(sys.stdin)
+apps = data.get("apps") or data.get("result") or []
+for app in apps:
+    if app.get("packageName") == package:
+        app_id = app.get("appId") or ""
+        if not app_id and app.get("name"):
+            app_id = app["name"].split("/")[-1]
+        if app_id:
+            print(app_id)
+            break
+PY
+    return
+  fi
+
+  # Fallback without jq/python3 - extract app ID for the package
+  echo "$apps_response" | grep -A 5 "\"packageName\"[[:space:]]*:[[:space:]]*\"$package_name\"" | grep -oE '"appId"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | grep -oE '"[^"]*"$' | tr -d '"' || true
+}
+
 # Parse JSON to find app ID for global package
 # The response format is: "apps": [{"name": "projects/.../androidApps/APP_ID", "packageName": "..."}]
-if command -v jq >/dev/null 2>&1; then
-  global_app_id=$(echo "$apps_response" | jq -r ".apps[] | select(.packageName == \"$global_package_name\") | .appId" 2>/dev/null || true)
-else
-  # Fallback without jq - extract app ID for the global package
-  global_app_id=$(echo "$apps_response" | grep -A 5 "\"packageName\"[[:space:]]*:[[:space:]]*\"$global_package_name\"" | grep -oE '"appId"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | grep -oE '"[^"]*"$' | tr -d '"' || true)
-fi
+global_app_id=$(get_app_id_for_package "$global_package_name")
 
 if [ -z "$global_app_id" ]; then
   echo "⚠️  Could not find app ID for global package: $global_package_name"
@@ -90,11 +118,7 @@ if echo "$sha_response" | grep -q '"certificates"'; then
     retry_delay=5  # Start with 5 seconds
     
     while [ $retry_count -le $max_retries ]; do
-      if command -v jq >/dev/null 2>&1; then
-        target_app_id=$(echo "$apps_response" | jq -r ".apps[] | select(.packageName == \"$package_name\") | .appId" 2>/dev/null || true)
-      else
-        target_app_id=$(echo "$apps_response" | grep -A 5 "\"packageName\"[[:space:]]*:[[:space:]]*\"$package_name\"" | grep -oE '"appId"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | grep -oE '"[^"]*"$' | tr -d '"' || true)
-      fi
+      target_app_id=$(get_app_id_for_package "$package_name")
       
       # If we found the app ID, break out of retry loop
       if [ -n "$target_app_id" ]; then


### PR DESCRIPTION
### Motivation
- SHA certificates were not being copied because the script sometimes failed to resolve Firebase Android app IDs when `jq` was not available or `appId` was present only inside the resource `name` field.
- Newly-created apps could also be missed due to insufficient retry/lookup robustness, causing the copy step to skip target variants.
- The goal is to make app ID resolution more reliable so SHA-1/256 fingerprints from the global package are copied to all variants automatically.

### Description
- Added a helper function `get_app_id_for_package()` to `gcp/cloud-build/copy-sha-certificates.sh` that tries `jq`, then a `python3` JSON parsing fallback, and finally a `grep` fallback for app ID lookup.
- The helper extracts `appId` either from `.appId` or by splitting the `name` field when `appId` is missing, and prints the resolved ID.
- Replaced the previous inline lookup calls with `get_app_id_for_package` for both the global app lookup and the target app lookup inside the retry/refetch loop to handle API propagation delays.
- Changes applied to `gcp/cloud-build/copy-sha-certificates.sh` to improve reliability of the SHA certificate copy step.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963e5377a848330874162f17959d698)