### PR TITLE
Fix Firebase app ID lookup for SHA copy script

### DIFF
--- a/docs/BANGLADESH_VERSION_APPROACH.md
+++ b/docs/BANGLADESH_VERSION_APPROACH.md
@@ -1,10 +1,11 @@
 # Bangladesh Version Approach
 
-**Document Version:** 2.10  
-**Last Updated:** 2025-12-30  
+**Document Version:** 2.11  
+**Last Updated:** 2025-12-31  
 **Status:** Planning - Legal Validation Completed
 
 **Revision History**:
+- v2.11 (2025-12-31): **FIREBASE APP ID LOOKUP FIX** - Clarified that the SHA copy step now detects Firebase app IDs from API responses that return either `apps` or `result`, preventing false "app ID not found" warnings in Cloud Build.
 - v2.10 (2025-12-30): **FIREBASE SHA COPY RELIABILITY** - Documented the SHA certificate copy step for Firebase Android app variants and noted the resilient JSON parsing to ensure the global app ID is discovered before copying SHA certificates to the Bangladesh variant.
 - v2.9 (2025-12-29): **LEGAL VALIDATION COMPLETED** - Game assumptions validated with ChatGPT legal consultation. Updated document to reflect that skill-based game structure, free entry, developer-funded prizes, and 18+ age restriction align with typical legal frameworks for promotional contests. Removed "pending legal validation" status.
 - v2.8 (2025-12-29): **DOCUMENTATION CONSOLIDATION** - Merged BANGLADESH_PAYMENT_METHODS_VERIFICATION.md into this document. Added detailed payment service verification section with technical details on why bKash/Nagad/Rocket cannot be used from Poland. Added payment service FAQs. All analysis now in single document.
@@ -186,7 +187,7 @@ android {
 - Prevents duplicate app creation by checking existing apps first
 - Logs all operations for debugging and audit purposes
 
-**SHA Certificate Copy for Variants**: After app creation, the Cloud Build flow runs `gcp/cloud-build/copy-sha-certificates.sh` to copy SHA certificates from the global app to the Bangladesh variant when needed. The script uses Firebase Management API responses and includes whitespace-tolerant parsing in the fallback path to ensure the global app ID is detected even when JSON output is formatted with spaces or newlines. This keeps the Bangladesh variant aligned with the global app’s signing configuration without manual console updates.
+**SHA Certificate Copy for Variants**: After app creation, the Cloud Build flow runs `gcp/cloud-build/copy-sha-certificates.sh` to copy SHA certificates from the global app to the Bangladesh variant when needed. The script recognizes Firebase Management API responses that return either an `apps` array or a `result` array (depending on the endpoint version), and includes whitespace-tolerant parsing in the fallback path to ensure the global app ID is detected even when JSON output is formatted with spaces or newlines. This keeps the Bangladesh variant aligned with the global app’s signing configuration without manual console updates.
 
 **Automated Configuration Download**: After Firebase apps are created, the configuration file is automatically downloaded using the Cloud Build script `gcp/cloud-build/download_google_services.yaml`. This script:
 - Downloads a single `google-services.json` file that contains configurations for all registered Android apps in the project

--- a/gcp/cloud-build/copy-sha-certificates.sh
+++ b/gcp/cloud-build/copy-sha-certificates.sh
@@ -35,7 +35,7 @@ get_app_id_for_package() {
   local response="$2"
 
   if command -v jq >/dev/null 2>&1; then
-    echo "$response" | jq -r ".apps[] | select(.packageName == \"$package_name\") | .appId" 2>/dev/null || true
+    echo "$response" | jq -r --arg pkg "$package_name" '(.apps // .result // [])[] | select(.packageName == $pkg) | (.appId // (if .name then (.name | split("/") | last) else "" end))' 2>/dev/null | head -n1 || true
     return
   fi
 


### PR DESCRIPTION
### Motivation
- The SHA copy step in `gcp/cloud-build/copy-sha-certificates.sh` could report "Could not find app ID" even when the Firebase app list was present because the script only searched `.apps` and did not handle alternate API payloads or missing `appId` fields. 
- Documentation needed updating to reflect the changed lookup behavior so Cloud Build logs and docs match the improved parsing logic.

### Description
- Updated the `jq` extraction in `gcp/cloud-build/copy-sha-certificates.sh` to search `(.apps // .result // [])` and to fall back to parsing the `name` field when `appId` is not present, ensuring robust app ID discovery across API response formats. 
- Retained and left intact the existing Python and grep-based fallbacks so the script works when `jq` is not available. 
- Bumped and updated `docs/BANGLADESH_VERSION_APPROACH.md` to version `2.11` and added a revision note describing the app ID lookup fix and the SHA copy behavior to avoid confusing logs.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696942f9aa5c83308d06abb4fdf3cfca)