### PR TITLE
Re-prompt uninstall dialog when global app remains installed (Bangladesh flavor)

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java
@@ -130,8 +130,8 @@ public class MenuActivity extends BaseActivity {
                         + ", globalStillInstalled=" + globalStillInstalled);
 
                 if (globalStillInstalled) {
-                    Log.w("TAG_Soccer", "MenuActivity.uninstallGlobalAppLauncher: Global app still installed after uninstall flow; finishing activity to enforce uninstall requirement");
-                    finish();
+                    Log.w("TAG_Soccer", "MenuActivity.uninstallGlobalAppLauncher: Global app still installed after uninstall flow; keeping activity open and re-prompting uninstall requirement");
+                    checkAndShowUninstallGlobalPrompt();
                     return;
                 }
 


### PR DESCRIPTION
### Motivation
- Ensure the Bangladesh-flavor migration flow continues the global uninstall process instead of closing the BD app when the global package is still present.

### Description
- In `MenuActivity` replaced the `finish()` path in the `uninstallGlobalAppLauncher` callback with a call to `checkAndShowUninstallGlobalPrompt()` and updated the log message to reflect re-prompt behavior (file: `mobile/app/src/main/java/piotr_gorczynski/soccer2/MenuActivity.java`).

### Testing
- Ran `./gradlew :app:tasks --all` to discover build tasks successfully, and attempted `./gradlew :app:compile_devBangladeshDebugJavaWithJavac` which failed due to missing Android SDK configuration (`ANDROID_HOME` / `sdk.dir`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d9b5213883309a518ea0f11a124a)