### PR TITLE
Harden Firebase SHA copy app lookup

### DIFF
--- a/docs/BANGLADESH_VERSION_APPROACH.md
+++ b/docs/BANGLADESH_VERSION_APPROACH.md
@@ -1,10 +1,11 @@
 # Bangladesh Version Approach
 
-**Document Version:** 2.9  
-**Last Updated:** 2025-12-29  
+**Document Version:** 2.10  
+**Last Updated:** 2025-12-30  
 **Status:** Planning - Legal Validation Completed
 
 **Revision History**:
+- v2.10 (2025-12-30): **FIREBASE SHA COPY RELIABILITY** - Documented the SHA certificate copy step for Firebase Android app variants and noted the resilient JSON parsing to ensure the global app ID is discovered before copying SHA certificates to the Bangladesh variant.
 - v2.9 (2025-12-29): **LEGAL VALIDATION COMPLETED** - Game assumptions validated with ChatGPT legal consultation. Updated document to reflect that skill-based game structure, free entry, developer-funded prizes, and 18+ age restriction align with typical legal frameworks for promotional contests. Removed "pending legal validation" status.
 - v2.8 (2025-12-29): **DOCUMENTATION CONSOLIDATION** - Merged BANGLADESH_PAYMENT_METHODS_VERIFICATION.md into this document. Added detailed payment service verification section with technical details on why bKash/Nagad/Rocket cannot be used from Poland. Added payment service FAQs. All analysis now in single document.
 - v2.7 (2025-12-29): **PAYMENT METHOD UPDATE** - Clarified that Wise may have limited mobile wallet support from Poland. Updated recommendations to prioritize Remitly for direct mobile wallet transfers (bKash, Nagad), with Wise as alternative for bank transfers. Updated all payment-related sections, setup guides, and cost estimates to reflect accurate service capabilities.
@@ -184,6 +185,8 @@ android {
   - `piotr_gorczynski.soccer2.bd` (Bangladesh variant)
 - Prevents duplicate app creation by checking existing apps first
 - Logs all operations for debugging and audit purposes
+
+**SHA Certificate Copy for Variants**: After app creation, the Cloud Build flow runs `gcp/cloud-build/copy-sha-certificates.sh` to copy SHA certificates from the global app to the Bangladesh variant when needed. The script uses Firebase Management API responses and includes whitespace-tolerant parsing in the fallback path to ensure the global app ID is detected even when JSON output is formatted with spaces or newlines. This keeps the Bangladesh variant aligned with the global app’s signing configuration without manual console updates.
 
 **Automated Configuration Download**: After Firebase apps are created, the configuration file is automatically downloaded using the Cloud Build script `gcp/cloud-build/download_google_services.yaml`. This script:
 - Downloads a single `google-services.json` file that contains configurations for all registered Android apps in the project

--- a/gcp/cloud-build/copy-sha-certificates.sh
+++ b/gcp/cloud-build/copy-sha-certificates.sh
@@ -55,8 +55,11 @@ PY
   fi
 
   # Fallback without jq/python3 - extract app ID for the package
+  # Normalize JSON by removing whitespace so we can match packageName reliably.
+  compact_response=$(echo "$apps_response" | tr -d '[:space:]')
+
   # Normalize JSON into one object per line to handle compact responses
-  app_block=$(echo "$apps_response" | tr '{' '\n' | tr '}' '\n' | grep -F "\"packageName\":\"$package_name\"" | head -1 || true)
+  app_block=$(echo "$compact_response" | tr '{' '\n' | tr '}' '\n' | grep -F "\"packageName\":\"$package_name\"" | head -1 || true)
 
   if [ -z "$app_block" ]; then
     return


### PR DESCRIPTION
### Motivation
- The SHA copy script could miss the global Android app ID when the Firebase Management API returned JSON with spaces/newlines, causing the SHA copy to be skipped.

### Description
- Normalize API response whitespace in `gcp/cloud-build/copy-sha-certificates.sh` fallback parser so package lookups succeed when `jq`/`python3` are not available, and update `docs/BANGLADESH_VERSION_APPROACH.md` to document the SHA copy step and bump the document version to `2.10`.

### Testing
- No automated tests were run for these small shell and documentation changes; edits were committed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967dd724da88330b4587badfa74d9ed)