### PR TITLE
Add @google-cloud/firestore dependency for admin tooling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@google-cloud/firestore": "^7.11.6",
         "firebase-admin": "^12.7.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@google-cloud/firestore": "^7.11.6",
     "firebase-admin": "^12.7.0"
   },
   "overrides": {


### PR DESCRIPTION
### Motivation
- Ensure `firebase-admin`-based admin tooling (e.g. `tools/copy-test-to-dev/copy-test-to-dev.js`) can resolve the Firestore client at runtime because the script previously failed with a missing `@google-cloud/firestore` error.

### Description
- Add `@google-cloud/firestore` to `dependencies` in `package.json` and synchronize the root `package-lock.json` entry so the lockfile reflects the new direct dependency.

### Testing
- Ran `npm install` in the repo root which completed successfully, but `npm install @google-cloud/firestore` failed with a `403 Forbidden` from the registry, so the dependency installation could not be validated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fbc5e282483309831c35236d617ab)