### PR TITLE
Add detailed diagnostics for Bangladesh global-app uninstall flow

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/BangladeshMigrationHelper.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/BangladeshMigrationHelper.java
@@ -245,13 +245,20 @@ public class BangladeshMigrationHelper {
      * @return true if the prompt should be shown
      */
     public static boolean shouldShowUninstallGlobalPrompt(Context context) {
-        if (!AppFlavourDetector.isBangladeshFlavour(context)) {
+        boolean isBangladeshFlavour = AppFlavourDetector.isBangladeshFlavour(context);
+        Log.d(TAG, "BangladeshMigrationHelper.shouldShowUninstallGlobalPrompt: isBangladeshFlavour=" + isBangladeshFlavour);
+        if (!isBangladeshFlavour) {
             return false;
         }
-        if (!isGlobalAppInstalled(context)) {
+
+        boolean globalInstalled = isGlobalAppInstalled(context);
+        Log.d(TAG, "BangladeshMigrationHelper.shouldShowUninstallGlobalPrompt: globalInstalled=" + globalInstalled);
+        if (!globalInstalled) {
             Log.d(TAG, "BangladeshMigrationHelper.shouldShowUninstallGlobalPrompt: Global app not installed");
             return false;
         }
+
+        Log.d(TAG, "BangladeshMigrationHelper.shouldShowUninstallGlobalPrompt: Showing uninstall prompt");
         return true;
     }
 
@@ -265,8 +272,10 @@ public class BangladeshMigrationHelper {
     public static boolean isGlobalAppInstalled(Context context) {
         try {
             context.getPackageManager().getPackageInfo(GLOBAL_APP_PACKAGE, 0);
+            Log.d(TAG, "BangladeshMigrationHelper.isGlobalAppInstalled: package " + GLOBAL_APP_PACKAGE + " is installed");
             return true;
         } catch (PackageManager.NameNotFoundException e) {
+            Log.d(TAG, "BangladeshMigrationHelper.isGlobalAppInstalled: package " + GLOBAL_APP_PACKAGE + " is NOT installed");
             return false;
         }
     }

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -2338,7 +2338,17 @@ public class MenuActivity extends BaseActivity {
      * the global version.
      */
     private void checkAndShowUninstallGlobalPrompt() {
+        Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: entered with state {isFinishing="
+                + isFinishing()
+                + ", isDestroyed="
+                + isDestroyed()
+                + ", globalUninstallPending="
+                + globalUninstallPending
+                + ", globalUninstallDialogOpen="
+                + globalUninstallDialogOpen
+                + "}");
         if (isFinishing() || isDestroyed()) {
+            Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: returning early because activity is finishing/destroyed");
             return;
         }
         if (globalUninstallPending) {
@@ -2348,12 +2358,16 @@ public class MenuActivity extends BaseActivity {
             // onWindowFocusChanged(true) will fire once the system dialog actually closes
             // and will call this method again to re-check the global-app state.
             globalUninstallPending = false;
+            Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: consumed globalUninstallPending=true and skipped prompt on this pass");
             return;
         }
-        if (!BangladeshMigrationHelper.shouldShowUninstallGlobalPrompt(this)) {
+        boolean shouldShow = BangladeshMigrationHelper.shouldShowUninstallGlobalPrompt(this);
+        Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: helper decision shouldShow=" + shouldShow);
+        if (!shouldShow) {
             return;
         }
         final boolean[] uninstallClicked = {false};
+        Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: showing uninstall-required dialog");
         AlertDialog dialog = new AlertDialog.Builder(this)
                 .setTitle(R.string.uninstall_global_title)
                 .setMessage(R.string.uninstall_global_message)
@@ -2361,12 +2375,25 @@ public class MenuActivity extends BaseActivity {
                     uninstallClicked[0] = true;
                     globalUninstallPending = true;
                     globalUninstallDialogOpen = true;
+                    Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: uninstall clicked; updated flags {globalUninstallPending="
+                            + globalUninstallPending
+                            + ", globalUninstallDialogOpen="
+                            + globalUninstallDialogOpen
+                            + "}");
                     BangladeshMigrationHelper.promptUninstallGlobalApp(this);
                 })
                 .setCancelable(false)
                 .create();
         dialog.setOnDismissListener(d -> {
+            Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: dialog dismissed; uninstallClicked="
+                    + uninstallClicked[0]
+                    + ", flags {globalUninstallPending="
+                    + globalUninstallPending
+                    + ", globalUninstallDialogOpen="
+                    + globalUninstallDialogOpen
+                    + "}");
             if (!uninstallClicked[0]) {
+                Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: uninstall not clicked -> finishing activity");
                 finish();
             }
         });


### PR DESCRIPTION
### Motivation
- Diagnose why the Bangladesh flavor uninstall dialog reappears after tapping `Uninstall` by producing clearer runtime traces. 

### Description
- Add verbose `Log.d` tracing in `MenuActivity.checkAndShowUninstallGlobalPrompt()` to record entry state (`isFinishing`, `isDestroyed`, `globalUninstallPending`, `globalUninstallDialogOpen`), early-return reasons, helper decision, dialog lifecycle events, and flag transitions. 
- Add logging in `BangladeshMigrationHelper.shouldShowUninstallGlobalPrompt()` to record flavor detection and the helper decision. 
- Add logging in `BangladeshMigrationHelper.isGlobalAppInstalled()` to record whether the global package is detected as installed. 
- Changes touch `mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java` and `mobile/app/src/main/java/piotr_gorczynski/soccer2/BangladeshMigrationHelper.java`. 

### Testing
- Ran `./gradlew :app:tasks --all | rg -n "test|unit" -i` to discover available test tasks, which executed successfully. 
- Attempted `./gradlew :mobile:app:testDebugUnitTest --tests "piotr_gorczynski.soccer2.BangladeshMigrationHelperTest"`, which failed due to incorrect project/task path in this repo layout. 
- Attempted `./gradlew :app:test_testBangladeshDebugUnitTest --tests "piotr_gorczynski.soccer2.BangladeshMigrationHelperTest"`, which failed because the Android SDK location is not configured in the environment (missing `ANDROID_HOME` / `local.properties sdk.dir`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c02dd4148330be8e22cd43012876)