### PR TITLE
Add on-tournament-complete function codebase to firebase config

### DIFF
--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -105,6 +105,12 @@
       "codebase": "update-payment-status",
       "runtime": "nodejs20",
       "region": "us-central1"
+    },
+    {
+      "source": "functions/on-tournament-complete",
+      "codebase": "on-tournament-complete",
+      "runtime": "nodejs20",
+      "region": "us-central1"
     }
   ],
   "firestore": {


### PR DESCRIPTION
### Motivation
- The Cloud Build deploy step uses `firebase deploy --only functions:on-tournament-complete` but `firebase/firebase.json` did not contain a matching codebase entry, causing the deploy to fail with `Error: No function matches given --only filters.`

### Description
- Add an entry for `functions/on-tournament-complete` to `firebase/firebase.json` with `codebase: "on-tournament-complete"`, `runtime: "nodejs20"`, and `region: "us-central1"` so the `--only functions:on-tournament-complete` filter matches.

### Testing
- Ran `node -e "JSON.parse(require('fs').readFileSync('firebase/firebase.json','utf8'))"` to validate the modified `firebase/firebase.json` is valid JSON and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb40c3c848330b37199d28b056e95)