### PR TITLE
fix: resolve high severity npm audit vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1485,9 +1485,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"


### PR DESCRIPTION
### Motivation
- Address a high-severity advisory reported by `npm audit` (node-forge) so the project passes `npm audit --audit-level=high` and reduces CI/security noise.

### Description
- Updated the `node-forge` lockfile entry in `package-lock.json` from `1.3.3` to `1.4.0` to incorporate the upstream security fixes. 
- Performed `npm audit fix` which updated the lockfile but did not change `package.json`.
- The high-severity advisory was removed while remaining low-severity findings (transitive `@tootallnate/once` chain) remain.

### Testing
- Ran `npm audit --audit-level=high` before the change and it failed due to a high-severity `node-forge` advisory. 
- Ran `npm audit fix` and then `npm audit --audit-level=high`, which exited successfully and reported only low-severity vulnerabilities remaining. 
- Ran `npm audit fix --audit-level=high` which reported the dependency tree as up to date.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6c02370688330aae9216c4d91f7c9)