### PR TITLE
fix: register update-payment-status codebase for firebase deploy filter

### DIFF
--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -99,6 +99,12 @@
       "codebase": "check-nickname",
       "runtime": "nodejs20",
       "region": "us-central1"
+    },
+    {
+      "source": "functions/update-payment-status",
+      "codebase": "update-payment-status",
+      "runtime": "nodejs20",
+      "region": "us-central1"
     }
   ],
   "firestore": {


### PR DESCRIPTION
### Motivation
- Cloud Build failed the `update-payment-status` deployment step because the function was not registered in `firebase/firebase.json`, causing the `firebase deploy --only functions:update-payment-status` filter to match nothing.

### Description
- Add `functions/update-payment-status` entry to `firebase/firebase.json` with `codebase: "update-payment-status"` and set `runtime: "nodejs20"` and `region: "us-central1"` to match other functions.

### Testing
- The prior Cloud Build run failed with `Error: No function matches given --only filters.` during the deploy step (reproduced in the rollout log).
- Verified `firebase/firebase.json` is valid with `node -e "JSON.parse(require('fs').readFileSync('firebase/firebase.json','utf8')); console.log('firebase.json valid')"` which succeeded.
- Changes were staged and committed successfully (`git add` + `git commit`) as part of the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb1d059508330817cb5d841c492b6)