### PR TITLE
Improve SHA copy logging, curl error handling, and verification retries

### DIFF
--- a/gcp/cloud-build/sha_copy.yaml
+++ b/gcp/cloud-build/sha_copy.yaml
@@ -11,7 +11,7 @@ steps:
     args:
       - '-c'
       - |
-        set -e
+        set -euo pipefail
         echo "Checking if project starting with ${_FOLDER_NAME}-${_ENVIRONMENT} exists..."
         gcloud projects list \
           --filter="name~^${_FOLDER_NAME}-${_ENVIRONMENT}" \
@@ -29,7 +29,7 @@ steps:
     args:
       - '-c'
       - |
-        set -e
+        set -euo pipefail
         firebase_project_id=$(cat /workspace/SOCCER_PROJECT_ID.txt)
         echo "⬇️ Installing Firebase CLI..."
         mkdir -p /workspace/firebase
@@ -61,7 +61,7 @@ steps:
     args:
       - '-c'
       - |
-        set -e
+        set -euo pipefail
         firebase_project_id=$(cat /workspace/SOCCER_PROJECT_ID.txt)
         global_app_id=$(cat /workspace/global_app_id.txt 2>/dev/null || true)
         bd_app_id=$(cat /workspace/bd_app_id.txt 2>/dev/null || true)
@@ -82,14 +82,30 @@ steps:
         missing_file=/workspace/sha_missing.txt
 
         echo "🔑 Fetching SHA certificates from global app..."
-        curl -s -H "Authorization: Bearer $access_token" \
-          "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$global_app_id/sha" \
-          > "$global_sha_file"
+        global_response=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $access_token" "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$global_app_id/sha")
+        global_http_code=$(echo "$global_response" | tail -n1)
+        global_body=$(echo "$global_response" | head -n -1)
+        echo "$global_body" > "$global_sha_file"
+        if [[ "$global_http_code" != "200" ]]; then
+          echo "❌ Failed to fetch global SHA certificates. HTTP $global_http_code"
+          if [ -n "$global_body" ]; then
+            echo "Response: $global_body"
+          fi
+          exit 1
+        fi
 
         echo "🔍 Fetching SHA certificates from Bangladesh app..."
-        curl -s -H "Authorization: Bearer $access_token" \
-          "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$bd_app_id/sha" \
-          > "$target_sha_file"
+        target_response=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $access_token" "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$bd_app_id/sha")
+        target_http_code=$(echo "$target_response" | tail -n1)
+        target_body=$(echo "$target_response" | head -n -1)
+        echo "$target_body" > "$target_sha_file"
+        if [[ "$target_http_code" != "200" ]]; then
+          echo "❌ Failed to fetch Bangladesh SHA certificates. HTTP $target_http_code"
+          if [ -n "$target_body" ]; then
+            echo "Response: $target_body"
+          fi
+          exit 1
+        fi
 
         python3 - <<'PY'
         import json
@@ -105,6 +121,8 @@ steps:
             try:
                 data = json.loads(path.read_text() or "{}")
             except json.JSONDecodeError:
+                print(f"❌ Invalid JSON in {path}. Raw content:")
+                print(path.read_text())
                 return []
             certs = data.get("certificates") or []
             cleaned = []
@@ -128,6 +146,12 @@ steps:
         PY
 
         missing_count=$(grep -c . "$missing_file" || true)
+        echo "🧾 Missing cert list:"
+        if [ -s "$missing_file" ]; then
+          cat "$missing_file"
+        else
+          echo "(empty)"
+        fi
         if [ "$missing_count" -eq 0 ]; then
           echo "✅ No missing SHA certificates. Nothing to copy."
           exit 0
@@ -142,11 +166,16 @@ steps:
           fi
 
           echo "➕ Adding SHA certificate $sha_hash ($cert_type) to Bangladesh app..."
-          add_response=$(curl -s -w '\n%{http_code}' -X POST \
+          if ! add_response=$(curl -sS -w '\n%{http_code}' -X POST \
             -H "Authorization: Bearer $access_token" \
             -H "Content-Type: application/json" \
             "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$bd_app_id/sha" \
-            -d "{\"shaHash\":\"$sha_hash\",\"certType\":\"$cert_type\"}")
+            -d "{\"shaHash\":\"$sha_hash\",\"certType\":\"$cert_type\"}" 2>&1); then
+            echo "❌ curl failed while adding $sha_hash ($cert_type)."
+            echo "Response/Error: $add_response"
+            failures=$((failures + 1))
+            continue
+          fi
 
           http_code=$(echo "$add_response" | tail -n1)
           response_body=$(echo "$add_response" | head -n -1)
@@ -158,6 +187,7 @@ steps:
             failures=$((failures + 1))
           else
             echo "✅ Added $sha_hash ($cert_type). HTTP $http_code"
+            echo "Response: ${response_body:-<empty>}"
           fi
         done < "$missing_file"
 
@@ -169,11 +199,24 @@ steps:
         echo "✅ SHA certificate copy completed successfully."
 
         echo "🔍 Verifying SHA certificates on Bangladesh app after copy..."
-        curl -s -H "Authorization: Bearer $access_token" \
-          "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$bd_app_id/sha" \
-          > "$target_sha_file"
+        attempt=1
+        max_attempts=3
+        sleep_seconds=5
+        while true; do
+          echo "🔁 Verification attempt ${attempt}/${max_attempts}..."
+          verify_response=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $access_token" "https://firebase.googleapis.com/v1beta1/projects/$firebase_project_id/androidApps/$bd_app_id/sha")
+          verify_http_code=$(echo "$verify_response" | tail -n1)
+          verify_body=$(echo "$verify_response" | head -n -1)
+          echo "$verify_body" > "$target_sha_file"
+          if [[ "$verify_http_code" != "200" ]]; then
+            echo "❌ Failed to verify Bangladesh SHA certificates. HTTP $verify_http_code"
+            if [ -n "$verify_body" ]; then
+              echo "Response: $verify_body"
+            fi
+            exit 1
+          fi
 
-        python3 - <<'PY'
+          if python3 - <<'PY'
         import json
         from pathlib import Path
 
@@ -186,6 +229,8 @@ steps:
             try:
                 data = json.loads(path.read_text() or "{}")
             except json.JSONDecodeError:
+                print(f"❌ Invalid JSON in {path}. Raw content:")
+                print(path.read_text())
                 return []
             certs = data.get("certificates") or []
             cleaned = []
@@ -210,6 +255,21 @@ steps:
             raise SystemExit(1)
         print("✅ Verification succeeded. All global certs are present on Bangladesh app.")
         PY
+          then
+            verify_status=0
+          else
+            verify_status=$?
+          fi
+          if [ "$verify_status" -eq 0 ]; then
+            break
+          fi
+          if [ "$attempt" -ge "$max_attempts" ]; then
+            exit "$verify_status"
+          fi
+          echo "⏳ Verification still missing certs. Waiting ${sleep_seconds}s before retry..."
+          sleep "$sleep_seconds"
+          attempt=$((attempt + 1))
+        done
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
### Motivation
- Make the SHA certificate copy step more observable by printing the missing-cert list and surfacing HTTP/curl errors and response bodies for troubleshooting. 
- Harden shell execution and `curl` usage to avoid silent failures caused by line-continuation/formatting issues and to capture HTTP status codes. 
- Reduce flakes caused by API propagation delays by retrying post-copy verification before failing the build.

### Description
- Enabled stricter shell flags with `set -euo pipefail` in build steps to fail fast on unexpected errors. 
- Replaced silent `curl` calls with `curl -sS -w '\n%{http_code}'` and persisted response bodies to files, logging non-200 responses and printing response bodies for successes and failures. 
- Added explicit logging of the missing SHA list (`/workspace/sha_missing.txt`) before attempting adds, and improved JSON decode diagnostics by printing raw content on `json.JSONDecodeError`. 
- Made the add-step resilient to `curl` runtime errors by capturing `curl` failures, counting failures, and always printing the API response body (or `<empty>`); added a verification retry loop (`max_attempts=3`, `sleep_seconds=5`) that re-checks presence of certs before failing.

### Testing
- An automated Cloud Build run in the transcript prior to these edits failed due to missing certs after verification retries exhausted and the step exited non-zero. 
- No automated CI or Cloud Build was executed against the modified code after applying these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a79ce064c8330b5a8edb0ca32c846)