### PR TITLE
Update tournament config for Spring Warm-Up Showdown

### DIFF
--- a/tools/create-tournament/tournament-config.json
+++ b/tools/create-tournament/tournament-config.json
@@ -1,8 +1,8 @@
 {
-  "name": "🇧🇩 Bangladesh Championship",
+  "name": "🌱 Spring Warm-Up Showdown",
   "maxParticipants": 16,
-  "registrationDeadline": "2026-02-15T00:00:00Z",
-  "matchesDeadline": "2026-02-28T23:59:59Z",
+  "registrationDeadline": "2026-02-28T23:59:00Z",
+  "matchesDeadline": "2026-03-14T23:59:00Z",
   "regulation": "kMkYf7Y7WEPNEXcJbj6E",
-  "visibleInFlavours": ["bangladesh"]
+  "visibleInFlavours": ["global"]
 }


### PR DESCRIPTION
### Motivation
- Provide a new tournament configuration for the Spring Warm-Up Showdown with the requested name, dates, regulation ID, and global visibility.

### Description
- Replaced `tools/create-tournament/tournament-config.json` values to set `name` to `🌱 Spring Warm-Up Showdown`.
- Updated `registrationDeadline` to `2026-02-28T23:59:00Z` which corresponds to `1 March 2026 00:59:00 UTC+1`.
- Updated `matchesDeadline` to `2026-03-14T23:59:00Z` which corresponds to `15 March 2026 00:59:00 UTC+1`.
- Set `visibleInFlavours` to `["global"]` and preserved the `regulation` ID `kMkYf7Y7WEPNEXcJbj6E`.

### Testing
- Parsed the updated JSON with `node -e "JSON.parse(require('fs').readFileSync('tools/create-tournament/tournament-config.json','utf8'))"` and it succeeded (valid JSON).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69908c8df8348330adf3a9e021ebe530)