### PR TITLE
Avoid NPE in SoccerApp lifecycle logging

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java
@@ -343,8 +343,7 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
 
     /* ------------ APP RETURNS TO FOREGROUND --------------------------- */
     @Override public void onStart(@NonNull LifecycleOwner owner) {
-        Log.d("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName()
-                + ": APP RETURNS TO FOREGROUND");
+        Log.d("TAG_Soccer", getClass().getSimpleName() + ".onStart: APP RETURNS TO FOREGROUND");
 
         appInForeground = true;
         tournamentNotificationChecked = false;  // Reset flag when app returns to foreground
@@ -366,8 +365,7 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
 
     /* ------------ APP GOES TO BACKGROUND ------------------------------ */
     @Override public void onStop(@NonNull LifecycleOwner owner) {
-        Log.d("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName()
-                + ": APP GOES TO BACKGROUND");
+        Log.d("TAG_Soccer", getClass().getSimpleName() + ".onStop: APP GOES TO BACKGROUND");
         appInForeground = false;
         if (userStatusDbRef == null) return;             // ← ADD
 
@@ -375,16 +373,13 @@ public class SoccerApp extends Application implements DefaultLifecycleObserver {
 
         userStatusDbRef.setValue(offline)                 // atomic write
                 .addOnSuccessListener(v -> {
-                    Log.d("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName()
-                            + ": ✅ calling goOffline()");
+                    Log.d("TAG_Soccer", getClass().getSimpleName() + ".onStop: ✅ calling goOffline()");
                     FirebaseDatabase.getInstance().goOffline();
-                    Log.d("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName()
-                            + ": ✅ calling scheduleHeartbeat()");
+                    Log.d("TAG_Soccer", getClass().getSimpleName() + ".onStop: ✅ calling scheduleHeartbeat()");
                     scheduleHeartbeat();                      // 15-min pulses
                 })
                 .addOnFailureListener(e ->
-                        Log.e("TAG_Soccer", getClass().getSimpleName() + "." + Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName()
-                                + ": ❌ seting value offline failed", e));
+                        Log.e("TAG_Soccer", getClass().getSimpleName() + ".onStop: ❌ seting value offline failed", e));
     }
 
     /**


### PR DESCRIPTION
### Motivation
- A production crash showed a `NullPointerException` originating from `Objects.requireNonNull(...getEnclosingMethod()...)` in `SoccerApp.onStart`, so reflective method-name logging is unsafe in release/runtime-optimized environments.
- Prevent the app from crashing on lifecycle transitions by removing logging patterns that can return null at runtime.

### Description
- Replaced fragile reflective logging calls like `Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName()` with explicit method labels (e.g. `.onStart` and `.onStop`) in `mobile/app/src/main/java/piotr_gorczynski/soccer2/SoccerApp.java`.
- Updated `Log.d`/`Log.e` messages in `onStart`, `onStop`, and the `onStop` success/failure callbacks to use stable string literals instead of reflection.
- No functional logic changes beyond logging text; presence tracking and lifecycle guard checks remain unchanged.

### Testing
- Attempted to compile the release Java sources with `./gradlew :app:compileProdGlobalReleaseJavaWithJavac` to validate the change; the build could not complete because Gradle failed to resolve the plugin `org.gradle.toolchains.foojay-resolver-convention:1.0.0` from the configured repositories (so compilation could not be verified in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f64bbacda88330a5c5b0b05db1117c)