### PR TITLE
Fix unchecked cast in tournaments flavour filter

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentsActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentsActivity.java
@@ -130,13 +130,13 @@ public class TournamentsActivity extends BaseActivity {
             for (DocumentSnapshot doc : snap.getDocuments()) {
                 // Filter tournaments based on visibleInFlavours field
                 // If the field doesn't exist, show the tournament (backward compatibility)
-                List<String> visibleInFlavours;
-                visibleInFlavours = (List<String>) doc.get("visibleInFlavours");
-                if (visibleInFlavours != null) {
-                        if (!visibleInFlavours.contains(currentFlavour)) {
-                            // Skip this tournament - not visible in current flavour
-                            continue;
-                        }
+                Object visibleInFlavoursObj = doc.get("visibleInFlavours");
+                if (visibleInFlavoursObj instanceof List<?>) {
+                    List<?> visibleInFlavours = (List<?>) visibleInFlavoursObj;
+                    if (!visibleInFlavours.contains(currentFlavour)) {
+                        // Skip this tournament - not visible in current flavour
+                        continue;
+                    }
                 }
 
                 String status = doc.getString("status");
@@ -293,4 +293,3 @@ public class TournamentsActivity extends BaseActivity {
     }
 
 }
-


### PR DESCRIPTION
### Motivation
- Avoid an unchecked cast and potential ClassCastException when reading the `visibleInFlavours` field from Firestore by performing a safe runtime type check.

### Description
- Replace the unchecked cast `(List<String>) doc.get("visibleInFlavours")` with an `instanceof` check and a safe cast to `List<?>` in `mobile/app/src/main/java/piotr_gorczynski/soccer2/TournamentsActivity.java` so the code only filters by flavour when the field is actually a list.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987036dd9488330b5436958e7c1bb61)