### PR TITLE
Improve SHA copy logging, error handling, and add verification retries

### DIFF
--- a/gcp/cloud-build/sha_copy.yaml
+++ b/gcp/cloud-build/sha_copy.yaml
@@ -11,7 +11,7 @@ steps:
     args:
       - '-c'
       - |
-        set -e
+        set -euo pipefail
         echo "Checking if project starting with ${_FOLDER_NAME}-${_ENVIRONMENT} exists..."
         gcloud projects list \
           --filter="name~^${_FOLDER_NAME}-${_ENVIRONMENT}" \
@@ -29,7 +29,7 @@ steps:
     args:
       - '-c'
       - |
-        set -e
+        set -euo pipefail
         firebase_project_id=$(cat /workspace/SOCCER_PROJECT_ID.txt)
         echo "⬇️ Installing Firebase CLI..."
         mkdir -p /workspace/firebase
@@ -61,7 +61,7 @@ steps:
     args:
       - '-c'
       - |
-        set -e
+        set -euo pipefail
         firebase_project_id=$(cat /workspace/SOCCER_PROJECT_ID.txt)
         global_app_id=$(cat /workspace/global_app_id.txt 2>/dev/null || true)
         bd_app_id=$(cat /workspace/bd_app_id.txt 2>/dev/null || true)
@@ -82,14 +82,32 @@ steps:
         missing_file=/workspace/sha_missing.txt
 
         echo "🔑 Fetching SHA certificates from global app..."
-        curl -s -H "Authorization: Bearer $access_token" \
-          "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$global_app_id/sha" \
-          > "$global_sha_file"
+        global_response=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $access_token" \
+          "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$global_app_id/sha")
+        global_http_code=$(echo "$global_response" | tail -n1)
+        global_body=$(echo "$global_response" | head -n -1)
+        echo "$global_body" > "$global_sha_file"
+        if [[ "$global_http_code" != "200" ]]; then
+          echo "❌ Failed to fetch global SHA certificates. HTTP $global_http_code"
+          if [ -n "$global_body" ]; then
+            echo "Response: $global_body"
+          fi
+          exit 1
+        fi
 
         echo "🔍 Fetching SHA certificates from Bangladesh app..."
-        curl -s -H "Authorization: Bearer $access_token" \
-          "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$bd_app_id/sha" \
-          > "$target_sha_file"
+        target_response=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $access_token" \
+          "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$bd_app_id/sha")
+        target_http_code=$(echo "$target_response" | tail -n1)
+        target_body=$(echo "$target_response" | head -n -1)
+        echo "$target_body" > "$target_sha_file"
+        if [[ "$target_http_code" != "200" ]]; then
+          echo "❌ Failed to fetch Bangladesh SHA certificates. HTTP $target_http_code"
+          if [ -n "$target_body" ]; then
+            echo "Response: $target_body"
+          fi
+          exit 1
+        fi
 
         python3 - <<'PY'
         import json
@@ -105,6 +123,8 @@ steps:
             try:
                 data = json.loads(path.read_text() or "{}")
             except json.JSONDecodeError:
+                print(f"❌ Invalid JSON in {path}. Raw content:")
+                print(path.read_text())
                 return []
             certs = data.get("certificates") or []
             cleaned = []
@@ -142,7 +162,7 @@ steps:
           fi
 
           echo "➕ Adding SHA certificate $sha_hash ($cert_type) to Bangladesh app..."
-          add_response=$(curl -s -w '\n%{http_code}' -X POST \
+          add_response=$(curl -sS -w '\n%{http_code}' -X POST \
             -H "Authorization: Bearer $access_token" \
             -H "Content-Type: application/json" \
             "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$bd_app_id/sha" \
@@ -158,6 +178,9 @@ steps:
             failures=$((failures + 1))
           else
             echo "✅ Added $sha_hash ($cert_type). HTTP $http_code"
+            if [ -n "$response_body" ]; then
+              echo "Response: $response_body"
+            fi
           fi
         done < "$missing_file"
 
@@ -169,11 +192,25 @@ steps:
         echo "✅ SHA certificate copy completed successfully."
 
         echo "🔍 Verifying SHA certificates on Bangladesh app after copy..."
-        curl -s -H "Authorization: Bearer $access_token" \
-          "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$bd_app_id/sha" \
-          > "$target_sha_file"
+        attempt=1
+        max_attempts=3
+        sleep_seconds=5
+        while true; do
+          echo "🔁 Verification attempt ${attempt}/${max_attempts}..."
+          verify_response=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $access_token" \
+            "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$bd_app_id/sha")
+          verify_http_code=$(echo "$verify_response" | tail -n1)
+          verify_body=$(echo "$verify_response" | head -n -1)
+          echo "$verify_body" > "$target_sha_file"
+          if [[ "$verify_http_code" != "200" ]]; then
+            echo "❌ Failed to verify Bangladesh SHA certificates. HTTP $verify_http_code"
+            if [ -n "$verify_body" ]; then
+              echo "Response: $verify_body"
+            fi
+            exit 1
+          fi
 
-        python3 - <<'PY'
+          if python3 - <<'PY'
         import json
         from pathlib import Path
 
@@ -186,6 +223,8 @@ steps:
             try:
                 data = json.loads(path.read_text() or "{}")
             except json.JSONDecodeError:
+                print(f"❌ Invalid JSON in {path}. Raw content:")
+                print(path.read_text())
                 return []
             certs = data.get("certificates") or []
             cleaned = []
@@ -210,6 +249,21 @@ steps:
             raise SystemExit(1)
         print("✅ Verification succeeded. All global certs are present on Bangladesh app.")
         PY
+          then
+            verify_status=0
+          else
+            verify_status=$?
+          fi
+          if [ "$verify_status" -eq 0 ]; then
+            break
+          fi
+          if [ "$attempt" -ge "$max_attempts" ]; then
+            exit "$verify_status"
+          fi
+          echo "⏳ Verification still missing certs. Waiting ${sleep_seconds}s before retry..."
+          sleep "$sleep_seconds"
+          attempt=$((attempt + 1))
+        done
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
### Motivation
- Provide more actionable diagnostics when Firebase SHA API calls fail and reduce false negatives caused by API propagation delays.

### Description
- Enabled stricter shell failure semantics by adding `set -euo pipefail` to the build steps and switched `curl` calls to surface errors with `curl -sS` while capturing HTTP status via `-w '\n%{http_code}'` in `gcp/cloud-build/sha_copy.yaml`.
- Persist HTTP response bodies to files and log non-200 responses as well as successful `POST` responses to improve observability of fetch/add operations.
- Improved JSON parsing diagnostics in the embedded `python3` helper by printing raw content on `json.JSONDecodeError` and writing missing certs to `/workspace/sha_missing.txt` for transparent failure output.
- Added a verification retry loop (`max_attempts=3`, `sleep_seconds=5`) that repeats post-copy verification and exits with the verification status if retries are exhausted.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a79ce064c8330b5a8edb0ca32c846)