### PR TITLE
Default Android Gradle build to dev/global flavor

### DIFF
--- a/mobile/app/build.gradle
+++ b/mobile/app/build.gradle
@@ -31,7 +31,7 @@ def detectMarketFromTasks = {
     return "global"  // Default to global if not detected
 }
 
-ext.buildEnv = project.findProperty("env") ?: detectEnvFromTasks() ?: ""
+ext.buildEnv = project.findProperty("env") ?: detectEnvFromTasks() ?: "dev"
 // buildMarket is detected for informational logging purposes
 // Note: The copyGoogleServicesJson task uses a single file for all markets
 ext.buildMarket = project.findProperty("market") ?: detectMarketFromTasks() ?: "global"


### PR DESCRIPTION
### Motivation
- Ensure builds that do not specify a variant or `-Penv` default to the development/global configuration so local builds behave as expected.

### Description
- Update `mobile/app/build.gradle` to set `ext.buildEnv` fallback to `"dev"` (previously empty) while keeping the market fallback as `"global"`, so the default build becomes `dev`/`global`.

### Testing
- No automated tests were run for this trivial configuration change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980e12e4a9483309851fe75d5700f9f)