### PR TITLE
Avoid NPE in UniversalLoginActivity provider login logging

### DIFF
--- a/mobile/app/src/main/java/piotr_gorczynski/soccer2/UniversalLoginActivity.java
+++ b/mobile/app/src/main/java/piotr_gorczynski/soccer2/UniversalLoginActivity.java
@@ -97,18 +97,14 @@ public class UniversalLoginActivity extends BaseActivity {
     }
 
     private void handleProviderLogin(String provider) {
-        Log.d("TAG_Soccer", getClass().getSimpleName() + "." +
-                Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
-                ": Provider selected = " + provider);
+        Log.d("TAG_Soccer", getClass().getSimpleName() + ".handleProviderLogin: Provider selected = " + provider);
 
         // Disable all login buttons and show toast to prevent multiple clicks
         setLoginButtonsEnabled(false);
         Toast.makeText(this, getString(R.string.login_in_progress), Toast.LENGTH_SHORT).show();
 
         String nickname = storedNickname; // may be null
-        Log.d("TAG_Soccer", getClass().getSimpleName() + "." +
-                Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName() +
-                ": Calling authManager.loginWithProvider");
+        Log.d("TAG_Soccer", getClass().getSimpleName() + ".handleProviderLogin: Calling authManager.loginWithProvider");
 
         FirebaseAuthManager.LoginCallback callback = createLoginCallback();
 


### PR DESCRIPTION
### Motivation
- The reflective logging pattern using `Objects.requireNonNull(new Object(){}.getClass().getEnclosingMethod()).getName()` in `handleProviderLogin` can return `null` in production (e.g. after obfuscation) and cause a `NullPointerException` that crashes the app before the login flow proceeds.

### Description
- Replaced the reflective method-name logging in `UniversalLoginActivity.handleProviderLogin` with static log messages (e.g. `".handleProviderLogin: ..."`) to remove the `Objects.requireNonNull(...)` usage and eliminate the NPE crash path.

### Testing
- Attempted to compile Java sources with `./gradlew :app:compileDebugJavaWithJavac` from `/workspace/Soccer/mobile`, but the build failed due to an unresolved Gradle plugin `org.gradle.toolchains.foojay-resolver-convention:1.0.0`, which is an environment/dependency resolution issue unrelated to the code change; no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f873b6aa5c83309f2ef466390e567e)