### PR TITLE
Suppress Android Studio library constraints sync warning

### DIFF
--- a/mobile/gradle.properties
+++ b/mobile/gradle.properties
@@ -22,4 +22,5 @@ org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.uniquePackageNames=false
 android.dependency.useConstraints=true
+android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false
 android.r8.strictFullModeForKeepRules=false


### PR DESCRIPTION
### Motivation
- Suppress the Android Studio sync warning about `android.dependency.excludeLibraryComponentsFromConstraints` while leaving existing dependency-constraint behavior (`android.dependency.useConstraints=true`) unchanged.

### Description
- Added `android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false` to `mobile/gradle.properties` to disable the sync-time warning.

### Testing
- Ran `./gradlew clean` from `mobile/` and the build completed successfully and the previous sync warning no longer appears during Gradle configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b3474985c8330aa66e7d6622dbd3c)