### PR TITLE
Improve Bangladesh migration logging visibility

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/BangladeshMigrationHelper.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/BangladeshMigrationHelper.java
@@ -16,7 +16,8 @@ import java.util.Locale;
  */
 public class BangladeshMigrationHelper {
     
-    private static final String TAG = "BangladeshMigration";
+    // Use app-wide tag so these logs are visible when filtering logcat by TAG_Soccer.
+    private static final String TAG = "TAG_Soccer";
     private static final String PREF_BD_PROMO_DISMISSED = "bd_promo_dismissed";
     private static final String PREF_BD_PROMO_LAST_SHOWN = "bd_promo_last_shown_ms";
     private static final String PREF_BD_PROMO_DISMISS_COUNT = "bd_promo_dismiss_count";
@@ -41,7 +42,7 @@ public class BangladeshMigrationHelper {
      */
     public static boolean isUserInBangladesh() {
         String countryCode = Locale.getDefault().getCountry();
-        Log.d(TAG, "Device country code: " + countryCode);
+        Log.d(TAG, "BangladeshMigrationHelper.isUserInBangladesh: Device country code: " + countryCode);
         
         // FOR DEBUGGING: Change "BD" to your country code (e.g., "PL" for Poland)
         return "BD".equals(countryCode);
@@ -62,13 +63,13 @@ public class BangladeshMigrationHelper {
     public static boolean shouldShowPromotion(Context context) {
         // Only show in global flavor
         if (!AppFlavourDetector.isGlobalFlavour(context)) {
-            Log.d(TAG, "Not showing promo: not global flavor");
+            Log.d(TAG, "BangladeshMigrationHelper.shouldShowPromotion: Not showing promo: not global flavor");
             return false;
         }
         
         // Only show to Bangladesh users
         if (!isUserInBangladesh()) {
-            Log.d(TAG, "Not showing promo: user not in Bangladesh");
+            Log.d(TAG, "BangladeshMigrationHelper.shouldShowPromotion: Not showing promo: user not in Bangladesh");
             return false;
         }
         
@@ -77,7 +78,7 @@ public class BangladeshMigrationHelper {
         // Check if permanently dismissed (after multiple dismissals)
         int dismissCount = prefs.getInt(PREF_BD_PROMO_DISMISS_COUNT, 0);
         if (dismissCount >= 3) {
-            Log.d(TAG, "Not showing promo: dismissed " + dismissCount + " times (permanent)");
+            Log.d(TAG, "BangladeshMigrationHelper.shouldShowPromotion: Not showing promo: dismissed " + dismissCount + " times (permanent)");
             return false;
         }
         
@@ -89,16 +90,16 @@ public class BangladeshMigrationHelper {
             long timeSinceDismissMs = currentMs - lastShownMs;
             
             if (timeSinceDismissMs < PROMO_RESHOW_DELAY_MS) {
-                Log.d(TAG, "Not showing promo: dismissed recently (will show again in " + 
+                Log.d(TAG, "BangladeshMigrationHelper.shouldShowPromotion: Not showing promo: dismissed recently (will show again in " + 
                     ((PROMO_RESHOW_DELAY_MS - timeSinceDismissMs) / (24 * 60 * 60 * 1000)) + " days)");
                 return false;
             } else {
                 // Time to show again
-                Log.d(TAG, "Time to show promo again (7 days passed)");
+                Log.d(TAG, "BangladeshMigrationHelper.shouldShowPromotion: Time to show promo again (7 days passed)");
             }
         }
         
-        Log.d(TAG, "Should show Bangladesh promotion");
+        Log.d(TAG, "BangladeshMigrationHelper.shouldShowPromotion: Should show Bangladesh promotion");
         return true;
     }
     


### PR DESCRIPTION
### Motivation
- The Bangladesh migration helper was logging under a different tag (`BangladeshMigration`) than the rest of the app log stream (`TAG_Soccer`), which made its runtime messages invisible when filtering logcat by `TAG_Soccer` and gave the false impression the helper never ran. 

### Description
- Switched the helper logging tag to `TAG_Soccer` so messages appear in the same filtered logcat stream as the app.  
- Prefixed key debug messages with method names (e.g., `BangladeshMigrationHelper.isUserInBangladesh` and `BangladeshMigrationHelper.shouldShowPromotion`) to make execution flow easier to confirm in runtime logs.  
- Updated several `Log.d` lines in `mobile/app/src/main/java/piotr_gorczynski/soccer2/BangladeshMigrationHelper.java` to use the new tag and more informative messages.  

### Testing
- Attempted to run tests using `./gradlew :mobile:app:testDebugUnitTest --tests piotr_gorczynski.soccer2.BangladeshMigrationHelperTest`, which failed because the wrapper is located under `mobile/gradlew` not at the repo root.  
- Ran discovery with `./gradlew :app:tasks --all` to find the correct variant-specific unit test tasks.  
- Attempted to run `./gradlew test_devGlobalDebugUnitTest --tests piotr_gorczynski.soccer2.BangladeshMigrationHelperTest`, but the build was blocked by missing Android SDK configuration (`ANDROID_HOME`/`local.properties`), so unit tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b397b17108330ac803cf0252c6127)