### PR TITLE
Align Bangladesh Facebook provider authority with global flavor

### DIFF
--- a/mobile/app/src/bangladesh/AndroidManifest.xml
+++ b/mobile/app/src/bangladesh/AndroidManifest.xml
@@ -8,11 +8,10 @@
     </queries>
 
     <application>
-        <!-- Override Facebook Content Provider authority for Bangladesh variant -->
-        <!-- This prevents conflict when both global and Bangladesh apps are installed -->
+        <!-- Use the same Facebook Content Provider authority as global flavor -->
         <provider
             android:name="com.facebook.FacebookContentProvider"
-            android:authorities="com.facebook.app.FacebookContentProvider1232966491486195.bd"
+            android:authorities="com.facebook.app.FacebookContentProvider1232966491486195"
             android:exported="true"
             tools:replace="android:authorities" />
     </application>


### PR DESCRIPTION
### Motivation
- Ensure the Bangladesh flavor uses the same Facebook authentication authority as the global flavor to avoid mismatched credentials and simplify configuration.

### Description
- Updated `mobile/app/src/bangladesh/AndroidManifest.xml` to set the Facebook provider `android:authorities` to `com.facebook.app.FacebookContentProvider1232966491486195` and adjusted the in-file comment to reflect the shared authority.

### Testing
- Verified with `rg -n "FacebookContentProvider1232966491486195(\\.bd)?" mobile/app/src/*/AndroidManifest.xml` that both `main` and `bangladesh` manifests reference `com.facebook.app.FacebookContentProvider1232966491486195`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fae39184f88330b7d44a68875b864c)