### PR TITLE
Use Node-based npm-installed Firebase CLI and add paginated Firebase app lookup for SHA copy

### DIFF
--- a/gcp/cloud-build/copy-sha-certificates.sh
+++ b/gcp/cloud-build/copy-sha-certificates.sh
@@ -13,29 +13,34 @@ echo "📱 Global package: $global_package_name"
 # Generate access token for Firebase Management API
 access_token=$(gcloud auth print-access-token)
 
-# Get list of all Android apps with their app IDs
-echo "🔍 Fetching list of Android apps..."
-apps_response=$(curl -s -H "Authorization: Bearer $access_token" \
-  "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps")
-
-# Extract app IDs and package names using grep (jq alternative)
-echo "$apps_response" > /tmp/apps_response.json
-
 # Find the global app ID
 global_app_id=""
 echo "🔍 Searching for global app ID..."
 
-# Helper to get app ID for a package name
+# Fetch a page of Android apps from Firebase
+fetch_apps_page() {
+  local page_token="$1"
+  local url="https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps"
+
+  if [ -n "$page_token" ]; then
+    url="${url}?pageToken=${page_token}"
+  fi
+
+  curl -s -H "Authorization: Bearer $access_token" "$url"
+}
+
+# Helper to extract app ID for a package name from a response payload
 get_app_id_for_package() {
   local package_name="$1"
+  local response="$2"
 
   if command -v jq >/dev/null 2>&1; then
-    echo "$apps_response" | jq -r ".apps[] | select(.packageName == \"$package_name\") | .appId" 2>/dev/null || true
+    echo "$response" | jq -r ".apps[] | select(.packageName == \"$package_name\") | .appId" 2>/dev/null || true
     return
   fi
 
   if command -v python3 >/dev/null 2>&1; then
-    python3 - "$package_name" <<'PY' <<<"$apps_response"
+    python3 - "$package_name" <<'PY' <<<"$response"
 import json
 import sys
 
@@ -56,7 +61,7 @@ PY
 
   # Fallback without jq/python3 - extract app ID for the package
   # Normalize JSON by removing whitespace so we can match packageName reliably.
-  compact_response=$(echo "$apps_response" | tr -d '[:space:]')
+  compact_response=$(echo "$response" | tr -d '[:space:]')
 
   # Normalize JSON into one object per line to handle compact responses
   app_block=$(echo "$compact_response" | tr '{' '\n' | tr '}' '\n' | grep -F "\"packageName\":\"$package_name\"" | head -1 || true)
@@ -77,9 +82,68 @@ PY
   fi
 }
 
+# Helper to extract nextPageToken from a response payload
+get_next_page_token() {
+  local response="$1"
+
+  if command -v jq >/dev/null 2>&1; then
+    echo "$response" | jq -r '.nextPageToken // empty' 2>/dev/null || true
+    return
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - <<'PY' <<<"$response"
+import json
+import sys
+
+data = json.load(sys.stdin)
+token = data.get("nextPageToken") or ""
+if token:
+    print(token)
+PY
+    return
+  fi
+
+  echo "$response" | grep -oE '"nextPageToken"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*"nextPageToken"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/'
+}
+
+# Find app ID across paginated Firebase app list
+find_app_id_across_pages() {
+  local package_name="$1"
+  local page_token=""
+  local page=1
+  local app_id=""
+  local next_page_token=""
+
+  while :; do
+    if [ -n "$page_token" ]; then
+      echo "🔄 Fetching Firebase app list page $page..."
+    else
+      echo "🔍 Fetching list of Android apps..."
+    fi
+
+    apps_response=$(fetch_apps_page "$page_token")
+    echo "$apps_response" > /tmp/apps_response_page_${page}.json
+
+    app_id=$(get_app_id_for_package "$package_name" "$apps_response")
+    if [ -n "$app_id" ]; then
+      echo "$app_id"
+      return
+    fi
+
+    next_page_token=$(get_next_page_token "$apps_response")
+    if [ -z "$next_page_token" ]; then
+      break
+    fi
+
+    page_token="$next_page_token"
+    page=$((page + 1))
+  done
+}
+
 # Parse JSON to find app ID for global package
 # The response format is: "apps": [{"name": "projects/.../androidApps/APP_ID", "packageName": "..."}]
-global_app_id=$(get_app_id_for_package "$global_package_name")
+global_app_id=$(find_app_id_across_pages "$global_package_name")
 
 if [ -z "$global_app_id" ]; then
   echo "⚠️  Could not find app ID for global package: $global_package_name"
@@ -183,7 +247,7 @@ if echo "$sha_response" | grep -q '"certificates"'; then
     retry_delay=5  # Start with 5 seconds
     
     while [ $retry_count -le $max_retries ]; do
-      target_app_id=$(get_app_id_for_package "$package_name")
+      target_app_id=$(find_app_id_across_pages "$package_name")
       
       # If we found the app ID, break out of retry loop
       if [ -n "$target_app_id" ]; then
@@ -203,10 +267,8 @@ if echo "$sha_response" | grep -q '"certificates"'; then
         echo "⏳ App ID not found, waiting ${retry_delay}s before retry $retry_count/$max_retries..."
         sleep $retry_delay
         
-        # Refetch the app list
+        # Refetch the app list (including pagination)
         echo "🔄 Refetching Firebase app list..."
-        apps_response=$(curl -s -H "Authorization: Bearer $access_token" \
-          "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps")
         
         # Increase delay for next retry (exponential backoff)
         retry_delay=$((retry_delay * 2))

--- a/gcp/cloud-build/deploy_firebase.yaml
+++ b/gcp/cloud-build/deploy_firebase.yaml
@@ -32,47 +32,48 @@ steps:
         gcloud services enable firebase.googleapis.com --project="$(cat /workspace/SOCCER_PROJECT_ID.txt)"
 
   # Step 3: Install Firebase CLI
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+  - name: 'node:20-bullseye'
     entrypoint: 'bash'
     args:
       - '-c'
       - |
         set -e
         echo "⬇️ Installing Firebase CLI..."
-        curl -sL https://firebase.tools | bash
         mkdir -p /workspace/firebase
-        cp /usr/local/bin/firebase /workspace/firebase/
-        chmod +x /workspace/firebase/firebase
+        npm install --prefix /workspace/firebase firebase-tools@latest --no-fund --no-audit
+        firebase_bin="/workspace/firebase/node_modules/.bin/firebase"
         echo "🔍 Verifying Firebase CLI installation..."
-        if ! /workspace/firebase/firebase --version; then
+        if ! "$firebase_bin" --version; then
           echo "❌ Firebase CLI installation failed. Exiting."
           exit 1
         fi
         echo "✅ Firebase CLI installed successfully!"
 
   # Step 4: List Existing Firebase Projects
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+  - name: 'node:20-bullseye'
     entrypoint: 'bash'
     args:
       - '-c'
       - |
         set -e
         firebase_project_id=$(cat /workspace/SOCCER_PROJECT_ID.txt)
+        firebase_bin="/workspace/firebase/node_modules/.bin/firebase"
         echo "📱 Listing existing Firebase projects..."
-        /workspace/firebase/firebase projects:list
+        "$firebase_bin" projects:list
 
   # Step 6: Enable Firebase for the Project (if missing)
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+  - name: 'node:20-bullseye'
     entrypoint: 'bash'
     args:
       - '-c'
       - |
         set -e
         firebase_project_id=$(cat /workspace/SOCCER_PROJECT_ID.txt)
+        firebase_bin="/workspace/firebase/node_modules/.bin/firebase"
         echo "🛠️ Checking if Firebase is enabled for project: $firebase_project_id..."
 
         # List Firebase projects and store the result (excluding table headers)
-        firebase_projects=$(/workspace/firebase/firebase projects:list | tail -n +2 | awk '{print $2}')
+        firebase_projects=$("$firebase_bin" projects:list | tail -n +2 | awk '{print $2}')
 
         echo "🔍 Firebase projects found:"
         echo "$firebase_projects"
@@ -81,12 +82,12 @@ steps:
           echo "✅ Firebase is already enabled for this project."
         else
           echo "🚀 Enabling Firebase for project $firebase_project_id..."
-          /workspace/firebase/firebase projects:addfirebase "$firebase_project_id"
+          "$firebase_bin" projects:addfirebase "$firebase_project_id"
           echo "✅ Firebase has been successfully enabled for $firebase_project_id."
         fi
 
   # Step 7: Check if Firebase Android Apps Exist and Create Them (Global and Bangladesh)
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+  - name: 'node:20-bullseye'
     entrypoint: 'bash'
     args:
       - '-c'
@@ -94,6 +95,7 @@ steps:
         set -e
 
         firebase_project_id=$(cat /workspace/SOCCER_PROJECT_ID.txt)
+        firebase_bin="/workspace/firebase/node_modules/.bin/firebase"
         # Define package names for global and Bangladesh variants
         package_names=("piotr_gorczynski.soccer2" "piotr_gorczynski.soccer2.bd")
         mkdir -p /workspace/logs
@@ -102,7 +104,7 @@ steps:
         
         # List all Firebase apps in JSON format to get package names
         echo "🔍 Fetching list of existing Firebase Android apps..."
-        app_list_json=$(/workspace/firebase/firebase apps:list ANDROID --project="$firebase_project_id" --json 2>/dev/null || echo "[]")
+        app_list_json=$("$firebase_bin" apps:list ANDROID --project="$firebase_project_id" --json 2>/dev/null || echo "[]")
 
         # Print raw Firebase apps output for debugging
         echo "🔍 Raw Firebase Apps JSON Output:"
@@ -134,7 +136,7 @@ steps:
             echo "📱 Creating Firebase Android App for package: $package_name..."
             firebase_log_file="/workspace/logs/firebase-debug-${package_name}.log"
             
-            if ! /workspace/firebase/firebase apps:create android --package-name="$package_name" --project="$firebase_project_id" > "$firebase_log_file" 2>&1; then
+            if ! "$firebase_bin" apps:create android --package-name="$package_name" --project="$firebase_project_id" > "$firebase_log_file" 2>&1; then
               echo "⚠️ Error occurred while creating Android app for $package_name. Logging details..."
               cat "$firebase_log_file"
               exit 1


### PR DESCRIPTION
### Motivation
- Avoid the `firebase.tools` binary download/exec-format failure in cloud build by installing the Firebase CLI via `npm` in a Node container. 
- Ensure SHA certificate copying reliably finds Firebase Android app IDs when the `androidApps` response is paginated. 

### Description
- Switch Cloud Build Firebase-related steps to use `node:20-bullseye` and install `firebase-tools` with `npm install --prefix /workspace/firebase firebase-tools@latest`, and use the workspace binary at `/workspace/firebase/node_modules/.bin/firebase` for all Firebase commands. 
- Replace uses of the system `/usr/local/bin/firebase` with the workspace-installed `firebase` binary for `projects:list`, `projects:addfirebase`, `apps:list`, and `apps:create`. 
- Implement paginated app listing in `gcp/cloud-build/copy-sha-certificates.sh` with `fetch_apps_page`, `get_next_page_token`, `get_app_id_for_package` (now accepts a response payload and supports `jq`, `python3`, or grep fallbacks), and `find_app_id_across_pages` which iterates pages, persists pages to `/tmp/apps_response_page_<n>.json` for debugging, and returns the matched `appId`. 
- Update retry/refetch logic to re-run the paginated lookup when waiting for app propagation and add debugging outputs for SHA and API responses. 

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f1a89cc4833092e455efc75ce344)