### PR TITLE
Fix curl URL parsing bug; improve SHA copy logging, error handling & verification retries

### DIFF
--- a/gcp/cloud-build/sha_copy.yaml
+++ b/gcp/cloud-build/sha_copy.yaml
@@ -11,7 +11,7 @@ steps:
     args:
       - '-c'
       - |
-        set -e
+        set -euo pipefail
         echo "Checking if project starting with ${_FOLDER_NAME}-${_ENVIRONMENT} exists..."
         gcloud projects list \
           --filter="name~^${_FOLDER_NAME}-${_ENVIRONMENT}" \
@@ -29,7 +29,7 @@ steps:
     args:
       - '-c'
       - |
-        set -e
+        set -euo pipefail
         firebase_project_id=$(cat /workspace/SOCCER_PROJECT_ID.txt)
         echo "⬇️ Installing Firebase CLI..."
         mkdir -p /workspace/firebase
@@ -61,7 +61,7 @@ steps:
     args:
       - '-c'
       - |
-        set -e
+        set -euo pipefail
         firebase_project_id=$(cat /workspace/SOCCER_PROJECT_ID.txt)
         global_app_id=$(cat /workspace/global_app_id.txt 2>/dev/null || true)
         bd_app_id=$(cat /workspace/bd_app_id.txt 2>/dev/null || true)
@@ -82,14 +82,30 @@ steps:
         missing_file=/workspace/sha_missing.txt
 
         echo "🔑 Fetching SHA certificates from global app..."
-        curl -s -H "Authorization: Bearer $access_token" \
-          "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$global_app_id/sha" \
-          > "$global_sha_file"
+        global_response=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $access_token" "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$global_app_id/sha")
+        global_http_code=$(echo "$global_response" | tail -n1)
+        global_body=$(echo "$global_response" | head -n -1)
+        echo "$global_body" > "$global_sha_file"
+        if [[ "$global_http_code" != "200" ]]; then
+          echo "❌ Failed to fetch global SHA certificates. HTTP $global_http_code"
+          if [ -n "$global_body" ]; then
+            echo "Response: $global_body"
+          fi
+          exit 1
+        fi
 
         echo "🔍 Fetching SHA certificates from Bangladesh app..."
-        curl -s -H "Authorization: Bearer $access_token" \
-          "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$bd_app_id/sha" \
-          > "$target_sha_file"
+        target_response=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $access_token" "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$bd_app_id/sha")
+        target_http_code=$(echo "$target_response" | tail -n1)
+        target_body=$(echo "$target_response" | head -n -1)
+        echo "$target_body" > "$target_sha_file"
+        if [[ "$target_http_code" != "200" ]]; then
+          echo "❌ Failed to fetch Bangladesh SHA certificates. HTTP $target_http_code"
+          if [ -n "$target_body" ]; then
+            echo "Response: $target_body"
+          fi
+          exit 1
+        fi
 
         python3 - <<'PY'
         import json
@@ -105,6 +121,8 @@ steps:
             try:
                 data = json.loads(path.read_text() or "{}")
             except json.JSONDecodeError:
+                print(f"❌ Invalid JSON in {path}. Raw content:")
+                print(path.read_text())
                 return []
             certs = data.get("certificates") or []
             cleaned = []
@@ -142,7 +160,7 @@ steps:
           fi
 
           echo "➕ Adding SHA certificate $sha_hash ($cert_type) to Bangladesh app..."
-          add_response=$(curl -s -w '\n%{http_code}' -X POST \
+          add_response=$(curl -sS -w '\n%{http_code}' -X POST \
             -H "Authorization: Bearer $access_token" \
             -H "Content-Type: application/json" \
             "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$bd_app_id/sha" \
@@ -158,6 +176,9 @@ steps:
             failures=$((failures + 1))
           else
             echo "✅ Added $sha_hash ($cert_type). HTTP $http_code"
+            if [ -n "$response_body" ]; then
+              echo "Response: $response_body"
+            fi
           fi
         done < "$missing_file"
 
@@ -169,11 +190,24 @@ steps:
         echo "✅ SHA certificate copy completed successfully."
 
         echo "🔍 Verifying SHA certificates on Bangladesh app after copy..."
-        curl -s -H "Authorization: Bearer $access_token" \
-          "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$bd_app_id/sha" \
-          > "$target_sha_file"
+        attempt=1
+        max_attempts=3
+        sleep_seconds=5
+        while true; do
+          echo "🔁 Verification attempt ${attempt}/${max_attempts}..."
+          verify_response=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $access_token" "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$bd_app_id/sha")
+          verify_http_code=$(echo "$verify_response" | tail -n1)
+          verify_body=$(echo "$verify_response" | head -n -1)
+          echo "$verify_body" > "$target_sha_file"
+          if [[ "$verify_http_code" != "200" ]]; then
+            echo "❌ Failed to verify Bangladesh SHA certificates. HTTP $verify_http_code"
+            if [ -n "$verify_body" ]; then
+              echo "Response: $verify_body"
+            fi
+            exit 1
+          fi
 
-        python3 - <<'PY'
+          if python3 - <<'PY'
         import json
         from pathlib import Path
 
@@ -186,6 +220,8 @@ steps:
             try:
                 data = json.loads(path.read_text() or "{}")
             except json.JSONDecodeError:
+                print(f"❌ Invalid JSON in {path}. Raw content:")
+                print(path.read_text())
                 return []
             certs = data.get("certificates") or []
             cleaned = []
@@ -210,6 +246,21 @@ steps:
             raise SystemExit(1)
         print("✅ Verification succeeded. All global certs are present on Bangladesh app.")
         PY
+          then
+            verify_status=0
+          else
+            verify_status=$?
+          fi
+          if [ "$verify_status" -eq 0 ]; then
+            break
+          fi
+          if [ "$attempt" -ge "$max_attempts" ]; then
+            exit "$verify_status"
+          fi
+          echo "⏳ Verification still missing certs. Waiting ${sleep_seconds}s before retry..."
+          sleep "$sleep_seconds"
+          attempt=$((attempt + 1))
+        done
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
### Motivation
- Make the SHA certificate copy step more robust and observable by surfacing HTTP/curl errors, improving JSON diagnostics, and allowing verification to tolerate API propagation delays.
- Prevent failures caused by shell line-continuation formatting that produced an invalid `curl` invocation.

### Description
- Added stricter shell flags with `set -euo pipefail` to build steps and changed `curl` invocations to capture HTTP status with `-w '\n%{http_code}'` and surface errors with `-sS` for fetch/verify/add calls.
- Persisted HTTP response bodies to files and log non-200 responses as well as successful `POST` responses to improve observability of fetch/add operations.
- Improved JSON parsing diagnostics in embedded `python3` helpers by printing raw content on `json.JSONDecodeError` and writing missing certs to `/workspace/sha_missing.txt` for transparent failure output.
- Fixed `curl` line-continuation pitfalls by placing SHA fetch/verify URLs on the same `curl` line and added a verification retry loop (`max_attempts=3`, `sleep_seconds=5`) that repeats post-copy verification before failing.

### Testing
- A Cloud Build run prior to this fix failed with `curl: no URL specified` (step exited with status 127) due to the line-continuation issue observed in the build log.
- No automated tests or CI builds were executed after applying this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a79ce064c8330b5a8edb0ca32c846)