### PR TITLE
Harden Firebase app ID lookup in SHA copy step

### DIFF
--- a/docs/BANGLADESH_VERSION_APPROACH.md
+++ b/docs/BANGLADESH_VERSION_APPROACH.md
@@ -1,10 +1,11 @@
 # Bangladesh Version Approach
 
-**Document Version:** 2.11  
+**Document Version:** 2.12  
 **Last Updated:** 2025-12-31  
 **Status:** Planning - Legal Validation Completed
 
 **Revision History**:
+- v2.12 (2025-12-31): **FIREBASE APP ID LOOKUP HARDENING** - Updated the SHA copy step documentation to reflect more resilient app ID parsing across `apps`, `androidApps`, or `result` response shapes, plus a safer fallback split that avoids dropping fields in grep-only environments.
 - v2.11 (2025-12-31): **FIREBASE APP ID LOOKUP FIX** - Clarified that the SHA copy step now detects Firebase app IDs from API responses that return either `apps` or `result`, preventing false "app ID not found" warnings in Cloud Build.
 - v2.10 (2025-12-30): **FIREBASE SHA COPY RELIABILITY** - Documented the SHA certificate copy step for Firebase Android app variants and noted the resilient JSON parsing to ensure the global app ID is discovered before copying SHA certificates to the Bangladesh variant.
 - v2.9 (2025-12-29): **LEGAL VALIDATION COMPLETED** - Game assumptions validated with ChatGPT legal consultation. Updated document to reflect that skill-based game structure, free entry, developer-funded prizes, and 18+ age restriction align with typical legal frameworks for promotional contests. Removed "pending legal validation" status.
@@ -187,7 +188,7 @@ android {
 - Prevents duplicate app creation by checking existing apps first
 - Logs all operations for debugging and audit purposes
 
-**SHA Certificate Copy for Variants**: After app creation, the Cloud Build flow runs `gcp/cloud-build/copy-sha-certificates.sh` to copy SHA certificates from the global app to the Bangladesh variant when needed. The script recognizes Firebase Management API responses that return either an `apps` array or a `result` array (depending on the endpoint version), and includes whitespace-tolerant parsing in the fallback path to ensure the global app ID is detected even when JSON output is formatted with spaces or newlines. This keeps the Bangladesh variant aligned with the global app’s signing configuration without manual console updates.
+**SHA Certificate Copy for Variants**: After app creation, the Cloud Build flow runs `gcp/cloud-build/copy-sha-certificates.sh` to copy SHA certificates from the global app to the Bangladesh variant when needed. The script recognizes Firebase Management API responses that return `apps`, `androidApps`, or `result` arrays (depending on endpoint/version) and uses a safer fallback split for grep-only environments so package matches retain all fields. This keeps the Bangladesh variant aligned with the global app’s signing configuration without manual console updates.
 
 **Automated Configuration Download**: After Firebase apps are created, the configuration file is automatically downloaded using the Cloud Build script `gcp/cloud-build/download_google_services.yaml`. This script:
 - Downloads a single `google-services.json` file that contains configurations for all registered Android apps in the project

--- a/gcp/cloud-build/copy-sha-certificates.sh
+++ b/gcp/cloud-build/copy-sha-certificates.sh
@@ -35,7 +35,7 @@ get_app_id_for_package() {
   local response="$2"
 
   if command -v jq >/dev/null 2>&1; then
-    echo "$response" | jq -r --arg pkg "$package_name" '(.apps // .result // [])[] | select(.packageName == $pkg) | (.appId // (if .name then (.name | split("/") | last) else "" end))' 2>/dev/null | head -n1 || true
+    echo "$response" | jq -r --arg pkg "$package_name" '(.apps // .androidApps // .result // [])[] | select(.packageName == $pkg) | (.appId // (if .name then (.name | split("/") | last) else "" end))' 2>/dev/null | head -n1 || true
     return
   fi
 
@@ -46,7 +46,7 @@ import sys
 
 package = sys.argv[1]
 data = json.load(sys.stdin)
-apps = data.get("apps") or data.get("result") or []
+apps = data.get("apps") or data.get("androidApps") or data.get("result") or []
 for app in apps:
     if app.get("packageName") == package:
         app_id = app.get("appId") or ""
@@ -63,8 +63,9 @@ PY
   # Normalize JSON by removing whitespace so we can match packageName reliably.
   compact_response=$(echo "$response" | tr -d '[:space:]')
 
-  # Normalize JSON into one object per line to handle compact responses
-  app_block=$(echo "$compact_response" | tr '{' '\n' | tr '}' '\n' | grep -F "\"packageName\":\"$package_name\"" | head -1 || true)
+  # Split into one JSON object per line for each app entry.
+  # This avoids brace-based splitting that can drop key/value pairs.
+  app_block=$(echo "$compact_response" | sed 's/},{/}\n{/g' | grep -F "\"packageName\":\"$package_name\"" | head -1 || true)
 
   if [ -z "$app_block" ]; then
     return


### PR DESCRIPTION
### Motivation
- The SHA copy script sometimes failed to locate the global Firebase Android app ID because the Management API responses vary in shape (`apps`, `androidApps`, or `result`) and the grep-only fallback could lose fields when splitting JSON, resulting in false "Could not find app ID" warnings. 
- Documentation needed to be updated to record the more resilient parsing behavior and the rationale for the change.

### Description
- Extended the jq selector to search `(.apps // .androidApps // .result // [])` so app entries are detected regardless of API response shape and still prefer `appId` or fallback to the `name` suffix. 
- Updated the Python fallback to check `data.get("apps") or data.get("androidApps") or data.get("result")` so structured parsing also covers the additional response shape. 
- Replaced the brittle brace-splitting grep fallback with a safer `sed 's/},{/}\n{/'` split that preserves key/value pairs when creating one app object per line for grep-based extraction. 
- Bumped `docs/BANGLADESH_VERSION_APPROACH.md` to version `2.12` and documented the hardened app ID lookup and the safer grep-only fallback behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69694c1d55348330a64248f23168beca)