### PR TITLE
Handle Global-app uninstall flow with ActivityResultLauncher and add diagnostic logs

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/BangladeshMigrationHelper.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/BangladeshMigrationHelper.java
@@ -245,13 +245,20 @@ public class BangladeshMigrationHelper {
      * @return true if the prompt should be shown
      */
     public static boolean shouldShowUninstallGlobalPrompt(Context context) {
-        if (!AppFlavourDetector.isBangladeshFlavour(context)) {
+        boolean isBangladeshFlavour = AppFlavourDetector.isBangladeshFlavour(context);
+        Log.d(TAG, "BangladeshMigrationHelper.shouldShowUninstallGlobalPrompt: isBangladeshFlavour=" + isBangladeshFlavour);
+        if (!isBangladeshFlavour) {
             return false;
         }
-        if (!isGlobalAppInstalled(context)) {
+
+        boolean globalInstalled = isGlobalAppInstalled(context);
+        Log.d(TAG, "BangladeshMigrationHelper.shouldShowUninstallGlobalPrompt: globalInstalled=" + globalInstalled);
+        if (!globalInstalled) {
             Log.d(TAG, "BangladeshMigrationHelper.shouldShowUninstallGlobalPrompt: Global app not installed");
             return false;
         }
+
+        Log.d(TAG, "BangladeshMigrationHelper.shouldShowUninstallGlobalPrompt: Showing uninstall prompt");
         return true;
     }
 
@@ -265,10 +272,23 @@ public class BangladeshMigrationHelper {
     public static boolean isGlobalAppInstalled(Context context) {
         try {
             context.getPackageManager().getPackageInfo(GLOBAL_APP_PACKAGE, 0);
+            Log.d(TAG, "BangladeshMigrationHelper.isGlobalAppInstalled: package " + GLOBAL_APP_PACKAGE + " is installed");
             return true;
         } catch (PackageManager.NameNotFoundException e) {
+            Log.d(TAG, "BangladeshMigrationHelper.isGlobalAppInstalled: package " + GLOBAL_APP_PACKAGE + " is NOT installed");
             return false;
         }
+    }
+
+    /**
+     * Build uninstall intent for the Global app package.
+     * Includes EXTRA_RETURN_RESULT so caller can observe user action outcome.
+     */
+    public static Intent buildUninstallGlobalAppIntent() {
+        Intent intent = new Intent(Intent.ACTION_DELETE);
+        intent.setData(Uri.parse("package:" + GLOBAL_APP_PACKAGE));
+        intent.putExtra(Intent.EXTRA_RETURN_RESULT, true);
+        return intent;
     }
 
     /**
@@ -280,8 +300,7 @@ public class BangladeshMigrationHelper {
      */
     public static void promptUninstallGlobalApp(Context context) {
         try {
-            Intent intent = new Intent(Intent.ACTION_DELETE);
-            intent.setData(Uri.parse("package:" + GLOBAL_APP_PACKAGE));
+            Intent intent = buildUninstallGlobalAppIntent();
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             context.startActivity(intent);
             Log.d(TAG, "Opened system uninstall dialog for Global app");

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -28,6 +28,8 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 
 import com.google.android.gms.ads.AdError;
 import com.google.android.gms.ads.FullScreenContentCallback;
@@ -110,9 +112,23 @@ public class MenuActivity extends BaseActivity {
     private boolean isAdLoading = false;
     private boolean globalUninstallPending = false; // true during the transient onResume caused by launching the system dialog
     private boolean globalUninstallDialogOpen = false; // true from when the system dialog is launched until focus returns
+    private boolean awaitingGlobalUninstallResult = false;
+    private static final long GLOBAL_UNINSTALL_RECHECK_DELAY_MS = 1500L;
     private View loadingOverlay;
     private final Handler overlayHandler = new Handler(Looper.getMainLooper());
     private final Runnable hideOverlayRunnable = this::hideLoadingOverlayImmediate;
+    private final Runnable delayedUninstallRecheckRunnable = this::checkAndShowUninstallGlobalPrompt;
+    private final ActivityResultLauncher<Intent> uninstallGlobalAppLauncher =
+            registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
+                awaitingGlobalUninstallResult = false;
+                globalUninstallDialogOpen = false;
+                globalUninstallPending = false;
+                Log.d("TAG_Soccer", "MenuActivity.uninstallGlobalAppLauncher: resultCode=" + result.getResultCode());
+                overlayHandler.removeCallbacks(delayedUninstallRecheckRunnable);
+                overlayHandler.postDelayed(delayedUninstallRecheckRunnable, GLOBAL_UNINSTALL_RECHECK_DELAY_MS);
+                Log.d("TAG_Soccer", "MenuActivity.uninstallGlobalAppLauncher: scheduled uninstall-state recheck in "
+                        + GLOBAL_UNINSTALL_RECHECK_DELAY_MS + "ms");
+            });
     private long loadingOverlayShownAtMs = 0L;
     private static final long MIN_LOADING_OVERLAY_DURATION_MS = 250L;
 
@@ -598,16 +614,9 @@ public class MenuActivity extends BaseActivity {
     @Override
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
-        // When the system uninstall dialog opens in a new task the activity may remain
-        // "resumed" (no second onResume fires after the dialog closes). Detect the dialog
-        // closing via focus returning to verify the uninstall result.
-        // globalUninstallDialogOpen guards against unrelated focus changes (keyboard, etc.).
-        if (hasFocus && globalUninstallDialogOpen) {
+        if (hasFocus && globalUninstallDialogOpen && !awaitingGlobalUninstallResult) {
+            Log.d("TAG_Soccer", "MenuActivity.onWindowFocusChanged: focus returned with no pending uninstall result callback; forcing recheck");
             globalUninstallDialogOpen = false;
-            // Do not reset globalUninstallPending here: if no transient resume occurred it
-            // is still true and checkAndShowUninstallGlobalPrompt() will reset it and return
-            // early, deferring the real check to the subsequent continueOnResumeAfterBackendCheck
-            // call. If the transient resume already reset it, the check runs immediately below.
             checkAndShowUninstallGlobalPrompt();
         }
     }
@@ -2338,7 +2347,23 @@ public class MenuActivity extends BaseActivity {
      * the global version.
      */
     private void checkAndShowUninstallGlobalPrompt() {
+        Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: entered with state {isFinishing="
+                + isFinishing()
+                + ", isDestroyed="
+                + isDestroyed()
+                + ", globalUninstallPending="
+                + globalUninstallPending
+                + ", globalUninstallDialogOpen="
+                + globalUninstallDialogOpen
+                + ", awaitingGlobalUninstallResult="
+                + awaitingGlobalUninstallResult
+                + "}");
         if (isFinishing() || isDestroyed()) {
+            Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: returning early because activity is finishing/destroyed");
+            return;
+        }
+        if (awaitingGlobalUninstallResult) {
+            Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: uninstall flow is in progress; waiting for result callback");
             return;
         }
         if (globalUninstallPending) {
@@ -2348,12 +2373,16 @@ public class MenuActivity extends BaseActivity {
             // onWindowFocusChanged(true) will fire once the system dialog actually closes
             // and will call this method again to re-check the global-app state.
             globalUninstallPending = false;
+            Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: consumed globalUninstallPending=true and skipped prompt on this pass");
             return;
         }
-        if (!BangladeshMigrationHelper.shouldShowUninstallGlobalPrompt(this)) {
+        boolean shouldShow = BangladeshMigrationHelper.shouldShowUninstallGlobalPrompt(this);
+        Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: helper decision shouldShow=" + shouldShow);
+        if (!shouldShow) {
             return;
         }
         final boolean[] uninstallClicked = {false};
+        Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: showing uninstall-required dialog");
         AlertDialog dialog = new AlertDialog.Builder(this)
                 .setTitle(R.string.uninstall_global_title)
                 .setMessage(R.string.uninstall_global_message)
@@ -2361,12 +2390,28 @@ public class MenuActivity extends BaseActivity {
                     uninstallClicked[0] = true;
                     globalUninstallPending = true;
                     globalUninstallDialogOpen = true;
-                    BangladeshMigrationHelper.promptUninstallGlobalApp(this);
+                    Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: uninstall clicked; updated flags {globalUninstallPending="
+                            + globalUninstallPending
+                            + ", globalUninstallDialogOpen="
+                            + globalUninstallDialogOpen
+                            + "}");
+                    awaitingGlobalUninstallResult = true;
+                    Intent uninstallIntent = BangladeshMigrationHelper.buildUninstallGlobalAppIntent();
+                    Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: launching uninstall intent=" + uninstallIntent);
+                    uninstallGlobalAppLauncher.launch(uninstallIntent);
                 })
                 .setCancelable(false)
                 .create();
         dialog.setOnDismissListener(d -> {
+            Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: dialog dismissed; uninstallClicked="
+                    + uninstallClicked[0]
+                    + ", flags {globalUninstallPending="
+                    + globalUninstallPending
+                    + ", globalUninstallDialogOpen="
+                    + globalUninstallDialogOpen
+                    + "}");
             if (!uninstallClicked[0]) {
+                Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: uninstall not clicked -> finishing activity");
                 finish();
             }
         });


### PR DESCRIPTION
### Motivation
- Improve the Bangladesh-flavor flow that prompts users to uninstall the Global app by making the uninstall interaction observable and more robust.
- Add diagnostic logging to help trace why the uninstall prompt is shown or skipped and to aid debugging of transient lifecycle edge cases.
- Avoid re-showing the prompt during the transient onPause/onResume when the system uninstall dialog opens in a separate task.

### Description
- Added detailed `Log.d` messages throughout `BangladeshMigrationHelper` and `MenuActivity` to surface decisions about flavor detection and Global-app presence and to trace the uninstall prompt lifecycle.
- Extracted the uninstall intent creation into `BangladeshMigrationHelper.buildUninstallGlobalAppIntent()` and set `Intent.EXTRA_RETURN_RESULT` so the caller can observe the outcome.
- Reworked the uninstall flow in `MenuActivity` to use an `ActivityResultLauncher` (`uninstallGlobalAppLauncher`) and a new `awaitingGlobalUninstallResult` flag, and schedule a delayed recheck (`GLOBAL_UNINSTALL_RECHECK_DELAY_MS`) after the uninstall activity returns.
- Hardened lifecycle handling by consuming the `globalUninstallPending` transient resume, preventing repeated prompts, and added focus-based fallback recheck in `onWindowFocusChanged` when no result callback is pending.

### Testing
- Verified the project builds successfully with `./gradlew assembleDebug` to ensure compilation after the changes (build succeeded).
- Ran unit tests with `./gradlew test` to validate logic-level tests (no failing tests reported).
- Exercised the uninstall-dialog flow via the instrumentation/debug run to confirm the `ActivityResultLauncher` path and the delayed recheck are invoked (no automated failures reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c02dd4148330be8e22cd43012876)