### PR TITLE
Fix app ID lookup in SHA-copy script for compact Firebase JSON

### DIFF
--- a/gcp/cloud-build/copy-sha-certificates.sh
+++ b/gcp/cloud-build/copy-sha-certificates.sh
@@ -55,7 +55,23 @@ PY
   fi
 
   # Fallback without jq/python3 - extract app ID for the package
-  echo "$apps_response" | grep -A 5 "\"packageName\"[[:space:]]*:[[:space:]]*\"$package_name\"" | grep -oE '"appId"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | grep -oE '"[^"]*"$' | tr -d '"' || true
+  # Normalize JSON into one object per line to handle compact responses
+  app_block=$(echo "$apps_response" | tr '{' '\n' | tr '}' '\n' | grep -F "\"packageName\":\"$package_name\"" | head -1 || true)
+
+  if [ -z "$app_block" ]; then
+    return
+  fi
+
+  app_id=$(echo "$app_block" | grep -oE '"appId"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*"appId"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')
+  if [ -n "$app_id" ]; then
+    echo "$app_id"
+    return
+  fi
+
+  name_id=$(echo "$app_block" | grep -oE '"name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*"name"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/' | awk -F'/' '{print $NF}')
+  if [ -n "$name_id" ]; then
+    echo "$name_id"
+  fi
 }
 
 # Parse JSON to find app ID for global package


### PR DESCRIPTION
### Motivation
- The SHA-copy script (`gcp/cloud-build/copy-sha-certificates.sh`) failed to locate the global app ID when the Firebase API returned compact/condensed JSON, causing SHA certificates not to be copied to app variants. 
- The existing fallback relied on context-sensitive `grep` windows that missed tightly-packed JSON blocks. 
- The script must work even when `jq` or `python3` are not available in the runtime environment. 

### Description
- Improved the fallback parsing in `get_app_id_for_package` by normalizing the API response into per-object blocks and locating the block that contains the matching `packageName`. 
- Extracts the app identifier from either the `appId` field or the trailing segment of the `name` field if `appId` is not present. 
- Returns the found app ID (or nothing) so the rest of the script can proceed or skip appropriately. 
- Change applied to `gcp/cloud-build/copy-sha-certificates.sh` to make SHA copying robust against compact JSON responses. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69652b128764833087bc42b577b3481f)