### PR TITLE
Suppress deprecated signing API warning in FirebaseAuthManager

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java
@@ -198,6 +198,7 @@ public class FirebaseAuthManager {
                 });
     }
 
+    @SuppressWarnings("deprecation")
     private String getSigningCertificateHashes() {
         try {
             PackageManager packageManager = context.getPackageManager();


### PR DESCRIPTION
### Motivation
- The pre-Android P fallback in `getSigningCertificateHashes()` intentionally uses the legacy `PackageManager.GET_SIGNATURES` / `PackageInfo.signatures` API and was emitting deprecation warnings during compilation, cluttering build output.

### Description
- Added `@SuppressWarnings("deprecation")` to `getSigningCertificateHashes()` in `mobile/app/src/main/java/piotr_gorczynski/soccer2/FirebaseAuthManager.java` to silence the deprecation warning while preserving the backwards-compatible logic for pre-Android P devices.

### Testing
- Attempted to run `./gradlew :app:compile_devBangladeshDebugJavaWithJavac` from `mobile/`, but the Gradle wrapper download failed due to a network proxy error (`HTTP 403 Forbidden`), so a local compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b3106bddc833084913aedfa77e004)