### PR TITLE
Handle Global app uninstall flow and add result handling/logging for Bangladesh migration

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/BangladeshMigrationHelper.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/BangladeshMigrationHelper.java
@@ -245,13 +245,20 @@ public class BangladeshMigrationHelper {
      * @return true if the prompt should be shown
      */
     public static boolean shouldShowUninstallGlobalPrompt(Context context) {
-        if (!AppFlavourDetector.isBangladeshFlavour(context)) {
+        boolean isBangladeshFlavour = AppFlavourDetector.isBangladeshFlavour(context);
+        Log.d(TAG, "BangladeshMigrationHelper.shouldShowUninstallGlobalPrompt: isBangladeshFlavour=" + isBangladeshFlavour);
+        if (!isBangladeshFlavour) {
             return false;
         }
-        if (!isGlobalAppInstalled(context)) {
+
+        boolean globalInstalled = isGlobalAppInstalled(context);
+        Log.d(TAG, "BangladeshMigrationHelper.shouldShowUninstallGlobalPrompt: globalInstalled=" + globalInstalled);
+        if (!globalInstalled) {
             Log.d(TAG, "BangladeshMigrationHelper.shouldShowUninstallGlobalPrompt: Global app not installed");
             return false;
         }
+
+        Log.d(TAG, "BangladeshMigrationHelper.shouldShowUninstallGlobalPrompt: Showing uninstall prompt");
         return true;
     }
 
@@ -265,10 +272,23 @@ public class BangladeshMigrationHelper {
     public static boolean isGlobalAppInstalled(Context context) {
         try {
             context.getPackageManager().getPackageInfo(GLOBAL_APP_PACKAGE, 0);
+            Log.d(TAG, "BangladeshMigrationHelper.isGlobalAppInstalled: package " + GLOBAL_APP_PACKAGE + " is installed");
             return true;
         } catch (PackageManager.NameNotFoundException e) {
+            Log.d(TAG, "BangladeshMigrationHelper.isGlobalAppInstalled: package " + GLOBAL_APP_PACKAGE + " is NOT installed");
             return false;
         }
+    }
+
+    /**
+     * Build uninstall intent for the Global app package.
+     * Includes EXTRA_RETURN_RESULT so caller can observe user action outcome.
+     */
+    public static Intent buildUninstallGlobalAppIntent() {
+        Intent intent = new Intent(Intent.ACTION_DELETE);
+        intent.setData(Uri.parse("package:" + GLOBAL_APP_PACKAGE));
+        intent.putExtra(Intent.EXTRA_RETURN_RESULT, true);
+        return intent;
     }
 
     /**
@@ -280,8 +300,7 @@ public class BangladeshMigrationHelper {
      */
     public static void promptUninstallGlobalApp(Context context) {
         try {
-            Intent intent = new Intent(Intent.ACTION_DELETE);
-            intent.setData(Uri.parse("package:" + GLOBAL_APP_PACKAGE));
+            Intent intent = buildUninstallGlobalAppIntent();
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             context.startActivity(intent);
             Log.d(TAG, "Opened system uninstall dialog for Global app");

--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -1,6 +1,7 @@
 package piotr_gorczynski.soccer2;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
@@ -28,6 +29,8 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 
 import com.google.android.gms.ads.AdError;
 import com.google.android.gms.ads.FullScreenContentCallback;
@@ -110,9 +113,30 @@ public class MenuActivity extends BaseActivity {
     private boolean isAdLoading = false;
     private boolean globalUninstallPending = false; // true during the transient onResume caused by launching the system dialog
     private boolean globalUninstallDialogOpen = false; // true from when the system dialog is launched until focus returns
+    private boolean awaitingGlobalUninstallResult = false;
     private View loadingOverlay;
     private final Handler overlayHandler = new Handler(Looper.getMainLooper());
     private final Runnable hideOverlayRunnable = this::hideLoadingOverlayImmediate;
+    private final ActivityResultLauncher<Intent> uninstallGlobalAppLauncher =
+            registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
+                awaitingGlobalUninstallResult = false;
+                globalUninstallDialogOpen = false;
+                globalUninstallPending = false;
+
+                boolean uninstallSucceeded = result.getResultCode() == Activity.RESULT_OK;
+                boolean globalStillInstalled = BangladeshMigrationHelper.isGlobalAppInstalled(this);
+                Log.d("TAG_Soccer", "MenuActivity.uninstallGlobalAppLauncher: resultCode=" + result.getResultCode()
+                        + ", uninstallSucceeded=" + uninstallSucceeded
+                        + ", globalStillInstalled=" + globalStillInstalled);
+
+                if (globalStillInstalled) {
+                    Log.w("TAG_Soccer", "MenuActivity.uninstallGlobalAppLauncher: Global app still installed after uninstall flow; finishing activity to enforce uninstall requirement");
+                    finish();
+                    return;
+                }
+
+                Log.d("TAG_Soccer", "MenuActivity.uninstallGlobalAppLauncher: Global app uninstall confirmed");
+            });
     private long loadingOverlayShownAtMs = 0L;
     private static final long MIN_LOADING_OVERLAY_DURATION_MS = 250L;
 
@@ -598,16 +622,9 @@ public class MenuActivity extends BaseActivity {
     @Override
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
-        // When the system uninstall dialog opens in a new task the activity may remain
-        // "resumed" (no second onResume fires after the dialog closes). Detect the dialog
-        // closing via focus returning to verify the uninstall result.
-        // globalUninstallDialogOpen guards against unrelated focus changes (keyboard, etc.).
-        if (hasFocus && globalUninstallDialogOpen) {
+        if (hasFocus && globalUninstallDialogOpen && !awaitingGlobalUninstallResult) {
+            Log.d("TAG_Soccer", "MenuActivity.onWindowFocusChanged: focus returned with no pending uninstall result callback; forcing recheck");
             globalUninstallDialogOpen = false;
-            // Do not reset globalUninstallPending here: if no transient resume occurred it
-            // is still true and checkAndShowUninstallGlobalPrompt() will reset it and return
-            // early, deferring the real check to the subsequent continueOnResumeAfterBackendCheck
-            // call. If the transient resume already reset it, the check runs immediately below.
             checkAndShowUninstallGlobalPrompt();
         }
     }
@@ -2338,7 +2355,23 @@ public class MenuActivity extends BaseActivity {
      * the global version.
      */
     private void checkAndShowUninstallGlobalPrompt() {
+        Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: entered with state {isFinishing="
+                + isFinishing()
+                + ", isDestroyed="
+                + isDestroyed()
+                + ", globalUninstallPending="
+                + globalUninstallPending
+                + ", globalUninstallDialogOpen="
+                + globalUninstallDialogOpen
+                + ", awaitingGlobalUninstallResult="
+                + awaitingGlobalUninstallResult
+                + "}");
         if (isFinishing() || isDestroyed()) {
+            Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: returning early because activity is finishing/destroyed");
+            return;
+        }
+        if (awaitingGlobalUninstallResult) {
+            Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: uninstall flow is in progress; waiting for result callback");
             return;
         }
         if (globalUninstallPending) {
@@ -2348,12 +2381,16 @@ public class MenuActivity extends BaseActivity {
             // onWindowFocusChanged(true) will fire once the system dialog actually closes
             // and will call this method again to re-check the global-app state.
             globalUninstallPending = false;
+            Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: consumed globalUninstallPending=true and skipped prompt on this pass");
             return;
         }
-        if (!BangladeshMigrationHelper.shouldShowUninstallGlobalPrompt(this)) {
+        boolean shouldShow = BangladeshMigrationHelper.shouldShowUninstallGlobalPrompt(this);
+        Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: helper decision shouldShow=" + shouldShow);
+        if (!shouldShow) {
             return;
         }
         final boolean[] uninstallClicked = {false};
+        Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: showing uninstall-required dialog");
         AlertDialog dialog = new AlertDialog.Builder(this)
                 .setTitle(R.string.uninstall_global_title)
                 .setMessage(R.string.uninstall_global_message)
@@ -2361,12 +2398,28 @@ public class MenuActivity extends BaseActivity {
                     uninstallClicked[0] = true;
                     globalUninstallPending = true;
                     globalUninstallDialogOpen = true;
-                    BangladeshMigrationHelper.promptUninstallGlobalApp(this);
+                    Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: uninstall clicked; updated flags {globalUninstallPending="
+                            + globalUninstallPending
+                            + ", globalUninstallDialogOpen="
+                            + globalUninstallDialogOpen
+                            + "}");
+                    awaitingGlobalUninstallResult = true;
+                    Intent uninstallIntent = BangladeshMigrationHelper.buildUninstallGlobalAppIntent();
+                    Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: launching uninstall intent=" + uninstallIntent);
+                    uninstallGlobalAppLauncher.launch(uninstallIntent);
                 })
                 .setCancelable(false)
                 .create();
         dialog.setOnDismissListener(d -> {
+            Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: dialog dismissed; uninstallClicked="
+                    + uninstallClicked[0]
+                    + ", flags {globalUninstallPending="
+                    + globalUninstallPending
+                    + ", globalUninstallDialogOpen="
+                    + globalUninstallDialogOpen
+                    + "}");
             if (!uninstallClicked[0]) {
+                Log.d("TAG_Soccer", "MenuActivity.checkAndShowUninstallGlobalPrompt: uninstall not clicked -> finishing activity");
                 finish();
             }
         });


### PR DESCRIPTION
### Motivation

- Ensure the Bangladesh flavour properly prompts users to remove the Global app and correctly observes the uninstall outcome. 
- Make the uninstall flow robust against transient lifecycle/focus changes caused by the system uninstall dialog. 
- Improve observability with additional debug logging for diagnosing uninstall and flavour detection behavior.

### Description

- Added detailed debug logs in `BangladeshMigrationHelper` and `MenuActivity` to report flavour detection, Global app presence, and uninstall flow state. 
- Introduced `buildUninstallGlobalAppIntent()` in `BangladeshMigrationHelper` and updated `promptUninstallGlobalApp()` to use it so the uninstall intent includes `Intent.EXTRA_RETURN_RESULT`. 
- Added `ActivityResultLauncher` (`uninstallGlobalAppLauncher`) to `MenuActivity` and an `awaitingGlobalUninstallResult` flag to handle the uninstall result callback and avoid duplicate prompts during transient lifecycle events. 
- Updated `checkAndShowUninstallGlobalPrompt()` and `onWindowFocusChanged()` to guard against activity finishing/destroyed state, in-progress uninstall flow, and transient resumes; moved to launching the uninstall via the registered launcher and handle post-uninstall logic (including finishing the activity if the Global app remains installed).

### Testing

- Built the debug APK with `./gradlew assembleDebug` and the build completed successfully. 
- Ran unit tests with `./gradlew test` and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c02dd4148330be8e22cd43012876)