### PR TITLE
Add preflight dependency checks for copy-test-to-dev script

### DIFF
--- a/tools/copy-test-to-dev/copy-test-to-dev.js
+++ b/tools/copy-test-to-dev/copy-test-to-dev.js
@@ -1,7 +1,33 @@
 // tools/copy-test-to-dev/copy-test-to-dev.js
 const fs = require('fs');
 const path = require('path');
-const admin = require('firebase-admin');
+const { createRequire } = require('module');
+
+const LOCAL_NODE_MODULES = path.join(__dirname, 'node_modules');
+const ROOT_NODE_MODULES = path.join(__dirname, '..', '..', 'node_modules');
+const LOCAL_FIREBASE_ADMIN = path.join(LOCAL_NODE_MODULES, 'firebase-admin');
+const ROOT_FIREBASE_ADMIN = path.join(ROOT_NODE_MODULES, 'firebase-admin');
+
+const moduleBaseDir = fs.existsSync(LOCAL_FIREBASE_ADMIN)
+  ? __dirname
+  : path.join(__dirname, '..', '..');
+const moduleNodeModules = fs.existsSync(LOCAL_FIREBASE_ADMIN)
+  ? LOCAL_NODE_MODULES
+  : ROOT_NODE_MODULES;
+
+if (!fs.existsSync(LOCAL_FIREBASE_ADMIN) && !fs.existsSync(ROOT_FIREBASE_ADMIN)) {
+  console.error('❌ Missing firebase-admin dependency.');
+  console.error('   Run `npm install` in tools/copy-test-to-dev or in the repo root.');
+  process.exit(1);
+}
+
+if (!fs.existsSync(path.join(moduleNodeModules, '@google-cloud', 'firestore'))) {
+  console.error('❌ Missing @google-cloud/firestore dependency for firebase-admin.');
+  console.error(`   Run \`npm install\` in ${moduleBaseDir} to install it.`);
+  process.exit(1);
+}
+
+const admin = createRequire(path.join(moduleBaseDir, 'package.json'))('firebase-admin');
 
 // Collections to copy from Firestore
 const FIRESTORE_COLLECTIONS = [


### PR DESCRIPTION
### Motivation
- Running `tools/copy-test-to-dev/copy-test-to-dev.js` failed with a cryptic `Cannot find module '@google-cloud/firestore/build/src/path'` when `firebase-admin` was resolved from a different `node_modules`; the script should surface a clear error and guidance when dependencies are missing or installed in a different location.

### Description
- Add deterministic module resolution that prefers a local `tools/copy-test-to-dev/node_modules` and falls back to the repo root `node_modules` using `createRequire` to load `firebase-admin` from the chosen package base.
- Add preflight checks that verify `firebase-admin` exists either locally or at the repo root and that `@google-cloud/firestore` is present under the selected `node_modules`, and print actionable `npm install` guidance when missing.
- Implement the changes in `tools/copy-test-to-dev/copy-test-to-dev.js` and keep original copy/clear logic unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fb97f1a348330894c36a91fc02224)