### PR TITLE
Remove deprecated AGP property overrides from mobile/gradle.properties

### DIFF
--- a/mobile/gradle.properties
+++ b/mobile/gradle.properties
@@ -9,7 +9,6 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-android.nonFinalResIds=false
 android.nonTransitiveRClass=false
 org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 
@@ -21,14 +20,6 @@ org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 
 #GPT fixes...
 android.useAndroidX=true
-android.enableJetifier=true
-android.defaults.buildfeatures.resvalues=true
-android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
-android.enableAppCompileTimeRClass=false
-android.usesSdkInManifest.disallowed=false
 android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.r8.strictFullModeForKeepRules=false
-android.r8.optimizedResourceShrinking=false
-android.builtInKotlin=false
-android.newDsl=false


### PR DESCRIPTION
### Motivation
- The project configuration emitted AGP deprecation warnings caused by explicit property overrides in `mobile/gradle.properties`, so the overrides were removed to allow the Android Gradle Plugin to use safe defaults.

### Description
- Removed deprecated property overrides from `mobile/gradle.properties` (for example `android.enableJetifier`, `android.newDsl`, `android.builtInKotlin`, `android.enableAppCompileTimeRClass`, `android.usesSdkInManifest.disallowed`, `android.r8.optimizedResourceShrinking`, `android.defaults.buildfeatures.resvalues`, `android.sdk.defaultTargetSdkToCompileSdkIfUnset`, and `android.nonFinalResIds`) and preserved the remaining non-deprecated settings.

### Testing
- Attempted to run `cd mobile && ./gradlew :app:assemble_devBangladeshDebug --warning-mode all`, but the build could not complete in this environment because the Gradle wrapper download was blocked by the network proxy (`HTTP/1.1 403 Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b2cac7c5c8330a42df6f92ada755a)